### PR TITLE
feat(packaging): add mcpb bundle scaffold

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -27,6 +27,10 @@ _skip_if_exists:
   - "CHANGELOG.md"
   - "LICENSE"
   - ".env.example"
+  - "packaging/mcpb/manifest.json.in"
+  - "packaging/mcpb/pyproject.toml.in"
+  - "packaging/mcpb/src/server.py"
+  - "packaging/mcpb/build.sh"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the

--- a/packaging/mcpb/.gitignore
+++ b/packaging/mcpb/.gitignore
@@ -1,0 +1,3 @@
+# Artifacts produced by build.sh (not in _skip_if_exists — maintained by the template).
+build/
+dist/

--- a/packaging/mcpb/build.sh.jinja
+++ b/packaging/mcpb/build.sh.jinja
@@ -10,8 +10,9 @@
 #   packaging/mcpb/{manifest.json.in,pyproject.toml.in,src/server.py,build.sh}
 #   are in the template's _skip_if_exists list, so future ``copier update``
 #   runs will NOT re-render them.  When mcpb bumps manifest_version, when
-#   you change license, or when the mcpb CLI version is bumped upstream,
-#   update these files manually.
+#   the project picks a license (starter is UNLICENSED — you MUST choose
+#   one before publishing), or when the mcpb CLI version is bumped
+#   upstream, update these files manually.
 set -euo pipefail
 
 VERSION="${VERSION:-dev}"

--- a/packaging/mcpb/build.sh.jinja
+++ b/packaging/mcpb/build.sh.jinja
@@ -5,6 +5,13 @@
 #   VERSION=1.0.0 ./packaging/mcpb/build.sh
 #
 # With no VERSION set, builds a "dev" bundle for validation only.
+#
+# Note on scaffold drift:
+#   packaging/mcpb/{manifest.json.in,pyproject.toml.in,src/server.py,build.sh}
+#   are in the template's _skip_if_exists list, so future ``copier update``
+#   runs will NOT re-render them.  When mcpb bumps manifest_version, when
+#   you change license, or when the mcpb CLI version is bumped upstream,
+#   update these files manually.
 set -euo pipefail
 
 VERSION="${VERSION:-dev}"
@@ -13,9 +20,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 BUILD_DIR="${REPO_ROOT}/packaging/mcpb/build"
 DIST_DIR="${REPO_ROOT}/packaging/mcpb/dist"
 
+# renovate: datasource=npm depName=@anthropic-ai/mcpb
+MCPB_VERSION="2.1.2"
+
 command -v mcpb >/dev/null 2>&1 || {
   echo "error: mcpb CLI not found. Install with:" >&2
-  echo "  npm install -g @anthropic-ai/mcpb@2.1.2" >&2
+  echo "  npm install -g @anthropic-ai/mcpb@${MCPB_VERSION}" >&2
   exit 1
 }
 

--- a/packaging/mcpb/build.sh.jinja
+++ b/packaging/mcpb/build.sh.jinja
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build a {{ project_name }} .mcpb bundle locally.
+#
+# Usage:
+#   VERSION=1.0.0 ./packaging/mcpb/build.sh
+#
+# With no VERSION set, builds a "dev" bundle for validation only.
+set -euo pipefail
+
+VERSION="${VERSION:-dev}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/packaging/mcpb/build"
+DIST_DIR="${REPO_ROOT}/packaging/mcpb/dist"
+
+command -v mcpb >/dev/null 2>&1 || {
+  echo "error: mcpb CLI not found. Install with:" >&2
+  echo "  npm install -g @anthropic-ai/mcpb@2.1.2" >&2
+  exit 1
+}
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/src" "${DIST_DIR}"
+
+# Restrict substitution to ${VERSION} only — other ${...} tokens in the template
+# (e.g. ${DOCUMENTS}, ${user_config.*}) are runtime placeholders for the host.
+VERSION="${VERSION}" envsubst '${VERSION}' < "${SCRIPT_DIR}/manifest.json.in" \
+  > "${BUILD_DIR}/manifest.json"
+VERSION="${VERSION}" envsubst '${VERSION}' < "${SCRIPT_DIR}/pyproject.toml.in" \
+  > "${BUILD_DIR}/pyproject.toml"
+cp "${SCRIPT_DIR}/src/server.py" "${BUILD_DIR}/src/server.py"
+
+mcpb validate "${BUILD_DIR}/manifest.json"
+mcpb pack "${BUILD_DIR}" "${DIST_DIR}/{{ project_name }}-${VERSION}.mcpb"
+
+echo "built ${DIST_DIR}/{{ project_name }}-${VERSION}.mcpb"

--- a/packaging/mcpb/manifest.json.in.jinja
+++ b/packaging/mcpb/manifest.json.in.jinja
@@ -16,7 +16,7 @@
   "homepage": "https://{{ github_org }}.github.io/{{ project_name }}/",
   "documentation": "https://{{ github_org }}.github.io/{{ project_name }}/",
   "support": "https://github.com/{{ github_org }}/{{ project_name }}/issues",
