### PR TITLE
chore(actions): bump setup-uv, deploy-pages, codeql-action

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 

--- a/.github/workflows/codeql.yml.jinja
+++ b/.github/workflows/codeql.yml.jinja
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -40,7 +40,7 @@ jobs:
           ref: {% raw %}${{ github.event_name == 'release' && 'main' || github.ref }}{% endraw %}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -40,7 +40,7 @@ jobs:
           token: {% raw %}${{ secrets.RELEASE_TOKEN }}{% endraw %}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.6"
 

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.6"
 


### PR DESCRIPTION
## Summary

- \`astral-sh/setup-uv@v8.0.0\` → \`v8.1.0\`
- \`actions/deploy-pages@v4\` → \`v5\`
- \`github/codeql-action/init@v3\` → \`v4\`
- \`github/codeql-action/analyze@v3\` → \`v4\`

These surfaced as dependabot PRs in all four downstream projects at once. Handling them upstream keeps the template the single source of truth and clears the fleet through the next copier retrofit instead of per-repo action-only bumps.

## Test plan

- [x] Only \`.github/workflows/*.jinja\` and \`template-ci.yml\` modified
- [x] grep \`setup-uv@v8.0.0\`, \`deploy-pages@v4\`, \`codeql-action.*@v3\` → no matches left in \`.github/\`
- [ ] Template CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)