### PR TITLE
fix(copier-update): add dependencies label guard + drop unused step id

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -45,7 +45,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run copier update
-        id: copier
         env:
           VCS_REF: {{ '${{ inputs.vcs_ref }}' }}
         run: |
@@ -95,14 +94,21 @@ jobs:
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "conflict_count=${conflict_count}" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure `copier` label exists
+      - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: {{ '${{ secrets.RELEASE_TOKEN }}' }}
         run: |
+          # `gh pr create --label foo` fails if the label doesn't exist,
+          # so ensure both labels are present first.  `|| true` keeps the
+          # step idempotent across repeat runs.
           gh label create copier \
             --color C5DEF5 \
             --description "Automated copier template sync" \
+            2>/dev/null || true
+          gh label create dependencies \
+            --color 0075CA \
+            --description "Pull requests that update a dependency file" \
             2>/dev/null || true
 
       - name: Commit and push to copier/update branch


### PR DESCRIPTION
## Summary

Two follow-ups surfaced during the code-review cycle on downstream bootstrap PRs (scholar #156, IG #191):

1. **\`dependencies\` label guard** — \`gh pr create --label dependencies\` fails if the \`dependencies\` label doesn't exist in the target repo. Adds the same \`gh label create … || true\` guard the \`copier\` label already has, so fresh downstream projects don't trip on the first weekly run. Step renamed \`Ensure \`copier\` label exists\` → \`Ensure PR labels exist\` to reflect scope.
2. **Drop unused \`id: copier\`** from the \"Run copier update\" step — no downstream step referenced \`steps.copier.*\`.

## Test plan

- [x] Rendered \`copier-update.yml\` parses as valid YAML (9 steps, unchanged count)
- [ ] Template CI green
- [ ] Post-merge: cut template v1.1.2; downstream refresh picks up both guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)