### PR TITLE
feat(dockerfile): sentinel-protect state-dir mkdir + VOLUME (#30)

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -104,3 +104,15 @@ jobs:
               docs/deployment/oidc.md \
               docs/guides/authentication.md \
             || { echo "::error::fastmcp-server-template literal leaked into shared docs"; exit 1; }
+
+      - name: Dockerfile sentinel structure
+        working-directory: /tmp/smoke
+        run: |
+          for marker in \
+            "# DOCKERFILE-STATE-DIRS-START" \
+            "# DOCKERFILE-STATE-DIRS-END" \
+            "# DOCKERFILE-VOLUMES-START" \
+            "# DOCKERFILE-VOLUMES-END"; do
+            count=$(grep -cF "$marker" Dockerfile)
+            [ "$count" = "1" ] || { echo "::error::expected 1 '$marker' sentinel, found $count"; exit 1; }
+          done

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -113,6 +113,9 @@ jobs:
             "# DOCKERFILE-STATE-DIRS-END" \
             "# DOCKERFILE-VOLUMES-START" \
             "# DOCKERFILE-VOLUMES-END"; do
-            count=$(grep -cF "$marker" Dockerfile)
+            # `|| true` keeps bash -e from aborting at the command substitution when
+            # grep finds zero matches (exit 1), so the ::error:: line below fires instead
+            # of an opaque "exit 1" without context.
+            count=$(grep -cF "$marker" Dockerfile || true)
             [ "$count" = "1" ] || { echo "::error::expected 1 '$marker' sentinel, found $count"; exit 1; }
           done

--- a/Dockerfile.jinja
+++ b/Dockerfile.jinja
@@ -35,7 +35,9 @@ RUN if [ "$APP_UID" -eq 0 ] || [ "$APP_GID" -eq 0 ]; then \
     fi \
     && groupadd -r --gid $APP_GID --non-unique appuser \
     && useradd -r --uid $APP_UID --gid $APP_GID --no-log-init -d /app appuser \
+    # DOCKERFILE-STATE-DIRS-START — domain state subdirs; kept across copier update
     && mkdir -p /data/service /data/state/fastmcp \
+    # DOCKERFILE-STATE-DIRS-END
     && chown -R appuser:appuser /app /data
 
 COPY --chmod=0755 docker-entrypoint.sh /usr/local/bin/
@@ -44,7 +46,9 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 EXPOSE 8000
 
+# DOCKERFILE-VOLUMES-START — mounted volume list; kept across copier update
 VOLUME ["/data/service", "/data/state"]
+# DOCKERFILE-VOLUMES-END
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["{{ project_name }}", "serve", "--transport", "http", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Wrap `mkdir -p /data/service /data/state/fastmcp` in `DOCKERFILE-STATE-DIRS-START/END` sentinels (`chown` stays outside — still template-owned)
- Wrap `VOLUME ["/data/service", "/data/state"]` in `DOCKERFILE-VOLUMES-START/END` sentinels
- Add `template-ci` step asserting exactly one of each marker in the rendered Dockerfile
- Drive-by: the new assertion uses `grep -cF ... || true` so a missing sentinel produces a human-readable `::error::` instead of an opaque `bash -e` abort at the command substitution

## Test plan
- [x] `template-ci` smoke render produces `Dockerfile` with count=1 for each of the four markers
- [x] `chown -R appuser:appuser /app /data` remains outside the STATE-DIRS block
- [x] Local `bash -eo pipefail` repro of the `|| true` fix confirmed (missing-sentinel case now emits readable error before exit)
- [x] Two-stage internal review: spec-compliant + code quality APPROVED

Closes #30. Part of the v1.1.10 workstream — spec: `docs/superpowers/specs/2026-04-23-triaged-fixes-v1.1.10-design.md`.

Follow-up: the pre-existing `CLAUDE.md sentinel structure` step (from PR #27) has the same `grep -cE` pattern and same latent opaque-failure issue. Out of scope here; I'll file a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)