### PR TITLE
fix(release): ship bump_manifests.py + wire PSR build_command

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -31,6 +31,7 @@ _skip_if_exists:
   - "packaging/mcpb/pyproject.toml.in"
   - "packaging/mcpb/src/server.py"
   - "packaging/mcpb/build.sh"
+  - "scripts/bump_manifests.py"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -129,7 +129,10 @@ pythonVersion = "3.11"
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "angular"
 tag_format = "v{version}"
-build_command = ""
+# Bump versioned manifests (server.json) inside the release commit rather
+# than in a follow-up commit + force-retag.  Extend scripts/bump_manifests.py
+# if your project adds more lockstep manifests (plugin.json, .mcp.json, ...).
+build_command = "python scripts/bump_manifests.py"
 # PSR stages and commits files listed in `assets` together with pyproject.toml
 # and CHANGELOG.md, so the release tag points at a single commit containing
 # all version-coupled files.  Add ".claude-plugin/plugin/.claude-plugin/plugin.json"

--- a/scripts/bump_manifests.py.jinja
+++ b/scripts/bump_manifests.py.jinja
@@ -52,15 +52,30 @@ def main() -> int:
     # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
     # keep their own ``ghcr.io/<owner>/<image>`` base.
     server_path = Path("server.json")
+    if not server_path.exists():
+        print(
+            f"server.json not found in {Path.cwd()} — run from repo root",
+            file=sys.stderr,
+        )
+        return 1
     server = _load(server_path)
     server["version"] = version
     for pkg in server.get("packages", []):
         if pkg.get("registryType") == "pypi":
             pkg["version"] = version
         elif pkg.get("registryType") == "oci":
-            pkg["identifier"] = re.sub(r":v[^:]+$", f":v{version}", pkg["identifier"])
+            identifier = pkg.get("identifier", "")
+            new_id, n = re.subn(r":v[^:]+$", f":v{version}", identifier)
+            if n == 0:
+                print(
+                    f"WARNING: OCI identifier {identifier!r} has no ':v<tag>' "
+                    "suffix to bump — left unchanged",
+                    file=sys.stderr,
+                )
+            pkg["identifier"] = new_id
     _dump(server_path, server)
 
+    print(f"bump_manifests: server.json → {version}")
     return 0
 
 

--- a/scripts/bump_manifests.py.jinja
+++ b/scripts/bump_manifests.py.jinja
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Bump versioned manifests to match the semantic-release version.
+
+Invoked by python-semantic-release via ``[tool.semantic_release] build_command``.
+PSR sets ``NEW_VERSION`` in the environment and, because ``server.json`` is
+listed in ``[tool.semantic_release] assets``, PSR stages and commits it
+together with ``pyproject.toml`` + ``CHANGELOG.md`` as the single release
+commit — which is the commit it then tags.
+
+The script runs inside PSR's Docker action container (python:3.14-slim), which
+has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
+
+Projects that ship additional versioned manifests (e.g. a Claude Code
+``plugin.json``, an ``.mcp.json``, or other lockstep JSON/TOML files) should
+add the extra paths to this script and list them in
+``pyproject.toml`` ``[tool.semantic_release] assets``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _dump(path: Path, data: Any) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        # ensure_ascii=False preserves UTF-8 characters literally, matching
+        # jq's default behavior and how a human editor would save the file.
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main() -> int:
+    version = os.environ.get("NEW_VERSION")
+    if not version:
+        print(
+            "NEW_VERSION must be set (python-semantic-release build_command env)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # server.json: top-level version, PyPI package version, OCI tag suffix.
+    # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
+    # keep their own ``ghcr.io/<owner>/<image>`` base.
+    server_path = Path("server.json")
+    server = _load(server_path)
+    server["version"] = version
+    for pkg in server.get("packages", []):
+        if pkg.get("registryType") == "pypi":
+            pkg["version"] = version
+        elif pkg.get("registryType") == "oci":
+            pkg["identifier"] = re.sub(r":v[^:]+$", f":v{version}", pkg["identifier"])
+    _dump(server_path, server)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Template had \`assets = [\"server.json\"]\` in PSR config but \`build_command = \"\"\` (empty) and no script to actually bump server.json on release. Every generated project ships with a server.json that goes stale after the first release.

Surfaced on IG: v1.5.1 shipped with \`server.json.version = \"1.5.0\"\` → \`mcp-publisher\` tried to re-publish v1.5.0 → MCP Registry returned \"cannot publish duplicate version\".

## What this adds

- **\`scripts/bump_manifests.py.jinja\`**: reads \`NEW_VERSION\` from PSR's env and rewrites server.json's top-level version, PyPI package version, and the \`:v<old>\` tag suffix of the OCI identifier. Starter handles only server.json; docstring tells projects to extend if they add more lockstep manifests (plugin.json, .mcp.json, ...).
- **\`pyproject.toml.jinja\`**: flip \`build_command = \"\"\` → \`build_command = \"python scripts/bump_manifests.py\"\`.
- **\`copier.yml\`**: add \`scripts/bump_manifests.py\` to \`_skip_if_exists\` so projects can extend the script without losing their edits on \`copier update\`.

## Also filed

Direct fix on IG at pvliesdonk/image-generation-mcp#187 — IG needs this today (before its next release) and can't wait for a template v1.0.3 cut. MV already has this script with its own multi-manifest variant, won't be affected by the template change.

## Test

- [x] Render smoke: \`copier copy ... /tmp/x\` produces \`scripts/bump_manifests.py\` and \`build_command = \"python scripts/bump_manifests.py\"\`
- [x] Direct script smoke on IG: \`NEW_VERSION=99.0.0 python scripts/bump_manifests.py\` correctly rewrites server.json
- [ ] CI green
- [ ] Post-merge + template v1.0.3: existing generated projects can \`copier update\` to inherit (server.json bumping will start working on their next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)