### PR TITLE
docs(claude-md): add 'Contributing fixes upstream' section (#37)

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -102,8 +102,8 @@ Fixes and improvements to shared code land in those repos and propagate here via
 
 ## Contributing fixes upstream
 
-- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml` (or wait for copier update).
-- **Template-level fix** (anything template-owned in this file — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
+- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
+- **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
 - **Domain-only fix** (anything inside `DOMAIN-START`/`DOMAIN-END` sentinels, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -100,6 +100,14 @@ Shared infrastructure (auth providers, middleware stack, logging bootstrap, even
 
 Fixes and improvements to shared code land in those repos and propagate here via `copier update` against the template's latest tag — run manually or via the weekly `.github/workflows/copier-update.yml` cron. Starter files listed in `_skip_if_exists` (e.g. `scripts/bump_manifests.py`, `packaging/mcpb/*`, the `tools.py` / `resources.py` / `prompts.py` / `domain.py` scaffolds, `README.md`, `CHANGELOG.md`, `LICENSE`, `.env.example`) are written once and require manual reconciliation on template updates — review `_skip_if_exists` in the template's `copier.yml` if you need to force-sync a file. Domain-specific code (tools, resources, prompts, and the fields and logic inside the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` and `CONFIG-FROM-ENV-START` / `CONFIG-FROM-ENV-END` sentinels) stays in this repo.
 
+## Contributing fixes upstream
+
+- **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml` (or wait for copier update).
+- **Template-level fix** (anything template-owned in this file — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
+- **Domain-only fix** (anything inside `DOMAIN-START`/`DOMAIN-END` sentinels, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+
+If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 
 ## Key Design Decisions


### PR DESCRIPTION
## Summary
- Append a `## Contributing fixes upstream` section to `CLAUDE.md.jinja`, inside the TEMPLATE-OWNED fences and outside any DOMAIN block
- Gives agents (and humans) reading a generated project's CLAUDE.md a clear signal of where to open PRs: `fastmcp-pvl-core` for library changes, `fastmcp-server-template` for template changes, consumer repo for domain-only changes
- Notes that copier-update conflict markers often indicate a template bug to investigate upstream

## Test plan
- [x] Rendered `CLAUDE.md` contains the new section
- [x] Existing `template-ci` sentinel assertion (3× `DOMAIN-START`, 3× `DOMAIN-END`) still passes
- [x] Only `CLAUDE.md.jinja` modified

Closes #37. Part of the v1.1.10 workstream — spec: `docs/superpowers/specs/2026-04-23-triaged-fixes-v1.1.10-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)