### PR TITLE
feat(infra): sync non-domain infrastructure from evolved derived repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ All configuration is via environment variables prefixed with `MCP_SERVER_`:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MCP_SERVER_READ_ONLY` | `true` | Disable write tools |
-| `MCP_SERVER_BEARER_TOKEN` | — | Enable bearer token auth |
 | `MCP_SERVER_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `MCP_SERVER_SERVER_NAME` | `mcp-server` | Server name shown to clients |
 | `MCP_SERVER_INSTRUCTIONS` | (dynamic) | System instructions for LLM context |
+| `MCP_SERVER_HTTP_PATH` | `/mcp` | Mount path for HTTP transport |
 
 ## Authentication
 
@@ -45,7 +45,16 @@ The server supports four auth modes:
 
 **Auth requires `--transport http` (or `sse`).** It has no effect with `--transport stdio`.
 
-See [Authentication guide](docs/guides/authentication.md) for setup details.
+| Variable | Description |
+|----------|-------------|
+| `MCP_SERVER_BEARER_TOKEN` | Static bearer token |
+| `MCP_SERVER_BASE_URL` | Public base URL — required for OIDC (e.g. `https://mcp.example.com`) |
+| `MCP_SERVER_OIDC_CONFIG_URL` | OIDC discovery endpoint |
+| `MCP_SERVER_OIDC_CLIENT_ID` | OIDC client ID |
+| `MCP_SERVER_OIDC_CLIENT_SECRET` | OIDC client secret |
+| `MCP_SERVER_OIDC_JWT_SIGNING_KEY` | JWT signing key — **required on Linux/Docker** to survive restarts |
+
+See [Authentication guide](docs/guides/authentication.md) for full setup details.
 
 ## Docker
 
@@ -67,6 +76,10 @@ uv run mypy src/
 ## Using this template
 
 See [TEMPLATE.md](TEMPLATE.md) for the step-by-step customisation guide, including the `rename.sh` bootstrap script.
+
+## Keeping derived repos in sync
+
+See [SYNC.md](SYNC.md) for the infrastructure vs domain boundary definition and the cherry-pick workflow for propagating non-domain changes between this template and derived repositories.
 
 ## License
 

