### PR TITLE
fix(release): publish linux packages on prerelease too

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -221,7 +221,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary

Drop the \`!inputs.prerelease\` gate from the \`publish-linux-packages\` job so .deb/.rpm artifacts attach to prerelease GitHub releases as well as stable.

## Why

Currently the gating is inconsistent:

| Job | Runs on rc? | Rationale |
|---|---|---|
| publish-pypi | no | PyPI is an immutable global index |
| publish-docker | yes | GHCR is fine for rc tags (\`unstable\` + \`vX.Y.Z-rc.N\`) |
| publish-linux-packages | **no** ← bug | These are just artifacts on a GH release; same risk as Docker/MCPB |
| publish-mcpb | yes | Artifact attached to the release |
| publish-claude-plugin-pr | no | Opens a PR to anthropics/claude-code-plugins; not for rc |
| publish-registry | no | MCP Registry is an immutable global index |

Surfaced during Step 4 bootstrap-replay validation of \`markdown-vault-mcp\`: \`v1.26.0-rc.1\` shipped Docker + MCPB but no .deb/.rpm — meaning we can't actually test the Linux packaging path on an rc, which defeats the purpose of having an rc.

## Test plan

- [x] CI green on PR
- [ ] After merge: cut v1.0.1 of the template, then trigger an rc release of MV with copier update — verify .deb/.rpm attach to the rc release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)