### PR TITLE
feat(cli): rewrite template CLI from argparse to typer

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -17,6 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp-pvl-core>=1.0,<2",
+    "typer>=0.12",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     # PROJECT-DEPS-END
 ]
@@ -68,6 +69,7 @@ ignore = ["E501"]
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002/TC003.
+"src/{{ python_module }}/cli.py" = ["B008"]
 "src/{{ python_module }}/_server_deps.py" = ["B008", "TC002", "TC003"]
 "src/{{ python_module }}/_server_apps.py" = ["B008", "TC001", "TC002"]
 "src/{{ python_module }}/tools.py" = ["B008", "TC001", "TC002"]

--- a/src/{{python_module}}/cli.py.jinja
+++ b/src/{{python_module}}/cli.py.jinja
@@ -65,10 +65,16 @@ def serve(
             http_path or os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
         )
         event_store = build_event_store(_ENV_PREFIX, config.server)
+        # lifespan="on" is essential: FastMCP's server_lifespan (startup/shutdown
+        # hooks, including service init) runs through the ASGI lifespan protocol.
+        # timeout_graceful_shutdown=3 lets SIGTERM drain requests within 3s so
+        # containers (Docker/k8s) stop cleanly.
         uvicorn.run(
             server.http_app(path=path, event_store=event_store),
             host=host,
             port=port,
+            lifespan="on",
+            timeout_graceful_shutdown=3,
         )
     else:
         server.run(transport=transport)

