### PR TITLE
fix(copier-update): pass REF through env: + top-level import in test_smoke.py

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -113,12 +113,14 @@ jobs:
 
       - name: Commit and push to copier/update branch
         if: steps.changes.outputs.changed == 'true'
+        env:
+          REF: {{ '${{ steps.meta.outputs.ref }}' }}
         run: |
           set -euo pipefail
           branch="copier/update"
           git checkout -B "${branch}"
           git add -A
-          git commit -m "chore(copier): update to {{ '${{ steps.meta.outputs.ref }}' }}" \
+          git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"
 

--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from {{ python_module }}.server import make_server
+
 
 def test_make_server_constructs() -> None:
     """make_server() returns a FastMCP instance without raising."""
-    from {{ python_module }}.server import make_server
-
     server = make_server()
     assert server is not None


### PR DESCRIPTION
## Summary

Two small hygiene fixes surfaced by reviewers on scholar-mcp#158:

1. **`copier-update.yml.jinja`** — the commit-message step interpolates `${{ steps.meta.outputs.ref }}` directly into a shell string, while the "Open or update PR" step immediately below already passes `REF` / `CONFLICT_COUNT` through `env:`. Switching the commit step to the same `env: REF` pattern makes both steps consistent and sandboxes any future non-tag refs from shell interpretation.

2. **`tests/test_smoke.py.jinja`** — gemini-code-assist flagged the lazy `from {module}.server import make_server` inside the test body as a PEP 8 nit. Single-test file, no import-error isolation need — top-level import is the cleaner form.

## Test plan

- [x] Rendered `copier-update.yml` parses as valid YAML
- [x] Rendered `test_smoke.py` passes via `pytest -x -q`
- [ ] Template CI green
- [ ] Post-merge: cut v1.1.4 (patch — `fix:`) so scholar-mcp#158 can refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)