### PR TITLE
fix(copier-update): stage conflict markers before git checkout -B

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -118,8 +118,15 @@ jobs:
         run: |
           set -euo pipefail
           branch="copier/update"
-          git checkout -B "${branch}"
+          # `git add -A` runs BEFORE `git checkout -B` because copier's
+          # `--conflict=inline` mode leaves conflict-marker files in the
+          # index as `UU` (unmerged).  `git checkout -B` refuses to switch
+          # branches with unresolved merge entries; staging them first
+          # clears the unmerged state and lets the branch creation proceed.
+          # The conflict markers themselves land in the commit for human
+          # resolution in the PR.
           git add -A
+          git checkout -B "${branch}"
           git commit -m "chore(copier): update to ${REF}" \
             -m "Automated \`copier update\` run — review the diff and merge if CI is green."
           git push --force-with-lease origin "${branch}"


### PR DESCRIPTION
## Summary

Reorders `git add -A` to run before `git checkout -B` so `copier update --conflict=inline` can commit its conflict markers.  Before this fix, any real 3-way merge conflict aborted the whole workflow with `error: you need to resolve your current index first`.

## Repro

markdown-vault-mcp workflow run [24798769825](https://github.com/pvliesdonk/markdown-vault-mcp/actions/runs/24798769825) failed here with CLAUDE.md + Dockerfile conflicts.

## Test plan

- [x] Reproduced locally against MV main + template v1.1.7 — confirmed checkout fails with original order, succeeds with reorder
- [x] Smoke render + idempotence
- [x] Rendered copier-update.yml has `git add -A` before `git checkout -B`
- [x] Local gate: ruff, mypy, pytest all pass

## Release note

After merge, cut v1.1.8.  Consumers' next `copier update` against v1.1.8 will pick up the workflow fix; existing runs that are still on v1.1.7 need a one-time hot-patch to their rendered `copier-update.yml` (see follow-up).