### PR TITLE
fix(mcpb): add [build-system] table to pyproject starter

### DIFF
--- a/packaging/mcpb/pyproject.toml.in.jinja
+++ b/packaging/mcpb/pyproject.toml.in.jinja
@@ -1,4 +1,8 @@
 # Rendered at build time by envsubst. ${VERSION} matches the package release.
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "{{ project_name }}-mcpb"
 version = "${VERSION}"


### PR DESCRIPTION
## Summary

One-liner: add a \`[build-system]\` stanza to \`packaging/mcpb/pyproject.toml.in.jinja\` to silence uv's warning when resolving the .mcpb bundle deps.

## Why

uv logs a warning on some versions when it encounters a \`pyproject.toml\` without \`[build-system]\`. The .mcpb bundle pyproject is never actually built as a Python package (\`mcpb pack\` just zips the directory), but uv still reads it during dep resolution at bundle install time.

## Surfaced

claude-review round 3 on pvliesdonk/image-generation-mcp#184 — \`minor\`, non-blocking. Mirrored to IG in that PR; this one lands the same fix in the template so future projects inherit it.

## Test plan

- [x] Template render (\`copier copy ... /tmp/x\`) produces valid pyproject.toml.in
- [ ] CI green
- [ ] Post-merge: next template release (v1.0.3 or later) ships this starter

🤖 Generated with [Claude Code](https://claude.com/claude-code)