### PR TITLE
feat(gitignore): ship opinionated .gitignore starter + add to _skip_if_exists

### DIFF
--- a/.gitignore.jinja
+++ b/.gitignore.jinja
@@ -1,0 +1,41 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtualenvs
+.venv/
+venv/
+
+# Tooling caches
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Test / coverage artifacts
+.coverage
+coverage.xml
+coverage.json
+htmlcov/
+
+# MkDocs build output
+site/
+
+# Local environment
+.env
+.env.local
+
+# --- Development / ecosystem ignores (don't ship)
+.mcpregistry_*
+.worktrees/
+.claude/worktrees/
+.claude/settings.local.json
+docs/superpowers/

--- a/copier.yml
+++ b/copier.yml
@@ -32,6 +32,7 @@ _skip_if_exists:
   - "packaging/mcpb/src/server.py"
   - "packaging/mcpb/build.sh"
   - "scripts/bump_manifests.py"
+  - ".gitignore"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the


### PR DESCRIPTION
## Summary

Template had no \`.gitignore.jinja\` — every generated project either ended up without a .gitignore on first \`copier copy\`, or got one hand-written by whatever subagent did the retrofit. During scholar-mcp's Step 6 retrofit, the subagent wholesale-replaced scholar's existing \`.gitignore\`, silently losing scholar's \`docs/superpowers/\` and \`.worktrees/\` entries. MV/IG retrofits also relied on careful hand-merging.

## What this adds

- **\`.gitignore.jinja\`**: opinionated starter covering Python bytecode, packaging, virtualenvs, tooling caches, test/coverage artifacts, MkDocs output, local env files, plus project-ecosystem ignores:
  - \`.mcpregistry_*\` — mcp-publisher temp state
  - \`.worktrees/\` — git worktrees convention
  - \`.claude/worktrees/\` — Claude Code worktree stash
  - \`.claude/settings.local.json\` — per-user overrides
  - \`docs/superpowers/\` — dev planning artifacts
- **\`copier.yml\`**: add \`.gitignore\` to \`_skip_if_exists\` so existing projects' \`.gitignore\` is preserved on \`copier update\`.

## Deliberately NOT ignored

- \`.claude/\` broadly. Projects may want to commit shared Claude assets (hooks, custom commands, project agents). Projects that want broader ignores add them in their own \`.gitignore\` — which is now preserved via \`_skip_if_exists\`.

## Downstream follow-up

- pvliesdonk/markdown-vault-mcp — separate PR (remove broad \`.claude/\`, add specific entries).
- pvliesdonk/image-generation-mcp — separate PR (same).
- pvliesdonk/scholar-mcp — applied directly on the open Step 6 retrofit PR #148.

## Test

- [x] Render smoke with example-mcp answers: \`.gitignore\` rendered with full content
- [ ] CI green
- [ ] Post-merge: cut template v1.0.5 with the starter

🤖 Generated with [Claude Code](https://claude.com/claude-code)