### PR TITLE
fix(copier): add shared deployment+auth docs to _skip_if_exists

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -41,6 +41,14 @@ _skip_if_exists:
   - "packaging/mcpb/build.sh"
   - "scripts/bump_manifests.py"
   - ".gitignore"
+  # Shared deployment/auth docs — rendered as starter content on first copy,
+  # but consumers typically customize them with domain-specific env vars,
+  # auth flows, and deployment notes.  Protected from copier update to avoid
+  # clobbering that customization.  Tracked for future sentinel-based
+  # protection in issue #29.
+  - "docs/deployment/docker.md"
+  - "docs/deployment/oidc.md"
+  - "docs/guides/authentication.md"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the


### PR DESCRIPTION
## Summary

Adds three paths to `copier.yml`'s `_skip_if_exists`:
- `docs/deployment/docker.md`
- `docs/deployment/oidc.md`
- `docs/guides/authentication.md`

All three consumers in this fleet (MV, scholar, image-gen) have 150-300 lines of domain-specific content in each file (env vars, auth flows, deployment flows).  Without this guard, the upcoming Phase 4 copier-update bot PRs would clobber all of it.

Fresh projects still get starter scaffolds via the normal render; updates skip.

## Test plan

- [x] Smoke render + idempotence check
- [x] Fresh-copy render still writes all three docs files (verified `ls /tmp/smoke/docs/`)
- [x] Local gate: ruff, mypy, pytest all pass

## Related

- Surfaced during code review of image-generation-mcp convergence PR #196
- Follow-up for future sentinel-based protection: #29