### PR TITLE
fix(dockerfile): COPY uv.lock so final uv sync sees the lockfile

### DIFF
--- a/Dockerfile.jinja
+++ b/Dockerfile.jinja
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
 
 # Copy source and install project.
-COPY pyproject.toml README.md /app/
+COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev


### PR DESCRIPTION
## Summary

- Downstream Docker builds on template v1.1.8 fail with `error: Unable to find lockfile at 'uv.lock'` because `Dockerfile.jinja`'s source COPY step omits `uv.lock` — only the earlier bind-mounted sync had access to it.
- One-line fix: add `uv.lock` to `COPY pyproject.toml ... README.md /app/`.
- Surfaced by scholar-mcp v1.7.1 release ([run](https://github.com/pvliesdonk/scholar-mcp/actions/runs/24825529763)); image-generation-mcp was unaffected only because its Dockerfile had been hand-edited to `COPY . .`.

## Release target

Pre-v1.1.9 patch release (v1.1.9 itself per `docs/superpowers/specs/2026-04-23-triaged-fixes-v1.1.9-design.md`). The in-flight design becomes v1.1.10.

## Test plan

- [x] Renders with `tests/fixtures/smoke-answers.yml` (verified locally).
- [x] Generated project's gate passes: `ruff check`, `ruff format --check`, `mypy src/`, `pytest -x -q`.
- [ ] `template-ci.yml` full matrix (3.11–3.14) green on PR.
- [ ] After merge: dispatch `template-release.yml` with `bump=patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)