### PR TITLE
fix(ci): docs deploy on v* tag push (not just release event)

### DIFF
--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -3,10 +3,12 @@ name: Documentation
 on:
   push:
     branches: [main]
-    # Tag-push is a SMOKE TEST: it runs `build` only (confirms docs still
-    # compile against a release tag) — the `upload-artifact` and `deploy`
-    # steps below are gated on `github.event_name == 'release'`, so actual
-    # GitHub Pages deployment still only happens via the release event.
+    # Tag-push also deploys: whichever event fires first (tag-push or
+    # release:published) wins the concurrency group below and performs
+    # the full build+upload+deploy.  The release-event path can race
+    # against tag availability (deploy-pages fetch fails), so tag-push
+    # gives a deterministic second path.  Gates on the `upload-artifact`
+    # step and `deploy` job below accept either event.
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -54,13 +56,13 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Upload artifact
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
   deploy:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Scholar v1.8.0-rc.1 and IG v1.8.0 both had docs deploy fail on the release-event path (deploy-pages step races against tag availability). The push-on-tag path already runs the workflow but only did \`build\` because upload + deploy were gated on \`event_name == 'release'\`.

Extend the gate to also accept tag-push on v*:

\`\`\`yaml
if: github.event_name == 'release'
    || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
\`\`\`

Whichever event fires first wins the \`(workflow, ref, event_name)\` concurrency group and performs the full deploy.  If one path fails the other is a deterministic second attempt.

## Downstream applications

- pvliesdonk/scholar-mcp#154
- pvliesdonk/image-generation-mcp (follow-up PR)
- pvliesdonk/markdown-vault-mcp (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)