--- a/src/{{python_module}}/cli.py.jinja
+++ b/src/{{python_module}}/cli.py.jinja
@@ -14,8 +14,6 @@ from fastmcp_pvl_core import (
 
 from {{ python_module }}.config import _ENV_PREFIX, ProjectConfig
 
-logger = logging.getLogger(__name__)
-
 app = typer.Typer(
     name="{{ project_name }}",
     help="{{ domain_description }}",
@@ -32,8 +30,26 @@ def _root(
         False, "-v", "--verbose", help="Enable debug logging."
     ),
 ) -> None:
-    """Root callback — bootstraps logging for every subcommand."""
+    """Root callback — bootstraps logging for every subcommand.
+
+    ``configure_logging_from_env`` sets the root logger *level* and
+    configures FastMCP's own logger tree, but does NOT attach a handler
+    to the root logger — so ``{{ python_module }}.*`` loggers would have
+    no output.  Attach one here.  Kept idempotent via the
+    ``if not root.handlers`` guard so repeated calls (e.g. from
+    ``make_server()`` on the same process) are safe.
+    """
     configure_logging_from_env(verbose=verbose)
+    root = logging.getLogger()
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+        root.addHandler(handler)
+    if verbose:
+        # httpx/httpcore are noisy at DEBUG; keep them quiet.  Core doesn't
+        # own these deps, so the silencing stays domain-local.
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 @app.command()

--- a/src/{{python_module}}/cli.py.jinja
+++ b/src/{{python_module}}/cli.py.jinja
@@ -1,85 +1,82 @@
-"""CLI entry point for {{ human_name }}.
-
-Uses ``fastmcp_pvl_core.make_serve_parser`` for the standard
-``-v``/``--transport``/``--host``/``--port``/``--http-path`` flags;
-add project-specific subcommands below if needed (see MV's CLI as a
-reference).
-"""
+"""Command-line interface for {{ human_name }}."""
 
 from __future__ import annotations
 
 import logging
-import os
-from typing import TYPE_CHECKING
+from typing import Literal
 
+import typer
 from fastmcp_pvl_core import (
+    build_event_store,
     configure_logging_from_env,
-    make_serve_parser,
     normalise_http_path,
 )
 
-if TYPE_CHECKING:
-    import argparse
+from {{ python_module }}.config import _ENV_PREFIX, ProjectConfig
 
 logger = logging.getLogger(__name__)
 
-_PROG = "{{ project_name }}"
-_ENV_PREFIX = "{{ env_prefix }}"
+app = typer.Typer(
+    name="{{ project_name }}",
+    help="{{ domain_description }}",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+Transport = Literal["stdio", "http", "sse"]
 
 
-def main() -> None:
-    """CLI entry point."""
-    parser = make_serve_parser(
-        prog=_PROG,
-        description="{{ domain_description }}",
-    )
-    sub = parser.add_subparsers(dest="command", required=True)
-    sub.add_parser("serve", help="run the MCP server")
-    # Add more subcommands here (index, search, reindex, ...) as needed.
-
-    args = parser.parse_args()
-
-    configure_logging_from_env(verbose=args.verbose)
-    # Root handler for {{ python_module }}.* — FastMCP's configure_logging
-    # only covers its own logger tree.
-    root = logging.getLogger()
-    if not root.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
-        root.addHandler(handler)
-
-    # Silence httpx/httpcore at DEBUG — kept inline, core doesn't own these deps.
-    if args.verbose:
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
-
-    if args.command == "serve":
-        _cmd_serve(args)
-    else:
-        parser.error(f"unknown command: {args.command}")
+@app.callback()
+def _root(
+    verbose: bool = typer.Option(
+        False, "-v", "--verbose", help="Enable debug logging."
+    ),
+) -> None:
+    """Root callback — bootstraps logging for every subcommand."""
+    configure_logging_from_env(verbose=verbose)
 
 
-def _cmd_serve(args: argparse.Namespace) -> None:
+@app.command()
+def serve(
+    transport: Transport = typer.Option(
+        "stdio", help="MCP transport (stdio / http / sse)."
+    ),
+    host: str = typer.Option("0.0.0.0", help="Bind host (http only)."),
+    port: int = typer.Option(8000, help="Bind port (http only)."),
+    http_path: str | None = typer.Option(
+        None,
+        "--http-path",
+        "--path",
+        help=(f"Mount path (http only, default: ${_ENV_PREFIX}_HTTP_PATH or /mcp)."),
+    ),
+) -> None:
+    """Run the MCP server."""
+    import os
+
     from {{ python_module }}.server import make_server
 
-    transport = args.transport
-    server = make_server(transport=transport)
-    env_http_path = os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
-    http_path = normalise_http_path(args.http_path or env_http_path)
+    config = ProjectConfig.from_env()
+    server = make_server(transport=transport, config=config)
 
     if transport == "http":
         import uvicorn
 
-        app = server.http_app(path=http_path, transport="http")
+        path = normalise_http_path(
+            http_path or os.environ.get(f"{_ENV_PREFIX}_HTTP_PATH")
+        )
+        event_store = build_event_store(_ENV_PREFIX, config.server)
         uvicorn.run(
-            app,
-            host=args.host,
-            port=args.port,
-            timeout_graceful_shutdown=3,
-            lifespan="on",
+            server.http_app(path=path, event_store=event_store),
+            host=host,
+            port=port,
         )
     else:
         server.run(transport=transport)
+
+
+def main() -> None:
+    """CLI entry point — used by ``[project.scripts]`` in pyproject.toml."""
+    app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rewrites the template's `src/{{python_module}}/cli.py.jinja` from argparse onto **typer**, and adds `typer>=0.12` to `[project].dependencies` in `pyproject.toml.jinja`.  Future projects rendered from the next template release get typer out of the box.

### What changes

- `cli.py.jinja`: `typer.Typer` app with a root callback (`-v`/`--verbose` bootstraps logging via `fastmcp_pvl_core.configure_logging_from_env`) plus a `serve` subcommand mirroring today's flags: `--transport` (stdio / http / sse), `--host`, `--port`, `--http-path`.  `--path` is retained as an alias so existing Dockerfiles and service units keep working.
- `pyproject.toml.jinja`: `typer>=0.12` appended right after the core dep.  Adds `src/{{ python_module }}/cli.py = ["B008"]` to ruff per-file-ignores (typer's `Option()` in defaults triggers B008, same false positive already handled for FastMCP's `Depends()` elsewhere).

### Why typer

- User preference over argparse; better UX (auto-generated `--help`, rich colour, typed options).
- Scholar-mcp (next in the fastmcp-pvl-core retrofit series) is about to adopt the template fresh, so it was cheaper to do this upstream once than port argparse → typer in each downstream project.

### Non-goals

- No changes to fastmcp-pvl-core — typer is a dependency of **generated projects**, not the core library.
- MV and IG are not forced to adopt.  They will see this as a diff on their next `copier update` pass and can accept or skip.
- No new subcommands in the template (`index`, `search`, `reindex` in MV stay MV-specific).

## Smoke-test evidence (rendered `example-mcp` project)

All gates green on the rendered output:
- `uv sync --extra dev` — OK
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 16 files already formatted
- `uv run mypy src/` — Success: no issues found
- `uv run pytest -x -q` — 2 passed
- `uv run example-mcp --help` — typer help renders correctly with `serve` subcommand
- `uv run example-mcp serve --help` — shows `--transport [stdio|http|sse]`, `--host`, `--port`, `--http-path,--path`

## Test plan

- [x] Template renders to a valid project
- [x] Rendered project's gates all pass (ruff/mypy/pytest)
- [x] CLI `--help` works end-to-end on the rendered project
- [ ] CI on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)