-  "license": "MIT",
+  "license": "UNLICENSED",
   "keywords": [],
   "server": {
     "type": "uv",

--- a/packaging/mcpb/manifest.json.in.jinja
+++ b/packaging/mcpb/manifest.json.in.jinja
@@ -1,0 +1,64 @@
+{
+  "manifest_version": "0.4",
+  "name": "{{ project_name }}",
+  "display_name": "{{ human_name }}",
+  "version": "${VERSION}",
+  "description": "{{ domain_description }}",
+  "long_description": "{{ domain_description }}",
+  "author": {
+    "name": "{{ github_org }}",
+    "url": "https://github.com/{{ github_org }}"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/{{ github_org }}/{{ project_name }}.git"
+  },
+  "homepage": "https://{{ github_org }}.github.io/{{ project_name }}/",
+  "documentation": "https://{{ github_org }}.github.io/{{ project_name }}/",
+  "support": "https://github.com/{{ github_org }}/{{ project_name }}/issues",
+  "license": "MIT",
+  "keywords": [],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/server.py",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["--from", "{{ pypi_name }}[all]==${VERSION}", "{{ project_name }}", "serve"],
+      "env": {
+        "{{ env_prefix }}_SERVER_NAME": "${user_config.server_name}",
+        "{{ env_prefix }}_READ_ONLY":   "${user_config.read_only}",
+        "FASTMCP_LOG_LEVEL":            "${user_config.log_level}"
+      }
+    }
+  },
+  "user_config": {
+    "server_name": {
+      "type": "string",
+      "title": "Server name",
+      "description": "Name shown in the Claude tool list.",
+      "required": false,
+      "default": "{{ project_name }}"
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read-only mode",
+      "description": "When true, write-tagged tools are hidden.",
+      "required": false,
+      "default": true
+    },
+    "log_level": {
+      "type": "string",
+      "title": "Log level",
+      "description": "One of: DEBUG, INFO, WARNING, ERROR.",
+      "required": false,
+      "default": "INFO"
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.11,<4.0"
+    }
+  }
+}

--- a/packaging/mcpb/pyproject.toml.in.jinja
+++ b/packaging/mcpb/pyproject.toml.in.jinja
@@ -1,0 +1,8 @@
+# Rendered at build time by envsubst. ${VERSION} matches the package release.
+[project]
+name = "{{ project_name }}-mcpb"
+version = "${VERSION}"
+requires-python = ">=3.11"
+dependencies = [
+  "{{ pypi_name }}[all]==${VERSION}",
+]

--- a/packaging/mcpb/src/server.py.jinja
+++ b/packaging/mcpb/src/server.py.jinja
@@ -5,13 +5,16 @@ code path (``server.type: "uv"`` + ``entry_point``).  The primary launch path
 is ``mcp_config.command: "uvx"`` which fetches {{ project_name }} directly
 from PyPI and bypasses this shim entirely.
 
-The shim injects ``serve`` into ``sys.argv`` because ``cli.main()`` delegates
-to argparse which reads ``sys.argv``; the bundle host does not pass subcommands.
+The shim appends ``serve`` to ``sys.argv`` (unless already present) because
+``cli.main()`` delegates to argparse and requires a subcommand.  Existing
+argv entries (e.g. ``-v`` for verbose logging) are preserved so the bundle
+remains debuggable when invoked directly.
 """
 
 import sys
 
 from {{ python_module }}.cli import main
 
-sys.argv = [sys.argv[0], "serve"]
+if "serve" not in sys.argv[1:]:
+    sys.argv.append("serve")
 main()

--- a/packaging/mcpb/src/server.py.jinja
+++ b/packaging/mcpb/src/server.py.jinja
@@ -1,0 +1,17 @@
+"""Entry shim for the {{ project_name }} .mcpb bundle.
+
+This file is only executed when the host uses the ``uv run src/server.py``
+code path (``server.type: "uv"`` + ``entry_point``).  The primary launch path
+is ``mcp_config.command: "uvx"`` which fetches {{ project_name }} directly
+from PyPI and bypasses this shim entirely.
+
+The shim injects ``serve`` into ``sys.argv`` because ``cli.main()`` delegates
+to argparse which reads ``sys.argv``; the bundle host does not pass subcommands.
+"""
+
+import sys
+
+from {{ python_module }}.cli import main
+
+sys.argv = [sys.argv[0], "serve"]
+main()


### PR DESCRIPTION
## Summary

Template's \`release.yml.jinja\` has always shipped a \`build-mcpb\` job that expects \`packaging/mcpb/manifest.json.in\`, \`pyproject.toml.in\`, and \`src/server.py\`, but the template itself never shipped those files. Any project rendered from the template hits a hard release failure on first rc:

\`\`\`
packaging/mcpb/manifest.json.in: No such file or directory
##[error]Process completed with exit code 1.
\`\`\`

Surfaced by \`pvliesdonk/image-generation-mcp\` during its Step 5 retrofit (v1.6.0-rc.1 — Docker succeeded, build-mcpb failed).

## What this adds

- \`packaging/mcpb/manifest.json.in.jinja\` — minimal manifest using the 8 copier vars; three starter \`user_config\` entries (\`server_name\`, \`read_only\`, \`log_level\`) populated from the env vars every generated project carries.
- \`packaging/mcpb/pyproject.toml.in.jinja\` — thin wrapper: \`{{ pypi_name }}[all]==\${VERSION}\`.
- \`packaging/mcpb/src/server.py.jinja\` — entry shim (\`sys.argv = [argv[0], \"serve\"]\`; primary launch is uvx, this only runs when host uses \`server.type: \"uv\"\`).
- \`packaging/mcpb/build.sh.jinja\` — local bundle build helper (envsubst + \`mcpb validate/pack\`).

All four added to \`_skip_if_exists\` — projects extend the manifest with domain-specific \`user_config\` fields, keywords, and \`mcp_config\` env vars, and their edits survive future \`copier update\` runs.

## Test plan

- [x] Local render with a fake project name produces valid files (parsed JSON, pyproject, server.py shim)
- [ ] CI green
- [ ] After merge: cut \`v1.0.2\` template patch, then MV/IG can \`copier update\` to inherit the starter

🤖 Generated with [Claude Code](https://claude.com/claude-code)