### PR TITLE
fix(ci): surface CLAUDE.md sentinel count errors under bash -e (#43)

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -72,8 +72,11 @@ jobs:
           # Line-anchored regexes so prose mentions don't satisfy the check.
           # Count assertions so a dropped inner DOMAIN-START/END pair fails
           # loudly — copier's 3-way merge needs all fences intact.
-          start=$(grep -cE '^<!-- DOMAIN-START -->$' CLAUDE.md)
-          end=$(grep -cE '^<!-- DOMAIN-END -->$' CLAUDE.md)
+          # `|| true` keeps bash -e from aborting at the command substitution when
+          # grep finds zero matches (exit 1), so the ::error:: lines below fire
+          # instead of an opaque "exit 1" without context.
+          start=$(grep -cE '^<!-- DOMAIN-START -->$' CLAUDE.md || true)
+          end=$(grep -cE '^<!-- DOMAIN-END -->$' CLAUDE.md || true)
           [ "$start" = "3" ] || { echo "::error::expected 3 DOMAIN-START fences, found $start"; exit 1; }
           [ "$end" = "3" ] || { echo "::error::expected 3 DOMAIN-END fences, found $end"; exit 1; }
           grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS BELOW' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED opening fence"; exit 1; }


### PR DESCRIPTION
## Summary
- `grep -c` exits 1 on zero matches; under GitHub Actions' default `bash -eo pipefail`, the existing `start=$(grep -cE ...)` lines in the `CLAUDE.md sentinel structure` step aborted at the command substitution, leaving CI with a bare `exit 1` instead of the intended `::error::expected 3 DOMAIN-START fences, found 0`.
- Appends `|| true` to both `grep -cE` invocations so the follow-on `[ "$start" = "3" ] || { echo ::error::...; exit 1; }` branches can fire with actual counts. Mirrors the pattern already used by the sibling Dockerfile sentinel step added in #42.
- No semantic change when sentinels are present; CI still fails on structural drift — just readably.

Closes #43.

## Test plan
- [x] Reproduced original bug locally: `bash -eo pipefail -c 'x=$(grep -cE X /dev/null); echo $x'` exits 1 with no output.
- [x] Verified fix: `x=$(grep -cE X /dev/null || true)` sets `x=0` and allows the subsequent `::error::` branch to run.
- [ ] CI green on template-ci matrix (Python 3.11–3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)