--- a/SYNC.md
+++ b/SYNC.md
@@ -1,0 +1,90 @@
+# Sync: Template ↔ Derived Repos
+
+This template has two known derived repositories:
+
+| Repo | Domain |
+|------|--------|
+| [pvliesdonk/markdown-vault-mcp](https://github.com/pvliesdonk/markdown-vault-mcp) | Obsidian/Markdown vault |
+| [pvliesdonk/image-gen-mcp](https://github.com/pvliesdonk/image-gen-mcp) | Image generation |
+
+When infrastructure improvements land in a derived repo they should be
+backported here, and vice-versa.  Domain-specific code (tools, config fields,
+CLI subcommands, service objects) is **never** synced.
+
+---
+
+## What is infrastructure vs domain?
+
+**Infrastructure** — sync in both directions:
+
+- `mcp_server.py` — auth wiring, `create_server()`, `build_event_store()`
+- `cli.py` — transport handling, HTTP path normalisation, logging setup
+- `config.py` — `_ENV_PREFIX`, `get_log_level()`, `_parse_bool()`, `_env()`
+  (but **not** domain-specific `ServerConfig` fields)
+- `_server_deps.py` — lifespan skeleton, `get_service()` pattern
+  (but **not** the actual service object or background tasks)
+- `_server_tools.py` — `register_tools(mcp, *, transport)` signature convention
+- `pyproject.toml` — build/lint/test/release tooling
+- `.github/workflows/` — CI pipelines
+- `server.json` — MCP server metadata schema
+
+**Domain** — never sync back to template:
+
+- `ServerConfig` fields beyond `read_only`
+- CLI subcommands beyond `serve`
+- Business logic in `_server_tools.py` / `_server_resources.py` / `_server_prompts.py`
+- The service/collection object in `_server_deps.py`
+- Domain-specific tests
+
+---
+
+## Sync checklist: derived repo → template
+
+When a PR in a derived repo changes infrastructure code, open a PR here with
+the same change (adapted to the generic module names).
+
+1. `_build_oidc_auth()` / `_build_bearer_auth()` — copy exactly (env prefix
+   is the only difference; `_ENV_PREFIX` handles it)
+2. `build_event_store()` — copy exactly
+3. `cli.py` transport/path normalisation — copy exactly
+4. `pyproject.toml` tool config (`ruff`, `mypy`, `pytest`, `semantic_release`)
+   — copy exactly
+5. GitHub workflows — copy exactly, update repo-specific URLs
+
+## Sync checklist: template → derived repos
+
+When this template is updated, apply the same infrastructure change in each
+derived repo:
+
+1. Rename `fastmcp_server_template` → the repo's module name where it appears
+2. Rename `MCP_SERVER` → the repo's `_ENV_PREFIX` where it appears in docs/comments
+3. Keep all domain logic untouched
+
+---
+
+## Current known divergences
+
+| Item | Template | markdown-vault-mcp | image-gen-mcp |
+|------|----------|--------------------|---------------|
+| `server.json` per-package env vars | ✅ | ✅ | ❌ legacy format |
+| `httpx` ImportError in `_build_oidc_auth` | ✅ | ✅ | ❌ bare import |
+| `transport` param in `create_server()` | ✅ | ✅ | check |
+| `build_event_store()` | ✅ | ✅ | ✅ |
+
+---
+
+## Approach for long-term maintenance
+
+These repos are too domain-specific to share a single base package, but too
+similar in plumbing to maintain independently.  Recommended approach:
+
+- **Tag infrastructure commits** with `infra:` scope in the commit message
+  (e.g. `fix(infra): handle httpx ImportError in OIDC auth`).  This makes
+  cherry-picking across repos easy: `git log --grep="(infra)"`.
+
+- **Cherry-pick, don't diff-and-paste.**  After landing an infra fix in any
+  repo, cherry-pick the commit into the others and resolve the trivial module-
+  name conflicts.  The diff stays minimal because domain code is untouched.
+
+- **Keep this file up to date.**  Update the divergences table above whenever
+  a sync happens (or doesn't happen intentionally).

--- a/docs/deployment/oidc.md
+++ b/docs/deployment/oidc.md
@@ -9,19 +9,19 @@ Optional token-based authentication for HTTP deployments. OIDC activates automat
 
 | Variable | Description |
 |----------|-------------|
-| `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL of the server (e.g. `https://mcp.example.com`; include prefix when mounted under subpath, e.g. `https://mcp.example.com/vault`) |
-| `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` | OIDC discovery endpoint (e.g. `https://auth.example.com/.well-known/openid-configuration`) |
-| `MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID` | OIDC client ID registered with your provider |
-| `MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET` | OIDC client secret |
+| `MCP_SERVER_BASE_URL` | Public base URL of the server (e.g. `https://mcp.example.com`; include prefix when mounted under subpath, e.g. `https://mcp.example.com/myservice`) |
+| `MCP_SERVER_OIDC_CONFIG_URL` | OIDC discovery endpoint (e.g. `https://auth.example.com/.well-known/openid-configuration`) |
+| `MCP_SERVER_OIDC_CLIENT_ID` | OIDC client ID registered with your provider |
+| `MCP_SERVER_OIDC_CLIENT_SECRET` | OIDC client secret |
 
 ## Optional Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key. **Required on Linux/Docker** — the default is ephemeral and invalidates tokens on restart |
-| `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
-| `MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
-| `MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the upstream access token as JWT instead of the id token. Only needed when your provider issues JWT access tokens and you require audience-claim validation on that token |
+| `MCP_SERVER_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key. **Required on Linux/Docker** — the default is ephemeral and invalidates tokens on restart |
+| `MCP_SERVER_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
+| `MCP_SERVER_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
+| `MCP_SERVER_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the upstream access token as JWT instead of the id token. Only needed when your provider issues JWT access tokens and you require audience-claim validation on that token |
 
 ## JWT Signing Key
 
@@ -33,7 +33,7 @@ openssl rand -hex 32
 ```
 
 !!! danger "Linux / Docker"
-    On Linux (including Docker), the ephemeral key is especially problematic because it does not persist across process restarts. Always set `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` in production.
+    On Linux (including Docker), the ephemeral key is especially problematic because it does not persist across process restarts. Always set `MCP_SERVER_OIDC_JWT_SIGNING_KEY` in production.
 
 ## Setup with Authelia
 
@@ -49,7 +49,7 @@ openssl rand -hex 32
 identity_providers:
   oidc:
     clients:
-      - client_id: markdown-vault-mcp
+      - client_id: my-mcp-server
         client_secret: '$pbkdf2-sha512$...'   # authelia crypto hash generate
         redirect_uris:
           - https://mcp.example.com/auth/callback
@@ -62,21 +62,17 @@ identity_providers:
 ### 2. Set environment variables
 
 ```bash
-MARKDOWN_VAULT_MCP_BASE_URL=https://mcp.example.com
-MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
-MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID=markdown-vault-mcp
-MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET=your-client-secret
-MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY=$(openssl rand -hex 32)
+MCP_SERVER_BASE_URL=https://mcp.example.com
+MCP_SERVER_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
+MCP_SERVER_OIDC_CLIENT_ID=my-mcp-server
+MCP_SERVER_OIDC_CLIENT_SECRET=your-client-secret
+MCP_SERVER_OIDC_JWT_SIGNING_KEY=$(openssl rand -hex 32)
 ```
-
-For subpath deployments (e.g., public URL `https://mcp.example.com/vault/mcp`), see [Subpath Deployments](#subpath-deployments) below.
-
-See also `examples/obsidian-oidc.env`.
 
 ### 3. Start with HTTP transport
 
 ```bash
-markdown-vault-mcp serve --transport http --port 8000
+mcp-server serve --transport http --port 8000
 ```
 
 ## Architecture
@@ -84,7 +80,7 @@ markdown-vault-mcp serve --transport http --port 8000
 The server uses FastMCP's built-in `OIDCProxy` auth provider (not the external `mcp-auth-proxy` sidecar). The authentication flow:
 
 ```
-Client → markdown-vault-mcp (with OIDCProxy) → OIDC Provider (Authelia/Keycloak)
+Client → mcp-server (with OIDCProxy) → OIDC Provider (Authelia/Keycloak)
 ```
 
 1. Client connects to the MCP server
@@ -97,24 +93,19 @@ Client → markdown-vault-mcp (with OIDCProxy) → OIDC Provider (Authelia/Keycl
 
 ```yaml
 services:
-  markdown-vault-mcp:
-    image: ghcr.io/pvliesdonk/markdown-vault-mcp:latest
+  mcp-server:
+    image: ghcr.io/pvliesdonk/fastmcp-server-template:latest
     env_file: .env
     volumes:
-      - ${MARKDOWN_VAULT_MCP_SOURCE_DIR:?Set MARKDOWN_VAULT_MCP_SOURCE_DIR}:/data/vault
       - state-data:/data/state
     environment:
-      MARKDOWN_VAULT_MCP_SOURCE_DIR: /data/vault
-      MARKDOWN_VAULT_MCP_INDEX_PATH: /data/state/index.db
-      MARKDOWN_VAULT_MCP_EMBEDDINGS_PATH: /data/state/embeddings/embeddings
-      MARKDOWN_VAULT_MCP_FASTEMBED_CACHE_DIR: /data/state/fastembed
       FASTMCP_HOME: /data/state/fastmcp
     restart: unless-stopped
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.markdown-vault-mcp.rule=Host(`mcp.example.com`)"
-      - "traefik.http.routers.markdown-vault-mcp.tls.certresolver=letsencrypt"
-      - "traefik.http.services.markdown-vault-mcp.loadbalancer.server.port=8000"
+      - "traefik.http.routers.mcp-server.rule=Host(`mcp.example.com`)"
+      - "traefik.http.routers.mcp-server.tls.certresolver=letsencrypt"
+      - "traefik.http.services.mcp-server.loadbalancer.server.port=8000"
     networks:
       - traefik
 
@@ -129,15 +120,15 @@ networks:
 With the corresponding `.env`:
 
 ```bash
-MARKDOWN_VAULT_MCP_READ_ONLY=true
-MARKDOWN_VAULT_MCP_BASE_URL=https://mcp.example.com
-MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
-MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID=markdown-vault-mcp
-MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET=your-client-secret
-MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY=your-stable-hex-key
+MCP_SERVER_READ_ONLY=true
+MCP_SERVER_BASE_URL=https://mcp.example.com
+MCP_SERVER_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
+MCP_SERVER_OIDC_CLIENT_ID=my-mcp-server
+MCP_SERVER_OIDC_CLIENT_SECRET=your-client-secret
+MCP_SERVER_OIDC_JWT_SIGNING_KEY=your-stable-hex-key
 ```
 
-For a prefixed deployment (e.g., `https://mcp.example.com/vault/mcp`), see [Subpath Deployments](#subpath-deployments) below.
+For a prefixed deployment (e.g., `https://mcp.example.com/myservice/mcp`), see [Subpath Deployments](#subpath-deployments) below.
 
 ## Subpath Deployments
 
@@ -145,50 +136,50 @@ When OIDC is enabled behind a reverse-proxy subpath, `BASE_URL` and `HTTP_PATH` 
 
 | Variable | Purpose | Example |
 |----------|---------|---------|
-| `BASE_URL` | Public URL of the server, **including the subpath prefix** | `https://mcp.example.com/vault` |
+| `BASE_URL` | Public URL of the server, **including the subpath prefix** | `https://mcp.example.com/myservice` |
 | `HTTP_PATH` | Internal MCP endpoint mount point — **no subpath prefix** | `/mcp` |
 
 The reverse proxy strips the subpath prefix before forwarding to the application. FastMCP concatenates `BASE_URL + HTTP_PATH` to build the public resource URL, so including the prefix in both produces broken URLs with duplicated path segments.
 
 !!! danger "Do not duplicate the subpath"
-    Setting `BASE_URL=https://mcp.example.com/vault` **and** `HTTP_PATH=/vault/mcp` produces a duplicated resource URL: `https://mcp.example.com/vault/vault/mcp`. The subpath belongs in `BASE_URL` only.
+    Setting `BASE_URL=https://mcp.example.com/myservice` **and** `HTTP_PATH=/myservice/mcp` produces a duplicated resource URL: `https://mcp.example.com/myservice/myservice/mcp`. The subpath belongs in `BASE_URL` only.
 
 ### Configuration
 
 Environment variables:
 
 ```bash
-MARKDOWN_VAULT_MCP_BASE_URL=https://mcp.example.com/vault
-MARKDOWN_VAULT_MCP_HTTP_PATH=/mcp
+MCP_SERVER_BASE_URL=https://mcp.example.com/myservice
+MCP_SERVER_HTTP_PATH=/mcp
 ```
 
 Register this callback URI in your OIDC provider:
 
 ```text
-https://mcp.example.com/vault/auth/callback
+https://mcp.example.com/myservice/auth/callback
 ```
 
 ### Reverse proxy routing
 
 The reverse proxy must:
 
-1. **Strip the prefix** (`/vault`) from operational routes before forwarding to the app
+1. **Strip the prefix** (`/myservice`) from operational routes before forwarding to the app
 2. **Forward OAuth discovery routes** to this service (without stripping prefixes):
     - `/.well-known/oauth-authorization-server` — authorization server metadata
-    - `/.well-known/oauth-protected-resource/vault/mcp` — protected resource metadata
+    - `/.well-known/oauth-protected-resource/myservice/mcp` — protected resource metadata
 
 Example Traefik configuration:
 
 ```yaml
 labels:
-  # Operational routes: strip /vault prefix before forwarding
-  - "traefik.http.routers.vault-app.rule=Host(`mcp.example.com`) && PathPrefix(`/vault`)"
-  - "traefik.http.middlewares.strip-vault.stripprefix.prefixes=/vault"
-  - "traefik.http.routers.vault-app.middlewares=strip-vault"
-  - "traefik.http.services.vault-app.loadbalancer.server.port=8000"
+  # Operational routes: strip /myservice prefix before forwarding
+  - "traefik.http.routers.mcp-app.rule=Host(`mcp.example.com`) && PathPrefix(`/myservice`)"
+  - "traefik.http.middlewares.strip-myservice.stripprefix.prefixes=/myservice"
+  - "traefik.http.routers.mcp-app.middlewares=strip-myservice"
+  - "traefik.http.services.mcp-app.loadbalancer.server.port=8000"
   # OAuth discovery routes: forward without stripping
-  - "traefik.http.routers.vault-wellknown.rule=Host(`mcp.example.com`) && (PathPrefix(`/.well-known/oauth-authorization-server`) || PathPrefix(`/.well-known/oauth-protected-resource/vault/mcp`))"
-  - "traefik.http.routers.vault-wellknown.service=vault-app"
+  - "traefik.http.routers.mcp-wellknown.rule=Host(`mcp.example.com`) && (PathPrefix(`/.well-known/oauth-authorization-server`) || PathPrefix(`/.well-known/oauth-protected-resource/myservice/mcp`))"
+  - "traefik.http.routers.mcp-wellknown.service=mcp-app"
 ```
 
 !!! note
@@ -197,15 +188,15 @@ labels:
 ### Shared-hostname limitation
 
 !!! warning "Shared-hostname subpath with native OIDC is not supported"
-    When multiple OAuth-capable services share a hostname (e.g., `mcp-auth-proxy` at the root and `markdown-vault-mcp` at `/vault`), native OIDC on a subpath does not work.
+    When multiple OAuth-capable services share a hostname, native OIDC on a subpath does not work.
 
-    **Why:** FastMCP serves the OAuth authorization-server metadata at `/.well-known/oauth-authorization-server` (host root), regardless of the subpath in `BASE_URL`. The FastMCP codebase contains an RFC 8414 path-aware override (`OIDCProxy.get_well_known_routes()`) that would serve it at `/.well-known/oauth-authorization-server/vault`. However, this method is not wired into the route mounting flow and is effectively dead code.
+    **Why:** FastMCP serves the OAuth authorization-server metadata at `/.well-known/oauth-authorization-server` (host root), regardless of the subpath in `BASE_URL`. The FastMCP codebase contains an RFC 8414 path-aware override (`OIDCProxy.get_well_known_routes()`) that would serve it at `/.well-known/oauth-authorization-server/myservice`. However, this method is not wired into the route mounting flow and is effectively dead code.
 
-    The protected-resource metadata (`/.well-known/oauth-protected-resource/vault/mcp`) is correctly path-namespaced and does not collide. Only the authorization-server discovery route is the problem.
+    The protected-resource metadata (`/.well-known/oauth-protected-resource/myservice/mcp`) is correctly path-namespaced and does not collide. Only the authorization-server discovery route is the problem.
 
-    This works when `markdown-vault-mcp` is the **only** OAuth service on the hostname — the host-root `/.well-known/oauth-authorization-server` does not collide with anything. It breaks when another service already owns that route.
+    This works when the MCP server is the **only** OAuth service on the hostname. It breaks when another service already owns `/.well-known/oauth-authorization-server`.
 
 **Recommendations for shared-hostname scenarios:**
 
-- **Dedicated hostname** (preferred): give `markdown-vault-mcp` its own hostname (e.g., `vault.example.com`) so discovery routes do not collide.
+- **Dedicated hostname** (preferred): give the MCP server its own hostname (e.g., `myservice.example.com`) so discovery routes do not collide.
 - **External auth gateway**: use `mcp-auth-proxy` as a sidecar instead of native OIDC. The MCP server runs unauthenticated behind the proxy, and the proxy handles OAuth discovery at its own routes.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-This guide covers how to protect your markdown-vault-mcp server with authentication. Choose the mode that fits your deployment.
+This guide covers how to protect your MCP server with authentication. Choose the mode that fits your deployment.
 
 !!! warning "Transport requirement"
     Authentication only works with HTTP transport (`--transport http` or `sse`). It has no effect with `--transport stdio`.
@@ -11,12 +11,12 @@ The server supports four authentication modes:
 
 | Mode | When to use | Configuration |
 |------|-------------|---------------|
-| **Multi-auth** | Mixed clients — e.g. Claude web (OIDC) + Claude Code (bearer token) on the same server | Set both `MARKDOWN_VAULT_MCP_BEARER_TOKEN` and all four OIDC variables |
-| **Bearer token** | Simple deployments behind a VPN, Docker compose stacks, development | Set `MARKDOWN_VAULT_MCP_BEARER_TOKEN` only |
+| **Multi-auth** | Mixed clients — e.g. Claude web (OIDC) + Claude Code (bearer token) on the same server | Set both `MCP_SERVER_BEARER_TOKEN` and all four OIDC variables |
+| **Bearer token** | Simple deployments behind a VPN, Docker compose stacks, development | Set `MCP_SERVER_BEARER_TOKEN` only |
 | **OIDC** | Production with user identity, SSO, multi-user access | Set all four OIDC variables only |
 | **No auth** | Local stdio usage, trusted networks | Default (nothing to configure) |
 
-When both bearer token and OIDC are configured, the server accepts **either** credential — a valid bearer token or a valid OIDC session. This is useful when different clients require different authentication flows against the same vault instance.
+When both bearer token and OIDC are configured, the server accepts **either** credential — a valid bearer token or a valid OIDC session. This is useful when different clients require different authentication flows against the same server instance.
 
 ---
 
@@ -35,13 +35,13 @@ The simplest way to protect your server. A single static token shared between se
 2. Set the environment variable:
 
     ```bash
-    MARKDOWN_VAULT_MCP_BEARER_TOKEN=your-generated-token
+    MCP_SERVER_BEARER_TOKEN=your-generated-token
     ```
 
 3. Start the server with HTTP transport:
 
     ```bash
-    markdown-vault-mcp serve --transport http --port 8000
+    mcp-server serve --transport http --port 8000
     ```
 
 ### Client usage
@@ -59,8 +59,6 @@ Authorization: Bearer your-generated-token
 - Development and testing environments
 - Any scenario where full OIDC is overkill
 
-See also: [`examples/bearer-auth.env`](https://github.com/pvliesdonk/markdown-vault-mcp/blob/main/examples/bearer-auth.env) for a ready-to-use example.
-
 ---
 
 ## OIDC
@@ -72,7 +70,7 @@ Full OAuth 2.1 authentication using an external identity provider. Supports user
 The server uses FastMCP's built-in `OIDCProxy` — no external auth sidecar needed:
 
 ```
-Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
+Client → mcp-server (OIDCProxy) → OIDC Provider
 ```
 
 1. Client connects to the server
@@ -85,19 +83,19 @@ Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
 
 | Variable | Description |
 |----------|-------------|
-| `MARKDOWN_VAULT_MCP_BASE_URL` | Public base URL (e.g. `https://mcp.example.com`) |
-| `MARKDOWN_VAULT_MCP_OIDC_CONFIG_URL` | OIDC discovery endpoint |
-| `MARKDOWN_VAULT_MCP_OIDC_CLIENT_ID` | Client ID registered with your provider |
-| `MARKDOWN_VAULT_MCP_OIDC_CLIENT_SECRET` | Client secret |
+| `MCP_SERVER_BASE_URL` | Public base URL (e.g. `https://mcp.example.com`) |
+| `MCP_SERVER_OIDC_CONFIG_URL` | OIDC discovery endpoint |
+| `MCP_SERVER_OIDC_CLIENT_ID` | Client ID registered with your provider |
+| `MCP_SERVER_OIDC_CLIENT_SECRET` | Client secret |
 
 ### Optional variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key — **required on Linux/Docker** |
-| `MARKDOWN_VAULT_MCP_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
-| `MARKDOWN_VAULT_MCP_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
-| `MARKDOWN_VAULT_MCP_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the access token as a JWT instead of the id token; useful for audience-claim validation on JWT access tokens |
+| `MCP_SERVER_OIDC_JWT_SIGNING_KEY` | ephemeral | JWT signing key — **required on Linux/Docker** |
+| `MCP_SERVER_OIDC_AUDIENCE` | — | Expected JWT audience claim; leave unset if your provider does not set one |
+| `MCP_SERVER_OIDC_REQUIRED_SCOPES` | `openid` | Comma-separated required scopes |
+| `MCP_SERVER_OIDC_VERIFY_ACCESS_TOKEN` | `false` | Set `true` to verify the access token as a JWT instead of the id token; useful for audience-claim validation on JWT access tokens |
 
 !!! danger "JWT signing key on Linux/Docker"
     Without `OIDC_JWT_SIGNING_KEY`, FastMCP generates an ephemeral key that invalidates all tokens on restart. Always set a stable key in production:
@@ -108,15 +106,6 @@ Client → markdown-vault-mcp (OIDCProxy) → OIDC Provider
 
 !!! tip "Long-running sessions"
     Current MCP clients do not reliably refresh tokens — see [Known Limitations](#known-limitations-mcp-oauth-token-refresh). Configure **all** token lifetimes (access, id, refresh) on your identity provider to cover a full workday (8h+). For simpler deployments, bearer token auth is unaffected by these limitations.
-
-### Provider guides
-
-For step-by-step setup with specific providers:
-
-- [Authelia](oidc-providers.md#authelia)
-- [Keycloak](oidc-providers.md#keycloak)
-- [Google](oidc-providers.md#google)
-- [GitHub (via Keycloak broker)](oidc-providers.md#github)
 
 For the full OIDC reference (env vars, Docker Compose, subpath deployments, architecture):
 
@@ -132,7 +121,7 @@ The `client_id` and/or `redirect_uris` in your OIDC provider config don't match 
 
 ### Tokens invalidated after restart
 
-You're missing `MARKDOWN_VAULT_MCP_OIDC_JWT_SIGNING_KEY`. Without it, FastMCP generates an ephemeral key on each startup. Generate and set a stable key:
+You're missing `MCP_SERVER_OIDC_JWT_SIGNING_KEY`. Without it, FastMCP generates an ephemeral key on each startup. Generate and set a stable key:
 
 ```bash
 openssl rand -hex 32
@@ -178,22 +167,20 @@ lifespans:
       refresh_token: '30d'
 ```
 
-See the [Authelia provider guide](oidc-providers.md#authelia) for the full configuration.
-
 ### Opaque access tokens (Authelia)
 
-Authelia issues opaque (non-JWT) access tokens. This is handled automatically — the server verifies the `id_token` instead. No extra configuration needed. See the [Authelia guide](oidc-providers.md#authelia) for details.
+Authelia issues opaque (non-JWT) access tokens. This is handled automatically — the server verifies the `id_token` instead. No extra configuration needed.
 
 ---
 
 ## Known Limitations: MCP OAuth token refresh
 
 !!! warning "Ecosystem-wide issue"
-    The limitations below affect **all** OAuth-protected MCP servers, not just markdown-vault-mcp. They are caused by issues in the MCP client implementations (Claude Code, Claude.ai, Claude Desktop) and the MCP Python SDK. Check the linked tracking issues for current status.
+    The limitations below affect **all** OAuth-protected MCP servers, not just this one. They are caused by issues in the MCP client implementations (Claude Code, Claude.ai, Claude Desktop) and the MCP Python SDK. Check the linked tracking issues for current status.
 
 ### The problem
 
-MCP clients cannot maintain sessions beyond the token lifetime because token refresh does not work. When tokens expire, the session drops and requires manual re-authentication. This affects every provider — Authelia, Keycloak, Google, Slack, Notion, Atlassian, and others.
+MCP clients cannot maintain sessions beyond the token lifetime because token refresh does not work. When tokens expire, the session drops and requires manual re-authentication. This affects every provider — Authelia, Keycloak, Google, and others.
 
 ### Why refresh doesn't work
 
@@ -226,4 +213,4 @@ These upstream issues are actively tracked:
 - [anthropics/claude-code#7744](https://github.com/anthropics/claude-code/issues/7744) — `offline_access` scope never requested
 - [modelcontextprotocol/python-sdk#1326](https://github.com/modelcontextprotocol/python-sdk/issues/1326) — SSE refresh deadlock
 
-When these are resolved, OIDC sessions should persist indefinitely via automatic token refresh with no changes needed to markdown-vault-mcp.
+When these are resolved, OIDC sessions should persist indefinitely via automatic token refresh with no changes needed server-side.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ ignore = ["E501"]
 # Context/FastMCP imports must stay runtime (not TYPE_CHECKING) for DI.
 "src/fastmcp_server_template/mcp_server.py" = ["B008", "TCH002"]
 "src/fastmcp_server_template/_server_deps.py" = ["B008", "TCH002"]
-"src/fastmcp_server_template/_server_tools.py" = ["B008", "TCH001", "TCH002"]
+"src/fastmcp_server_template/_server_tools.py" = ["ARG001", "B008", "TCH001", "TCH002"]
 "src/fastmcp_server_template/_server_resources.py" = ["B008", "TCH001", "TCH002"]
 "src/fastmcp_server_template/_server_prompts.py" = ["B008", "TCH002"]
 # pytest fixtures need runtime imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-mcp = ["fastmcp>=3.0,<4", "httpx"]
-all = ["fastmcp>=3.0,<4", "httpx"]
+mcp = ["fastmcp>=3.0,<4", "httpx", "uvicorn"]
+all = ["fastmcp>=3.0,<4", "httpx", "uvicorn"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-mcp = ["fastmcp>=3.0,<4"]
-all = ["fastmcp>=3.0,<4"]
+mcp = ["fastmcp>=3.0,<4", "httpx"]
+all = ["fastmcp>=3.0,<4", "httpx"]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",

--- a/server.json
+++ b/server.json
@@ -76,6 +76,11 @@
           "name": "MCP_SERVER_OIDC_CLIENT_SECRET",
           "description": "OIDC client secret",
           "required": false
+        },
+        {
+          "name": "MCP_SERVER_OIDC_JWT_SIGNING_KEY",
+          "description": "JWT signing key — required on Linux/Docker to survive restarts (generate with: openssl rand -hex 32)",
+          "required": false
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -15,7 +15,20 @@
       "version": "0.1.0",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "environmentVariables": [
+        {
+          "name": "MCP_SERVER_READ_ONLY",
+          "description": "Set to 'false' to enable write tools (default: true)",
+          "required": false,
+          "default": "true"
+        },
+        {
+          "name": "MCP_SERVER_BEARER_TOKEN",
+          "description": "Static bearer token for authentication (optional)",
+          "required": false
+        }
+      ]
     },
     {
       "registryType": "oci",
@@ -30,6 +43,39 @@
           "name": "--port",
           "default": 8000,
           "description": "Port for the HTTP transport"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "MCP_SERVER_READ_ONLY",
+          "description": "Set to 'false' to enable write tools (default: true)",
+          "required": false,
+          "default": "true"
+        },
+        {
+          "name": "MCP_SERVER_BEARER_TOKEN",
+          "description": "Static bearer token for authentication (optional)",
+          "required": false
+        },
+        {
+          "name": "MCP_SERVER_BASE_URL",
+          "description": "Public base URL of this server, required for OIDC (e.g. https://mcp.example.com)",
+          "required": false
+        },
+        {
+          "name": "MCP_SERVER_OIDC_CONFIG_URL",
+          "description": "OIDC discovery endpoint URL (e.g. https://auth.example.com/.well-known/openid-configuration)",
+          "required": false
+        },
+        {
+          "name": "MCP_SERVER_OIDC_CLIENT_ID",
+          "description": "OIDC client ID",
+          "required": false
+        },
+        {
+          "name": "MCP_SERVER_OIDC_CLIENT_SECRET",
+          "description": "OIDC client secret",
+          "required": false
         }
       ]
     }

--- a/src/fastmcp_server_template/_server_tools.py
+++ b/src/fastmcp_server_template/_server_tools.py
@@ -24,11 +24,17 @@ from ._server_deps import get_service
 logger = logging.getLogger(__name__)
 
 
-def register_tools(mcp: FastMCP) -> None:
+def register_tools(mcp: FastMCP, *, transport: str = "stdio") -> None:
     """Register all MCP tools on *mcp*.
 
     Args:
         mcp: The :class:`~fastmcp.FastMCP` instance to register tools on.
+        transport: Active transport (``"stdio"``, ``"sse"``, or ``"http"``).
+            Use this to conditionally register HTTP-only tools, e.g.::
+
+                if transport == "http":
+                    @mcp.tool()
+                    def create_download_link(...) -> str: ...
     """
 
     # -----------------------------------------------------------------------
@@ -36,7 +42,7 @@ def register_tools(mcp: FastMCP) -> None:
     # -----------------------------------------------------------------------
 
     @mcp.tool()
-    def ping(ctx: Context = Depends(get_service)) -> str:  # noqa: ARG001
+    def ping(ctx: Context = Depends(get_service)) -> str:
         """Health check.
 
         Returns:
@@ -51,7 +57,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(tags={"write"})
     def example_write(
         message: str,
-        ctx: Any = Depends(get_service),  # noqa: ARG001
+        ctx: Any = Depends(get_service),
     ) -> str:
         """Example write operation — replace with your domain write tools.
 

--- a/src/fastmcp_server_template/cli.py
+++ b/src/fastmcp_server_template/cli.py
@@ -57,7 +57,14 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     ):
         logger.warning("--host, --port and --path are only used with --transport http")
     if transport == "http":
-        import uvicorn
+        try:
+            import uvicorn
+        except ImportError:
+            logger.error(
+                "HTTP transport requires uvicorn. Install with: "
+                "pip install 'fastmcp-server-template[mcp]'"
+            )
+            sys.exit(1)
 
         event_store = build_event_store()
         app = server.http_app(path=http_path, event_store=event_store)

--- a/src/fastmcp_server_template/cli.py
+++ b/src/fastmcp_server_template/cli.py
@@ -40,7 +40,7 @@ def _normalise_http_path(path: str | None) -> str:
 def _cmd_serve(args: argparse.Namespace) -> None:
     """Run the MCP server."""
     try:
-        from fastmcp_server_template.mcp_server import create_server
+        from fastmcp_server_template.mcp_server import build_event_store, create_server
     except ImportError:
         logger.error(
             "FastMCP is not installed. Install with: "
@@ -48,8 +48,8 @@ def _cmd_serve(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    server = create_server()
     transport = args.transport
+    server = create_server(transport=transport)
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     http_path = _normalise_http_path(args.path or env_http_path)
     if transport != "http" and (
@@ -57,7 +57,17 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     ):
         logger.warning("--host, --port and --path are only used with --transport http")
     if transport == "http":
-        server.run(transport="http", host=args.host, port=args.port, path=http_path)
+        import uvicorn
+
+        event_store = build_event_store()
+        app = server.http_app(path=http_path, event_store=event_store)
+        uvicorn.run(
+            app,
+            host=args.host,
+            port=args.port,
+            lifespan="on",
+            timeout_graceful_shutdown=0,
+        )
     else:
         server.run(transport=transport)
 

--- a/src/fastmcp_server_template/cli.py
+++ b/src/fastmcp_server_template/cli.py
@@ -52,7 +52,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     server = create_server(transport=transport)
     env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
     http_path = _normalise_http_path(args.path or env_http_path)
-    if transport != "http" and (
+    if transport == "stdio" and (
         args.host != "0.0.0.0" or args.port != 8000 or args.path is not None
     ):
         logger.warning("--host, --port and --path are only used with --transport http")

--- a/src/fastmcp_server_template/mcp_server.py
+++ b/src/fastmcp_server_template/mcp_server.py
@@ -122,7 +122,7 @@ def _build_oidc_auth() -> Any:
     except ImportError as exc:
         raise RuntimeError(
             "OIDC auth requires httpx. Install with: "
-            "pip install 'fastmcp-server-template[mcp]' httpx"
+            "pip install 'fastmcp-server-template[mcp]'"
         ) from exc
 
     jwt_signing_key = (
@@ -214,7 +214,7 @@ def build_event_store() -> Any:
     """
     from fastmcp.server.event_store import EventStore
 
-    return EventStore()
+    return EventStore()  # type is EventStore; typed as Any to avoid top-level import
 
 
 def create_server(*, transport: str = "stdio") -> FastMCP:

--- a/src/fastmcp_server_template/mcp_server.py
+++ b/src/fastmcp_server_template/mcp_server.py
@@ -117,7 +117,13 @@ def _build_oidc_auth() -> Any:
         logger.debug("OIDC auth: disabled — missing env vars: %s", ", ".join(missing))
         return None
 
-    from fastmcp.server.auth.oidc_proxy import OIDCProxy
+    try:
+        from fastmcp.server.auth.oidc_proxy import OIDCProxy
+    except ImportError as exc:
+        raise RuntimeError(
+            "OIDC auth requires httpx. Install with: "
+            "pip install 'fastmcp-server-template[mcp]' httpx"
+        ) from exc
 
     jwt_signing_key = (
         os.environ.get(f"{_ENV_PREFIX}_OIDC_JWT_SIGNING_KEY", "").strip() or None
@@ -191,7 +197,27 @@ def _build_oidc_auth() -> Any:
     )
 
 
-def create_server() -> FastMCP:
+def build_event_store() -> Any:
+    """Build an event store for HTTP transport SSE resumability.
+
+    Returns an :class:`~fastmcp.server.event_store.EventStore` backed by
+    an in-memory store by default.  For production deployments, replace the
+    backing store with a persistent :class:`~key_value.aio.AsyncKeyValue`
+    backend (e.g. Redis) so events survive restarts.
+
+    The event store is only meaningful for the ``http`` transport — pass the
+    return value to :meth:`~fastmcp.FastMCP.http_app` via the ``event_store``
+    kwarg to enable client reconnection / SSE event replay.
+
+    Returns:
+        A configured :class:`~fastmcp.server.event_store.EventStore`.
+    """
+    from fastmcp.server.event_store import EventStore
+
+    return EventStore()
+
+
+def create_server(*, transport: str = "stdio") -> FastMCP:
     """Create and configure the FastMCP server.
 
     Reads configuration from environment variables via :func:`load_config`.
@@ -204,6 +230,11 @@ def create_server() -> FastMCP:
       (default ``"mcp-server"``).
     - ``MCP_SERVER_INSTRUCTIONS``: system-level instructions injected
       into LLM context (default: dynamic description reflecting read-only state).
+
+    Args:
+        transport: Active transport (``"stdio"``, ``"sse"``, or ``"http"``).
+            Passed to :func:`register_tools` so tools can conditionally register
+            HTTP-only endpoints (e.g. artifact download handlers).
 
     Returns:
         A fully configured :class:`~fastmcp.FastMCP` instance ready to run.
@@ -251,7 +282,7 @@ def create_server() -> FastMCP:
         auth=auth,
     )
 
-    register_tools(mcp)
+    register_tools(mcp, transport=transport)
     register_resources(mcp)
     register_prompts(mcp)
 


### PR DESCRIPTION
- mcp_server.py: wrap OIDCProxy import in try/except ImportError with
  a helpful httpx install hint (matches markdown-vault-mcp pattern)
- mcp_server.py: add build_event_store() for HTTP SSE resumability;
  backed by MemoryStore by default, replaceable with any AsyncKeyValue
- mcp_server.py: add transport param to create_server(), threaded to
  register_tools() for conditional HTTP-only tool registration
- cli.py: pass transport to create_server(); for HTTP transport use
  http_app(event_store=...) + uvicorn directly so event_store is wired
- _server_tools.py: add transport param to register_tools(); suppress
  ARG001 at file level (template placeholder pattern, not a real bug)
- server.json: add per-package environmentVariables entries for auth
  and config vars (correct 2025-12-11 schema format)
- SYNC.md: document infra vs domain boundary, divergence table,
  cherry-pick workflow for keeping template ↔ derived repos in sync

https://claude.ai/code/session_01FbhQXv4C3h1yzMndoWW7BS