### PR TITLE
fix(release): upsert marketplace.json when plugin is absent (#38)

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -347,11 +347,30 @@ jobs:
           VERSION: {% raw %}${{ needs.release.outputs.version }}{% endraw %}
         run: |
           cd catalog
-          jq --arg v "$VERSION" --arg ref "v$VERSION" '
-            .plugins |= map(
-              if .name == "{{ project_name }}"
-              then .version = $v | .source.ref = $ref
-              else . end
+          NEW_ENTRY=$(jq -n \
+            --arg name    "{{ project_name }}" \
+            --arg url     "https://github.com/{{ github_org }}/{{ project_name }}.git" \
+            --arg ref     "v$VERSION" \
+            --arg version "$VERSION" \
+            '{
+              name: $name,
+              source: {
+                source: "git-subdir",
+                url: $url,
+                path: ".claude-plugin/plugin",
+                ref: $ref
+              },
+              version: $version
+            }')
+          jq --arg name "{{ project_name }}" \
+             --arg v    "$VERSION" \
+             --arg ref  "v$VERSION" \
+             --argjson new "$NEW_ENTRY" '
+            .plugins |= (
+              if any(.[]; .name == $name)
+              then map(if .name == $name then .version = $v | .source.ref = $ref else . end)
+              else . + [$new]
+              end
             )
           ' marketplace.json > marketplace.json.tmp
           mv marketplace.json.tmp marketplace.json

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -123,9 +123,7 @@ jobs:
       - name: release.yml marketplace upsert
         working-directory: /tmp/smoke
         run: |
-          # PR 4 of v1.1.10 replaces the jq map-only update with an
-          # upsert that appends a new git-subdir entry when the plugin
-          # is absent. The rendered workflow must carry both markers.
+          # Regression guard: upsert block must survive template renders.
           grep -qF '"git-subdir"' .github/workflows/release.yml \
             || { echo "::error::release.yml missing git-subdir marker — upsert regressed"; exit 1; }
           grep -qF '".claude-plugin/plugin"' .github/workflows/release.yml \

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -119,3 +119,16 @@ jobs:
             count=$(grep -cF "$marker" Dockerfile || true)
             [ "$count" = "1" ] || { echo "::error::expected 1 '$marker' sentinel, found $count"; exit 1; }
           done
+
+      - name: release.yml marketplace upsert
+        working-directory: /tmp/smoke
+        run: |
+          # PR 4 of v1.1.10 replaces the jq map-only update with an
+          # upsert that appends a new git-subdir entry when the plugin
+          # is absent. The rendered workflow must carry both markers.
+          grep -qF '"git-subdir"' .github/workflows/release.yml \
+            || { echo "::error::release.yml missing git-subdir marker — upsert regressed"; exit 1; }
+          grep -qF '".claude-plugin/plugin"' .github/workflows/release.yml \
+            || { echo "::error::release.yml missing .claude-plugin/plugin path — upsert regressed"; exit 1; }
+          grep -qF 'any(.[]; .name == $name)' .github/workflows/release.yml \
+            || { echo "::error::release.yml missing upsert branch — still silently no-ops on missing entry"; exit 1; }


### PR DESCRIPTION
## Summary
- Replace the map-only `jq` in the `publish-claude-plugin-pr` step with an upsert: if the entry exists, update `version` + `source.ref` in place (identical behaviour to today); otherwise append a prospective entry whose `source.*` shape matches the live `markdown-vault-mcp` entry (`git-subdir`, `path=.claude-plugin/plugin`, `url=https://github.com/{github_org}/{project_name}.git`)
- Add template-ci assertion that the rendered `release.yml` carries the `"git-subdir"` and `".claude-plugin/plugin"` literals plus the `any(.[]; .name == $name)` upsert branch

First-time plugin publication (e.g. `scholar-mcp`, `image-generation-mcp` today) is currently broken as a silent no-op; this closes that gap.

## Test plan
- [x] jq fixture: empty catalog → new entry appended with full git-subdir shape
- [x] jq fixture: plugin already present → version + source.ref bumped in place, other fields preserved
- [x] jq fixture: other entries only → existing entries untouched, new entry appended
- [x] Smoke render: jinja-free upsert YAML present, all three CI grep assertions pass
- [x] Two-stage internal review: spec-compliant + code quality APPROVED
- [ ] Actual v1.1.10 dispatch will exercise the append path end-to-end against the real catalog (template itself isn't in `pvliesdonk/claude-plugins`, so the release will drive a real append + catalog PR)

Closes #38. Last implementation PR of the v1.1.10 workstream. Spec: `docs/superpowers/specs/2026-04-23-triaged-fixes-v1.1.10-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)