### PR TITLE
feat(ci): weekly copier update workflow

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -1,0 +1,129 @@
+name: Copier Update
+
+# Weekly automated `copier update` against this project's template source.
+# If the template has moved since `.copier-answers.yml:_commit`, opens (or
+# refreshes) a PR on branch `copier/update` so CI can validate the diff and
+# an operator can review/merge.
+#
+# Uses the RELEASE_TOKEN PAT (not GITHUB_TOKEN) so the opened PR triggers
+# downstream workflows — GITHUB_TOKEN-authored PRs are muted by design.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Monday 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      vcs_ref:
+        description: "Template ref to update to (default: latest tag from .copier-answers.yml source)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: {{ '${{ secrets.RELEASE_TOKEN }}' }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run copier update
+        id: copier
+        env:
+          VCS_REF: {{ '${{ inputs.vcs_ref }}' }}
+        run: |
+          set -euo pipefail
+          args=(update --trust --defaults --skip-answered --conflict=rej)
+          if [ -n "${VCS_REF}" ]; then
+            args+=(--vcs-ref "${VCS_REF}")
+          fi
+          uvx --from copier copier "${args[@]}"
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read template ref + count conflicts
+        if: steps.changes.outputs.changed == 'true'
+        id: meta
+        run: |
+          set -euo pipefail
+          ref=$(python3 -c "import yaml; print(yaml.safe_load(open('.copier-answers.yml'))['_commit'])")
+          rej_count=$(find . -name '*.rej' -not -path './.git/*' | wc -l | tr -d ' ')
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "rej_count=${rej_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure `copier` label exists
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: {{ '${{ secrets.RELEASE_TOKEN }}' }}
+        run: |
+          gh label create copier \
+            --color C5DEF5 \
+            --description "Automated copier template sync" \
+            2>/dev/null || true
+
+      - name: Commit and push to copier/update branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          git checkout -B "${branch}"
+          git add -A
+          git commit -m "chore(copier): update to {{ '${{ steps.meta.outputs.ref }}' }}" \
+            -m "Automated \`copier update\` run — review the diff and merge if CI is green."
+          git push --force-with-lease origin "${branch}"
+
+      - name: Open or update PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: {{ '${{ secrets.RELEASE_TOKEN }}' }}
+          REF: {{ '${{ steps.meta.outputs.ref }}' }}
+          REJ_COUNT: {{ '${{ steps.meta.outputs.rej_count }}' }}
+        run: |
+          set -euo pipefail
+          branch="copier/update"
+          title="chore(copier): update to ${REF}"
+
+          body="Automated \`copier update\` run against template ref \`${REF}\`.
+
+Review the diff, fix any \`.rej\` conflict files, and merge if CI is green."
+          if [ "${REJ_COUNT}" -gt 0 ]; then
+            body="${body}
+
+⚠️ **${REJ_COUNT} \`.rej\` conflict file(s) present — review and resolve manually before merging.**"
+          fi
+
+          if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            gh pr edit "${branch}" --title "${title}" --body "${body}"
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --label copier \
+              --label dependencies
+          fi

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -54,7 +54,7 @@ jobs:
           if [ -n "${VCS_REF}" ]; then
             args+=(--vcs-ref "${VCS_REF}")
           fi
-          uvx --from copier copier "${args[@]}"
+          uvx copier "${args[@]}"
 
       - name: Detect changes
         id: changes
@@ -70,7 +70,14 @@ jobs:
         id: meta
         run: |
           set -euo pipefail
-          ref=$(python3 -c "import yaml; print(yaml.safe_load(open('.copier-answers.yml'))['_commit'])")
+          # Parse `_commit:` from .copier-answers.yml without depending on
+          # PyYAML being present in the runner's system Python.  copier's
+          # to_nice_yaml output puts the key on its own line in canonical form.
+          ref=$(awk '/^_commit:[[:space:]]/ {print $2; exit}' .copier-answers.yml)
+          if [ -z "${ref}" ]; then
+            echo "::error::could not read _commit from .copier-answers.yml"
+            exit 1
+          fi
           rej_count=$(find . -name '*.rej' -not -path './.git/*' | wc -l | tr -d ' ')
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "rej_count=${rej_count}" >> "$GITHUB_OUTPUT"
@@ -107,17 +114,22 @@ jobs:
           branch="copier/update"
           title="chore(copier): update to ${REF}"
 
-          body="Automated \`copier update\` run against template ref \`${REF}\`.
-
-Review the diff, fix any \`.rej\` conflict files, and merge if CI is green."
+          # Build the PR body piece-by-piece with $'\n' separators — a single
+          # multi-line bash string would break the enclosing YAML block scalar
+          # because the continuation lines would need to stay at column 11.
+          body="Automated \`copier update\` run against template ref \`${REF}\`."
+          body+=$'\n\n'"Review the diff, fix any \`.rej\` conflict files, and merge if CI is green."
+          body+=$'\n\n'"> **Note:** \`--skip-answered\` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim \`.copier-answers.yml\` for unexpected new keys."
           if [ "${REJ_COUNT}" -gt 0 ]; then
-            body="${body}
-
-⚠️ **${REJ_COUNT} \`.rej\` conflict file(s) present — review and resolve manually before merging.**"
+            body+=$'\n\n'"⚠️ **${REJ_COUNT} \`.rej\` conflict file(s) present — review and resolve manually before merging.**"
           fi
 
           if gh pr view "${branch}" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
-            gh pr edit "${branch}" --title "${title}" --body "${body}"
+            gh pr edit "${branch}" \
+              --title "${title}" \
+              --body "${body}" \
+              --add-label copier \
+              --add-label dependencies
           else
             gh pr create \
               --base main \


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/copier-update.yml.jinja\` — a scheduled + manual GitHub Actions workflow that runs \`copier update\` against each generated project's template source and opens (or refreshes) a PR on branch \`copier/update\` whenever the template has moved.

## Behaviour

- **Schedule:** Monday 06:00 UTC; also \`workflow_dispatch\` with optional \`vcs_ref\` input.
- **Auth:** uses \`RELEASE_TOKEN\` (not \`GITHUB_TOKEN\`) so CI runs on the opened PR. \`GITHUB_TOKEN\`-authored PRs are muted by design.
- **Conflict handling:** \`--conflict=rej\` leaves \`.rej\` sidecars instead of merge markers; the workflow counts them and flags a ⚠ warning in the PR body when present.
- **Branch model:** single stable branch \`copier/update\` with \`--force-with-lease\`; if a PR is already open, the title/body are updated in place instead of creating a new PR.
- **Labels:** \`copier\` + \`dependencies\`. The \`copier\` label is auto-created on first run via \`gh label create ... || true\`.

## Rollout

Downstream projects (markdown-vault-mcp, image-generation-mcp, scholar-mcp) pick this up on their next \`copier update\` against a template tag that includes this commit. No action needed from operators — the weekly workflow starts firing automatically after the first update.

## Test plan

- [x] \`copier copy --vcs-ref HEAD\` renders \`.github/workflows/copier-update.yml\` cleanly into smoke project
- [ ] Post-merge: verify template-ci passes
- [ ] Post-merge: cut template v1.0.6 tag so downstream projects receive the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)