### PR TITLE
fix(claude-md): replace RST :class: with Markdown backticks

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -87,7 +87,7 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 
 ## Config & Customization Contract
 
-Domain configuration composes :class:`fastmcp_pvl_core.ServerConfig` inside :class:`ProjectConfig` (see `src/{{ python_module }}/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
+Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain config class (see `src/{{ python_module }}/config.py`).  Add domain fields between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels and populate them in `from_env` between the `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels.  Never inherit from `ServerConfig`; always compose.
 
 Env var prefix is `{{ env_prefix }}_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 


### PR DESCRIPTION
## Summary

Two small fixes in the template-owned `Config & Customization Contract` section of `CLAUDE.md.jinja`:

1. Replace `:class:\`Name\`` (Sphinx RST) with plain Markdown backticks.  The RST syntax renders as literal text in GitHub's Markdown view, not a formatted link.

2. Drop the hardcoded `ProjectConfig` class name.  markdown-vault-mcp uses `CollectionConfig`; others use different names.  Replace with "your domain config class" which is neutral and accurate for all fleet members.

Surfaced during scholar-mcp PR #161 review.

## Test plan

- [x] Smoke render + idempotence
- [x] `grep -c ':class:'` on rendered output returns 0
- [x] Gate: ruff, mypy, pytest all pass