### PR TITLE
Scaffold coverage + README post-setup (closes #50, #51)

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run mypy
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
   test:
     name: Test (Python {% raw %}${{ matrix.python-version }}{% endraw %})

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: mypy
         working-directory: /tmp/smoke
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
       - name: pytest
         working-directory: /tmp/smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,18 +28,24 @@ create new projects.
 ## Making changes
 
 1. Edit the relevant `.jinja` file(s).
-2. Render locally and verify the gate passes:
+2. Commit (copier reads from the git index — uncommitted changes are
+   silently ignored without `--vcs-ref=HEAD`).
+3. Render locally and verify the gate passes:
    ```bash
    rm -rf /tmp/smoke
    uv run --no-project --with copier copier copy --trust --defaults \
-     --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+     --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
    cd /tmp/smoke
    uv sync --all-extras --dev
    uv run ruff check . && uv run ruff format --check .
-   uv run mypy src/ && uv run pytest -x -q
+   uv run mypy src/ tests/ && uv run pytest -x -q
    ```
-3. Commit, push, open a PR.
-4. `template-ci.yml` runs the same gate on Python 3.11–3.14.
+   `--vcs-ref=HEAD` tells copier to use the latest commit instead of the
+   latest git tag (the default).  Without it, your edits render only
+   after a release.  If you need to iterate, amend the commit or make
+   follow-up commits — rendering from the working tree is not supported.
+4. Commit any fixes, push, open a PR.
+5. `template-ci.yml` runs the same gate on Python 3.11–3.14.
 
 ## Release
 

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -21,7 +21,7 @@ After `copier copy` and `gh repo create --push`:
 
 1. Configure GitHub secrets (see below).
 2. Install dev dependencies: `uv sync --all-extras --dev`.
-3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/`.
+3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/ tests/`.
 4. Push the first commit — CI should be green.
 
 ## GitHub secrets
@@ -50,7 +50,7 @@ The PR gate (matches CI):
 ```bash
 uv run pytest -x -q                                  # tests
 uv run ruff check --fix . && uv run ruff format .    # lint + format
-uv run mypy src/                                     # type-check
+uv run mypy src/ tests/                              # type-check
 ```
 
 See [`CLAUDE.md`](CLAUDE.md) for the full PR acceptance gates.

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -31,8 +31,8 @@ CI workflows reference three repository secrets. Configure them via
 
 | Secret | Used by | How to generate |
 |---|---|---|
-| `RELEASE_TOKEN` | `release.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` (and `pull_requests: write` if release PRs are enabled). Scoped to this repo. |
-| `CODECOV_TOKEN` | `ci.yml`, `coverage-status.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
 
 ```bash

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -15,6 +15,46 @@ pip install {{ pypi_name }}
 All configuration goes via `{{ env_prefix }}_*` env vars.  See
 [docs/configuration.md](docs/configuration.md).
 
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. Configure GitHub secrets (see below).
+2. Install dev dependencies: `uv sync --all-extras --dev`.
+3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/`.
+4. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via
+**Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` (and `pull_requests: write` if release PRs are enabled). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml`, `coverage-status.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/                                     # type-check
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for the full PR acceptance gates.
+
 ## Links
 
 - [Documentation](https://{{ github_org }}.github.io/{{ project_name }}/)

--- a/copier.yml
+++ b/copier.yml
@@ -31,6 +31,7 @@ _skip_if_exists:
   - "src/{{python_module}}/domain.py"
   - "tests/conftest.py"
   - "tests/test_smoke.py"
+  - "tests/test_cli.py"
   - "README.md"
   - "CHANGELOG.md"
   - "LICENSE"

--- a/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
+++ b/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
@@ -74,98 +74,9 @@ Record the baseline coverage % and which lines are uncovered (look for `cli.py`,
 
 ---
 
-## Task 1: Add resource + prompt tests to `tests/test_tools.py.jinja`
+## Task 1+2 (merged): Extend `tests/test_smoke.py.jinja` with all new test coverage
 
-**Files:**
-- Modify: `tests/test_tools.py.jinja`
-
-- [ ] **Step 1: Read the current file**
-
-```bash
-cat /mnt/code/fastmcp-server-template/tests/test_tools.py.jinja
-```
-
-Confirm it currently contains only `test_ping_returns_pong` and the `from fastmcp import Client` import.
-
-- [ ] **Step 2: Replace with extended version**
-
-Overwrite `/mnt/code/fastmcp-server-template/tests/test_tools.py.jinja` with:
-
-```jinja
-"""Golden-path smoke tests for the example tool, resource, and prompt."""
-
-from __future__ import annotations
-
-from fastmcp import Client
-
-
-async def test_ping_returns_pong(client: Client) -> None:
-    """The example ``ping`` tool round-trips cleanly through the MCP client."""
-    result = await client.call_tool("ping", {})
-    assert result.content[0].text == "pong"
-
-
-async def test_status_resource_reports_ready(client: Client) -> None:
-    """The example ``status://`` resource returns the running service's state."""
-    result = await client.read_resource("status://{{ project_name }}")
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    assert "ready" in text
-
-
-async def test_summarize_prompt_includes_context(client: Client) -> None:
-    """The example ``summarize`` prompt round-trips its ``context`` argument."""
-    result = await client.get_prompt("summarize", {"context": "hello world"})
-    assert "hello world" in result.messages[0].content.text
-```
-
-- [ ] **Step 3: Render + run only the new tests**
-
-```bash
-cd /mnt/code/fastmcp-server-template
-rm -rf /tmp/smoke
-uv run --no-project --with copier copier copy --trust --defaults \
-  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
-cd /tmp/smoke
-uv sync --all-extras --dev
-uv run pytest tests/test_tools.py -v
-```
-
-Expected: 3 tests pass (`test_ping_returns_pong`, `test_status_resource_reports_ready`, `test_summarize_prompt_includes_context`).
-
-If `test_status_resource_reports_ready` fails with an attribute error on `result[0]`, the FastMCP client API may have shifted — check `Client.read_resource`'s actual return type via `python -c "from fastmcp import Client; help(Client.read_resource)"` and adjust the access pattern. The `hasattr(...)` guard is defensive against future API minor shifts.
-
-- [ ] **Step 4: Run full gate to confirm coverage moved up**
-
-```bash
-cd /tmp/smoke
-uv run pytest --cov=src/smoke_mcp --cov-report=term 2>&1 | tail -15
-```
-
-Expected: total coverage > Task 0 baseline (gain from `resources.py` and `prompts.py` handler bodies + `domain.py:status`). Likely still under 80% — that's fine, more tests come in subsequent tasks.
-
-- [ ] **Step 5: Commit**
-
-```bash
-cd /mnt/code/fastmcp-server-template
-git add tests/test_tools.py.jinja
-git commit -m "$(cat <<'EOF'
-feat(scaffold-tests): cover example status resource and summarize prompt
-
-Pristine scaffolds had only `test_ping_returns_pong`, leaving the
-`status://` resource handler and `summarize` prompt handler uncovered.
-Add round-trip tests via the existing in-memory Client fixture so a
-greenfield scaffold exercises every shipped MCP primitive.
-
-Refs #50
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-EOF
-)"
-```
-
----
-
-## Task 2: Add `register_apps` env-var branch test to `tests/test_smoke.py.jinja`
+**Plan revision (2026-04-23):** Original Task 1 targeted `tests/test_tools.py.jinja`, but that file is in `copier.yml`'s `_exclude` block (not `_skip_if_exists`), so it never renders into greenfield scaffolds. Folding the resource + prompt tests into `tests/test_smoke.py.jinja` (which IS in `_skip_if_exists`) lands them where issue #50 needs them, without touching `_exclude`'s deliberate "downstream brings their own" semantics.
 
 **Files:**
 - Modify: `tests/test_smoke.py.jinja`
@@ -188,6 +99,7 @@ Overwrite `/mnt/code/fastmcp-server-template/tests/test_smoke.py.jinja` with:
 from __future__ import annotations
 
 import pytest
+from fastmcp import Client
 
 from {{ python_module }}._server_apps import register_apps
 from {{ python_module }}.server import make_server
@@ -215,13 +127,27 @@ def test_register_apps_logs_when_app_domain_set(
         # in the scaffold's no-op branch.
         register_apps(None)  # type: ignore[arg-type]
     assert any("example.com" in r.message for r in caplog.records)
+
+
+async def test_status_resource_reports_ready(client: Client) -> None:
+    """The example ``status://`` resource returns the running service's state."""
+    result = await client.read_resource("status://{{ project_name }}")
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    assert "ready" in text
+
+
+async def test_summarize_prompt_includes_context(client: Client) -> None:
+    """The example ``summarize`` prompt round-trips its ``context`` argument."""
+    result = await client.get_prompt("summarize", {"context": "hello world"})
+    assert "hello world" in result.messages[0].content.text
 ```
 
-Note: the `# type: ignore[arg-type]` is needed because `register_apps` is typed
-to take a `FastMCP`, but the scaffold body never dereferences it — it's
-the simplest way to test the env-var branch without spinning up a server.
+Notes:
+- The `client` fixture comes from `tests/conftest.py.jinja` (also in `_skip_if_exists`, also rendered into greenfield scaffolds). It wraps `make_server()` in an in-memory FastMCP `Client`.
+- The `# type: ignore[arg-type]` is needed because `register_apps` is typed to take a `FastMCP`, but the scaffold body never dereferences it — simplest way to test the env-var branch without spinning up a server.
+- `tests/test_tools.py.jinja` is **deliberately not modified** — it's in `_exclude` so changes there never reach scaffolds.
 
-- [ ] **Step 3: Render and run the new test**
+- [ ] **Step 3: Render and run the new tests**
 
 ```bash
 cd /mnt/code/fastmcp-server-template
@@ -233,17 +159,19 @@ uv sync --all-extras --dev
 uv run pytest tests/test_smoke.py -v
 ```
 
-Expected: 2 tests pass.
+Expected: 4 tests pass (`test_make_server_constructs`, `test_register_apps_logs_when_app_domain_set`, `test_status_resource_reports_ready`, `test_summarize_prompt_includes_context`).
 
-- [ ] **Step 4: Run mypy on the rendered project**
+If `test_status_resource_reports_ready` fails with an attribute error on `result[0]`, the FastMCP client API may have shifted — inspect with `python -c "from fastmcp import Client; help(Client.read_resource)"` and adjust the access pattern. The `hasattr(...)` guard is defensive against minor API shifts.
+
+- [ ] **Step 4: Run mypy + coverage check**
 
 ```bash
 cd /tmp/smoke
 uv run mypy src/ tests/
+uv run pytest --cov=src/smoke_mcp --cov-report=term 2>&1 | tail -15
 ```
 
-Expected: no errors. (The `# type: ignore[arg-type]` should silence the
-intentional misuse of `register_apps`.)
+Expected: mypy clean (the `# type: ignore[arg-type]` silences the intentional misuse). Coverage > Task 0 baseline (gain from `resources.py`, `prompts.py`, `domain.py:status`, and `_server_apps.py` if-branch). Likely still under 80% — Task 3 (CLI tests) closes the remaining gap.
 
 - [ ] **Step 5: Commit**
 
@@ -251,12 +179,18 @@ intentional misuse of `register_apps`.)
 cd /mnt/code/fastmcp-server-template
 git add tests/test_smoke.py.jinja
 git commit -m "$(cat <<'EOF'
-feat(scaffold-tests): cover register_apps env-var branch
+feat(scaffold-tests): cover register_apps branch + status resource + summarize prompt
 
-The default smoke test only exercises the inactive branch of
-register_apps. Add a test that sets {ENV_PREFIX}_APP_DOMAIN and
-asserts the info log fires, covering the if-branch that downstream
-projects always hit once they wire MCP Apps.
+The pristine scaffold's smoke test only exercised make_server() and
+register_apps's inactive branch; the status resource handler, summarize
+prompt handler, and register_apps's env-var branch were all uncovered,
+contributing to the 59% coverage that fails the project's own
+--fail-under=80 gate. Add three round-trip tests via the existing
+in-memory Client fixture (already shipped in conftest.py.jinja).
+
+Folded into test_smoke.py.jinja rather than test_tools.py.jinja
+because the latter is in copier.yml's _exclude block and never
+renders into greenfield scaffolds.
 
 Refs #50
 

--- a/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
+++ b/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
@@ -1,0 +1,557 @@
+# Scaffold Coverage + README Post-Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a pristine scaffold pass its own 80% coverage gate (issue #50) and add a README post-setup section documenting required GitHub secrets (issue #51).
+
+**Architecture:** Five small template-file edits + one `copier.yml` entry. No new abstractions. Validated by rendering `tests/fixtures/smoke-answers.yml` into `/tmp/smoke` after each change and running the generated project's gate (`uv sync` → `pytest` → `ruff` → `mypy`).
+
+**Tech Stack:** copier (template rendering), pytest with `--cov`, `typer.testing.CliRunner`, FastMCP `Client` for in-memory resource/prompt round-trips.
+
+**Spec:** [`docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md`](../specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md)
+
+---
+
+## File Structure
+
+| File | Change | Why |
+|---|---|---|
+| `tests/test_tools.py.jinja` | extend (+2 tests) | Cover `status` resource + `summarize` prompt handlers |
+| `tests/test_smoke.py.jinja` | extend (+1 test) | Cover `_server_apps.register_apps` env-var branch |
+| `tests/test_cli.py.jinja` | **create** | Cover `cli.py` (~26% of codebase, currently 0% covered) |
+| `copier.yml` | edit (+1 entry in `_skip_if_exists`) | Preserve downstream `test_cli.py` if present |
+| `README.md.jinja` | extend (+3 sections) | Post-scaffold checklist, GitHub secrets table, local dev gate |
+
+No new files in `src/`. No changes to existing source jinja templates. No changes to `pyproject.toml.jinja`.
+
+---
+
+## Conventions for the implementer
+
+- This is a **template repo**. Files ending in `.jinja` are rendered by copier into a generated project. Variables like `{{ python_module }}` are substituted at render time using `tests/fixtures/smoke-answers.yml`.
+- The validation loop is: edit `.jinja` → re-render to `/tmp/smoke` → `cd /tmp/smoke` → run the generated project's gate. Never run `pytest` from the template repo root — the template repo has no Python project of its own.
+- Each task ends with a commit using conventional commit format. Use `feat(scaffold-tests):` for test additions, `feat(readme):` for README changes, `chore(copier):` for `copier.yml`. Sign with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`.
+- The full render+gate command (used in many tasks) is wrapped in a helper alias for brevity in this doc — substitute the actual commands when running.
+
+**Render+gate one-liner (referenced as RENDER_GATE in this plan):**
+
+```bash
+rm -rf /tmp/smoke && \
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke && \
+cd /tmp/smoke && \
+uv sync --all-extras --dev && \
+uv run ruff check . && uv run ruff format --check . && \
+uv run mypy src/ && \
+uv run pytest -x -q
+```
+
+---
+
+## Task 0: Baseline render + record coverage
+
+**Files:** none (read-only sanity check)
+
+**Why:** Capture the starting coverage number so subsequent tasks can confirm forward motion.
+
+- [ ] **Step 1: Render and run gate, capture coverage**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run pytest --cov=src/smoke_mcp --cov-report=term-missing 2>&1 | tail -40
+```
+
+Expected: tests pass, coverage report shows total ~59% (or close), `FAIL Required test coverage of 80.0% not reached.`
+
+- [ ] **Step 2: Note baseline**
+
+Record the baseline coverage % and which lines are uncovered (look for `cli.py`, `_server_apps.py`, `domain.py:status`, `resources.py`, `prompts.py` in the missing-lines report). No commit — this is informational.
+
+---
+
+## Task 1: Add resource + prompt tests to `tests/test_tools.py.jinja`
+
+**Files:**
+- Modify: `tests/test_tools.py.jinja`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat /mnt/code/fastmcp-server-template/tests/test_tools.py.jinja
+```
+
+Confirm it currently contains only `test_ping_returns_pong` and the `from fastmcp import Client` import.
+
+- [ ] **Step 2: Replace with extended version**
+
+Overwrite `/mnt/code/fastmcp-server-template/tests/test_tools.py.jinja` with:
+
+```jinja
+"""Golden-path smoke tests for the example tool, resource, and prompt."""
+
+from __future__ import annotations
+
+from fastmcp import Client
+
+
+async def test_ping_returns_pong(client: Client) -> None:
+    """The example ``ping`` tool round-trips cleanly through the MCP client."""
+    result = await client.call_tool("ping", {})
+    assert result.content[0].text == "pong"
+
+
+async def test_status_resource_reports_ready(client: Client) -> None:
+    """The example ``status://`` resource returns the running service's state."""
+    result = await client.read_resource("status://{{ project_name }}")
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    assert "ready" in text
+
+
+async def test_summarize_prompt_includes_context(client: Client) -> None:
+    """The example ``summarize`` prompt round-trips its ``context`` argument."""
+    result = await client.get_prompt("summarize", {"context": "hello world"})
+    assert "hello world" in result.messages[0].content.text
+```
+
+- [ ] **Step 3: Render + run only the new tests**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run pytest tests/test_tools.py -v
+```
+
+Expected: 3 tests pass (`test_ping_returns_pong`, `test_status_resource_reports_ready`, `test_summarize_prompt_includes_context`).
+
+If `test_status_resource_reports_ready` fails with an attribute error on `result[0]`, the FastMCP client API may have shifted — check `Client.read_resource`'s actual return type via `python -c "from fastmcp import Client; help(Client.read_resource)"` and adjust the access pattern. The `hasattr(...)` guard is defensive against future API minor shifts.
+
+- [ ] **Step 4: Run full gate to confirm coverage moved up**
+
+```bash
+cd /tmp/smoke
+uv run pytest --cov=src/smoke_mcp --cov-report=term 2>&1 | tail -15
+```
+
+Expected: total coverage > Task 0 baseline (gain from `resources.py` and `prompts.py` handler bodies + `domain.py:status`). Likely still under 80% — that's fine, more tests come in subsequent tasks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+git add tests/test_tools.py.jinja
+git commit -m "$(cat <<'EOF'
+feat(scaffold-tests): cover example status resource and summarize prompt
+
+Pristine scaffolds had only `test_ping_returns_pong`, leaving the
+`status://` resource handler and `summarize` prompt handler uncovered.
+Add round-trip tests via the existing in-memory Client fixture so a
+greenfield scaffold exercises every shipped MCP primitive.
+
+Refs #50
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `register_apps` env-var branch test to `tests/test_smoke.py.jinja`
+
+**Files:**
+- Modify: `tests/test_smoke.py.jinja`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat /mnt/code/fastmcp-server-template/tests/test_smoke.py.jinja
+```
+
+Confirm it currently has just `test_make_server_constructs` and imports only `make_server`.
+
+- [ ] **Step 2: Replace with extended version**
+
+Overwrite `/mnt/code/fastmcp-server-template/tests/test_smoke.py.jinja` with:
+
+```jinja
+"""Smoke tests for {{ human_name }}."""
+
+from __future__ import annotations
+
+import pytest
+
+from {{ python_module }}._server_apps import register_apps
+from {{ python_module }}.server import make_server
+
+
+def test_make_server_constructs() -> None:
+    """make_server() returns a FastMCP instance without raising."""
+    server = make_server()
+    assert server is not None
+
+
+def test_register_apps_logs_when_app_domain_set(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """register_apps logs the configured app domain when the env var is set.
+
+    Covers the ``if app_domain:`` branch of ``_server_apps.register_apps``,
+    which the default smoke tests miss because no ``{{ env_prefix }}_APP_DOMAIN``
+    is set in the test env.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
+    with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
+        # Pass None for the FastMCP instance — register_apps doesn't touch it
+        # in the scaffold's no-op branch.
+        register_apps(None)  # type: ignore[arg-type]
+    assert any("example.com" in r.message for r in caplog.records)
+```
+
+Note: the `# type: ignore[arg-type]` is needed because `register_apps` is typed
+to take a `FastMCP`, but the scaffold body never dereferences it — it's
+the simplest way to test the env-var branch without spinning up a server.
+
+- [ ] **Step 3: Render and run the new test**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run pytest tests/test_smoke.py -v
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Run mypy on the rendered project**
+
+```bash
+cd /tmp/smoke
+uv run mypy src/ tests/
+```
+
+Expected: no errors. (The `# type: ignore[arg-type]` should silence the
+intentional misuse of `register_apps`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+git add tests/test_smoke.py.jinja
+git commit -m "$(cat <<'EOF'
+feat(scaffold-tests): cover register_apps env-var branch
+
+The default smoke test only exercises the inactive branch of
+register_apps. Add a test that sets {ENV_PREFIX}_APP_DOMAIN and
+asserts the info log fires, covering the if-branch that downstream
+projects always hit once they wire MCP Apps.
+
+Refs #50
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Create `tests/test_cli.py.jinja` and update `copier.yml`
+
+**Files:**
+- Create: `tests/test_cli.py.jinja`
+- Modify: `copier.yml` (`_skip_if_exists` block)
+
+- [ ] **Step 1: Create the new test file**
+
+Write `/mnt/code/fastmcp-server-template/tests/test_cli.py.jinja`:
+
+```jinja
+"""CLI tests for {{ human_name }}.
+
+Borrowed from scholar-mcp's ``test_cli.py`` typer pattern. ``--help``
+exits via typer before any command body runs, so these tests don't
+import ``server.py`` or start uvicorn — keeping them fast and free
+of side effects.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from {{ python_module }}.cli import app
+
+
+def test_help_exits_zero() -> None:
+    """`{{ project_name }} --help` lists the serve command."""
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_serve_help_exits_zero() -> None:
+    """`{{ project_name }} serve --help` documents the transport flag."""
+    result = CliRunner().invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "stdio" in result.output
+
+
+def test_no_args_shows_help() -> None:
+    """Bare invocation exits 0 with help text via ``no_args_is_help=True``."""
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+```
+
+- [ ] **Step 2: Add `tests/test_cli.py` to `copier.yml`'s `_skip_if_exists`**
+
+Open `/mnt/code/fastmcp-server-template/copier.yml` and locate the `_skip_if_exists` block (starts at line 27). Insert `tests/test_cli.py` directly after `tests/test_smoke.py`, so the relevant lines read:
+
+```yaml
+  - "tests/conftest.py"
+  - "tests/test_smoke.py"
+  - "tests/test_cli.py"
+  - "README.md"
+```
+
+This protects downstream projects (scholar-mcp, image-gen-mcp, markdown-vault-mcp) from having their existing `test_cli.py` overwritten by `copier update`.
+
+- [ ] **Step 3: Render and run the new tests**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run pytest tests/test_cli.py -v
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 4: Run the full gate and verify coverage clears 80%**
+
+```bash
+cd /tmp/smoke
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/ tests/
+uv run pytest -x -q
+```
+
+Expected: all four commands succeed. The pytest line should NOT show `FAIL Required test coverage of 80.0% not reached`. If it does, capture the `--cov-report=term-missing` output and inspect which lines remain uncovered — most likely candidates are CLI option-default fallbacks (`--http-path` env fallback) or the `transport != "stdio"` branch in `server.py`. If a small additional test would close the gap, add it under Task 1 or Task 3 rather than introducing a new task; otherwise, lower-priority uncovered lines can be left for downstream tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+git add tests/test_cli.py.jinja copier.yml
+git commit -m "$(cat <<'EOF'
+feat(scaffold-tests): add CLI smoke tests so pristine scaffold clears 80% coverage
+
+cli.py was ~26% of the rendered codebase and 0% covered, so a fresh
+copier copy + uv run pytest failed the project's own --fail-under=80
+gate. Add three CliRunner tests (--help, serve --help, bare invocation)
+borrowed from scholar-mcp's typer pattern, and protect existing
+downstream test_cli.py files via _skip_if_exists.
+
+Closes #50
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Extend `README.md.jinja` with post-scaffold sections
+
+**Files:**
+- Modify: `README.md.jinja`
+
+- [ ] **Step 1: Read the current README**
+
+```bash
+cat /mnt/code/fastmcp-server-template/README.md.jinja
+```
+
+Confirm it has `# {{ human_name }}`, `## Quick start`, `## Configuration`, `## Links` (in that order).
+
+- [ ] **Step 2: Replace with the extended version**
+
+Overwrite `/mnt/code/fastmcp-server-template/README.md.jinja` with:
+
+```jinja
+# {{ human_name }}
+
+{{ domain_description }}
+
+## Quick start
+
+```bash
+pip install {{ pypi_name }}
+{{ project_name }} serve                                # stdio
+{{ project_name }} serve --transport http --port 8000   # HTTP
+```
+
+## Configuration
+
+All configuration goes via `{{ env_prefix }}_*` env vars.  See
+[docs/configuration.md](docs/configuration.md).
+
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. Configure GitHub secrets (see below).
+2. Install dev dependencies: `uv sync --all-extras --dev`.
+3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/`.
+4. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via
+**Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` (and `pull_requests: write` if release PRs are enabled). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml`, `coverage-status.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/                                     # type-check
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for the full PR acceptance gates.
+
+## Links
+
+- [Documentation](https://{{ github_org }}.github.io/{{ project_name }}/)
+- [FastMCP](https://gofastmcp.com)
+- [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
+```
+
+Note: keep the `{{ project_name }}`, `{{ env_prefix }}`, `{{ github_org }}` jinja
+substitutions exactly as written — copier will fill them in at render time.
+
+- [ ] **Step 3: Render and verify content**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cat /tmp/smoke/README.md
+```
+
+Expected output verifies:
+- `## Post-scaffold checklist`, `## GitHub secrets`, `## Local development` sections present
+- `{{ … }}` placeholders are all rendered (no literal `{{` in output)
+- Secret table shows `RELEASE_TOKEN`, `CODECOV_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`
+- `gh secret set` snippet shows three commands
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+git add README.md.jinja
+git commit -m "$(cat <<'EOF'
+feat(readme): add post-scaffold checklist, GitHub secrets table, local dev gate
+
+A fresh copier copy + gh repo create --push leaves CI failing until
+three secrets are set, but the rendered README didn't mention any of
+them. Add a post-scaffold checklist, a secrets table with one-line
+generation steps and a gh secret set snippet, and the local PR gate
+commands so new downstream maintainers don't have to grep workflow
+files.
+
+Closes #51
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Final end-to-end validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Re-render and run the full gate**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/ tests/
+uv run pytest -x -q
+```
+
+Expected: every command exits 0. Pytest output should show 8 tests passing (was 2) and NO `FAIL Required test coverage` line.
+
+- [ ] **Step 2: Verify coverage is comfortably above the threshold**
+
+```bash
+cd /tmp/smoke
+uv run pytest --cov=src/smoke_mcp --cov-report=term 2>&1 | tail -5
+```
+
+Expected: total ≥ 85% (per spec's design target). If between 80-85%, that's still passing — the spec calls out 85% as a comfort margin, not a hard requirement.
+
+- [ ] **Step 3: Spot-check the rendered README**
+
+```bash
+grep -E "^##|RELEASE_TOKEN|CODECOV_TOKEN|CLAUDE_CODE_OAUTH_TOKEN" /tmp/smoke/README.md
+```
+
+Expected: shows all three secrets and the new section headings (`## Post-scaffold checklist`, `## GitHub secrets`, `## Local development`).
+
+- [ ] **Step 4: Push the branch (no PR yet — let user decide)**
+
+```bash
+cd /mnt/code/fastmcp-server-template
+git log --oneline -5
+git push origin HEAD
+```
+
+Stop here. Do NOT open a PR or trigger a release — both are user decisions per project conventions (see memory: release dispatch is manual). Surface the branch name and let the user open the PR themselves with `gh pr create` or via the `/commit-push-pr` skill.
+
+---
+
+## Self-review checklist (already completed by plan author)
+
+- ✅ Spec coverage: every spec section maps to a task (Task 1 → tests §2, Task 2 → tests §3, Task 3 → tests §1 + copier §1, Task 4 → README §4, Task 5 → spec's Validation section).
+- ✅ No placeholders: every code block is complete; no "TODO", "TBD", "implement later".
+- ✅ Type consistency: `register_apps`, `make_server`, `app`, `Client.read_resource`, `Client.get_prompt` signatures match between tasks and the actual scaffold source files.
+- ✅ Render+gate command repeated in each task (intentional — the "DRY" rule yields to "engineer may read tasks out of order" when the command is the validation gate).

--- a/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
+++ b/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
@@ -16,13 +16,15 @@
 
 | File | Change | Why |
 |---|---|---|
-| `tests/test_tools.py.jinja` | extend (+2 tests) | Cover `status` resource + `summarize` prompt handlers |
-| `tests/test_smoke.py.jinja` | extend (+1 test) | Cover `_server_apps.register_apps` env-var branch |
+| `tests/test_smoke.py.jinja` | extend (+3 tests) | `register_apps` env-var branch, `status` resource, `summarize` prompt |
 | `tests/test_cli.py.jinja` | **create** | Cover `cli.py` (~26% of codebase, currently 0% covered) |
+| `tests/conftest.py.jinja` | edit | `Client[Any]` annotation so strict mypy on `tests/` passes |
 | `copier.yml` | edit (+1 entry in `_skip_if_exists`) | Preserve downstream `test_cli.py` if present |
+| `pyproject.toml.jinja` | edit (+1 ruff per-file ignore) | Silence TC002 on the new annotation-only imports in `tests/test_smoke.py` |
 | `README.md.jinja` | extend (+3 sections) | Post-scaffold checklist, GitHub secrets table, local dev gate |
+| `CLAUDE.md` | edit | Document `--vcs-ref=HEAD` for local iteration (template-maintainer gate) |
 
-No new files in `src/`. No changes to existing source jinja templates. No changes to `pyproject.toml.jinja`.
+No new files in `src/`.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
+++ b/docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md
@@ -125,28 +125,31 @@ def test_register_apps_logs_when_app_domain_set(
     """
     monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
     with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
-        # Pass None for the FastMCP instance — register_apps doesn't touch it
-        # in the scaffold's no-op branch.
-        register_apps(None)  # type: ignore[arg-type]
+        # Pass a real FastMCP instance — register_apps currently doesn't
+        # touch it in the scaffold's no-op branch, but downstream edits may.
+        register_apps(make_server())
     assert any("example.com" in r.message for r in caplog.records)
 
 
-async def test_status_resource_reports_ready(client: Client) -> None:
-    """The example ``status://`` resource returns the running service's state."""
+async def test_status_resource_reports_ready(client: Client[Any]) -> None:
+    """The example ``status://`` resource reports a started service."""
     result = await client.read_resource("status://{{ project_name }}")
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    assert "ready" in text
+    first = result[0]
+    assert hasattr(first, "text"), f"expected text resource content, got {type(first).__name__}"
+    assert json.loads(first.text) == {"ready": True}
 
 
-async def test_summarize_prompt_includes_context(client: Client) -> None:
+async def test_summarize_prompt_includes_context(client: Client[Any]) -> None:
     """The example ``summarize`` prompt round-trips its ``context`` argument."""
     result = await client.get_prompt("summarize", {"context": "hello world"})
-    assert "hello world" in result.messages[0].content.text
+    content = result.messages[0].content
+    assert hasattr(content, "text"), f"expected text prompt content, got {type(content).__name__}"
+    assert "hello world" in content.text
 ```
 
 Notes:
-- The `client` fixture comes from `tests/conftest.py.jinja` (also in `_skip_if_exists`, also rendered into greenfield scaffolds). It wraps `make_server()` in an in-memory FastMCP `Client`.
-- The `# type: ignore[arg-type]` is needed because `register_apps` is typed to take a `FastMCP`, but the scaffold body never dereferences it — simplest way to test the env-var branch without spinning up a server.
+- The `client` fixture comes from `tests/conftest.py.jinja` (also in `_skip_if_exists`, also rendered into greenfield scaffolds). It wraps `make_server()` in an in-memory FastMCP `Client`. Fixture annotation: `Client[Any]` (the generic parameterises the transport; `Any` keeps the scaffold transport-agnostic).
+- Passing `make_server()` into `register_apps` keeps the branch honest: downstream maintainers who add real `.resource()`/`.tool()` registrations to the `if app_domain:` body won't hit `AttributeError` because the test starts failing loudly.
 - `tests/test_tools.py.jinja` is **deliberately not modified** — it's in `_exclude` so changes there never reach scaffolds.
 
 - [ ] **Step 3: Render and run the new tests**
@@ -163,7 +166,7 @@ uv run pytest tests/test_smoke.py -v
 
 Expected: 4 tests pass (`test_make_server_constructs`, `test_register_apps_logs_when_app_domain_set`, `test_status_resource_reports_ready`, `test_summarize_prompt_includes_context`).
 
-If `test_status_resource_reports_ready` fails with an attribute error on `result[0]`, the FastMCP client API may have shifted — inspect with `python -c "from fastmcp import Client; help(Client.read_resource)"` and adjust the access pattern. The `hasattr(...)` guard is defensive against minor API shifts.
+If `test_status_resource_reports_ready` fails with an `AssertionError: expected text resource content, got ...`, the FastMCP client API may have shifted to a different content-union variant — inspect with `python -c "from fastmcp import Client; help(Client.read_resource)"` and adjust the access pattern.
 
 - [ ] **Step 4: Run mypy + coverage check**
 
@@ -244,9 +247,13 @@ def test_serve_help_exits_zero() -> None:
 
 
 def test_no_args_shows_help() -> None:
-    """Bare invocation exits 0 with help text via ``no_args_is_help=True``."""
+    """Bare invocation shows help text via ``no_args_is_help=True``.
+
+    Typer/Click exits with code 2 (missing command) but still prints the
+    help output.  Pinning the exit code locks in the documented behaviour.
+    """
     result = CliRunner().invoke(app, [])
-    assert result.exit_code == 0
+    assert result.exit_code == 2
     assert "serve" in result.output
 ```
 

--- a/docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md
+++ b/docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md
@@ -1,0 +1,242 @@
+# Scaffold coverage + README post-setup extension
+
+**Date:** 2026-04-23
+**Issues:** [#50](https://github.com/pvliesdonk/fastmcp-server-template/issues/50), [#51](https://github.com/pvliesdonk/fastmcp-server-template/issues/51)
+
+## Problem
+
+Two papercuts surface on the first greenfield use of the template
+(`paperless-mcp`):
+
+1. **Pristine scaffold fails its own coverage gate.** The shipped
+   `tests/test_smoke.py` + `tests/test_tools.py` exercise ~59% of the
+   generated code, well below `pyproject.toml`'s `fail_under = 80`.
+   A new downstream maintainer sees red CI on commit 1.
+
+2. **Required GitHub secrets are undocumented.** After
+   `gh repo create --push`, three secrets must be configured before CI
+   stops failing — `RELEASE_TOKEN`, `CODECOV_TOKEN`,
+   `CLAUDE_CODE_OAUTH_TOKEN`. None of them are mentioned anywhere in
+   the rendered README; users grep workflow files to discover each.
+
+Issue #52 (stale venv shebangs after moving a scaffolded project) is
+out of scope — that's a `uv` behaviour question, not a template fix.
+
+## Goals
+
+- A pristine scaffold's `uv run pytest` passes the 80% threshold
+  without any downstream test-writing.
+- A new downstream maintainer can find every required GitHub secret
+  in the rendered README, with copy-pasteable commands to set them.
+- Maintenance footprint stays small: borrow the existing typer test
+  pattern from `scholar-mcp`, don't invent a new one.
+
+## Non-goals
+
+- Fixing or documenting the stale-shebang issue (#52).
+- Adding a `scripts/setup-secrets.sh` interactive helper (the README
+  table closes the loop for most users; defer the script).
+- Moving deployment docs into the README (`docs/deployment/*.md.jinja`
+  already covers Docker / OIDC).
+
+## Coverage gap analysis
+
+Source files in the rendered scaffold (executable line estimates):
+
+| File | ~LOC | Covered by current tests? |
+|---|---|---|
+| `cli.py` | ~70 | **No** — no CLI tests exist |
+| `server.py` | ~50 | Mostly (transport!=stdio branch uncovered) |
+| `_server_apps.py` | ~20 | Else-branch only (no env-var branch covered) |
+| `_server_deps.py` | ~30 | Yes (via `client` fixture lifespan) |
+| `config.py` | ~25 | Yes |
+| `domain.py` | ~25 | `start/stop/ping` covered, `status` not |
+| `tools.py` | ~25 | Yes (`ping` tested) |
+| `resources.py` | ~15 | `register_*` only — `status` handler not invoked |
+| `prompts.py` | ~10 | `register_*` only — `summarize` handler not invoked |
+
+`cli.py` alone is ~70 of ~270 executable lines (~26% of the codebase),
+which is the dominant gap. Covering it lifts coverage to ~75-80% —
+marginal. Adding handler-invocation tests for the `status` resource,
+the `summarize` prompt, and the `_server_apps` env-var branch comfortably
+clears 80% with headroom for downstream branch additions.
+
+## Design
+
+### 1. New file: `tests/test_cli.py.jinja`
+
+Borrowed pattern: `scholar-mcp/tests/test_cli.py` (the only downstream
+that uses typer; markdown-vault-mcp and image-gen-mcp are argparse-based).
+
+```python
+"""CLI tests for {{ human_name }}."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from {{ python_module }}.cli import app
+
+
+def test_help_exits_zero() -> None:
+    """`{{ project_name }} --help` lists the serve command."""
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_serve_help_exits_zero() -> None:
+    """`{{ project_name }} serve --help` documents transport flags."""
+    result = CliRunner().invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "stdio" in result.output
+
+
+def test_no_args_shows_help() -> None:
+    """`no_args_is_help=True` makes bare invocation exit 0 with help text."""
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+```
+
+`--help` exits via typer before any command body runs, so no
+`make_server()` / uvicorn imports execute. No mocks needed.
+
+**Copier placement:** Add `tests/test_cli.py` to `_skip_if_exists` in
+`copier.yml` — same treatment as `tests/test_smoke.py`. Greenfield
+scaffolds get the file; downstreams that already have their own
+`test_cli.py` (scholar-mcp, image-gen-mcp, markdown-vault-mcp) keep
+theirs.
+
+### 2. Extend `tests/test_tools.py.jinja`
+
+Add two handler-invocation tests using the existing `client` fixture:
+
+```python
+async def test_status_resource_returns_ready(client: Client) -> None:
+    """The `status://{{ project_name }}` resource reports the running service."""
+    result = await client.read_resource("status://{{ project_name }}")
+    payload = result[0].text
+    assert "ready" in payload
+
+
+async def test_summarize_prompt_includes_context(client: Client) -> None:
+    """The `summarize` prompt round-trips the context argument."""
+    result = await client.get_prompt("summarize", {"context": "hello world"})
+    assert "hello world" in result.messages[0].content.text
+```
+
+`test_tools.py` is in `_exclude` — never re-rendered after first copy,
+so existing downstreams aren't affected.
+
+### 3. Extend `tests/test_smoke.py.jinja`
+
+Add one branch test for `_server_apps.register_apps`:
+
+```python
+def test_register_apps_logs_when_app_domain_set(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`register_apps` logs an info message when the app-domain env var is set."""
+    monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
+    with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
+        make_server()
+    assert any("example.com" in r.message for r in caplog.records)
+```
+
+`test_smoke.py` is in `_skip_if_exists` — greenfield scaffolds get
+the new tests; existing downstreams keep their version.
+
+### 4. Extend `README.md.jinja`
+
+`README.md` is in `_skip_if_exists` — extensions land on greenfield
+scaffolds only, which is exactly the issue audience (someone who just
+ran `copier copy` and `gh repo create`).
+
+New sections appended after the existing `## Configuration` block,
+before `## Links`:
+
+```markdown
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. Configure GitHub secrets (see below).
+2. Install dev dependencies: `uv sync --all-extras --dev`.
+3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/`.
+4. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via
+**Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml` | Fine-grained PAT at https://github.com/settings/personal-access-tokens/new with `contents: write` (and `pull_requests: write` if release PRs are enabled). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml`, `coverage-status.yml` | https://codecov.io → sign in with GitHub → add the repo → copy the upload token from repo settings. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                      # tests
+uv run ruff check --fix . && uv run ruff format .   # lint + format
+uv run mypy src/                         # type-check
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for the full PR acceptance gates.
+```
+
+The existing `## Quick start`, `## Configuration`, and `## Links`
+sections stay unchanged.
+
+## File changes
+
+| File | Change | Notes |
+|---|---|---|
+| `tests/test_cli.py.jinja` | **new** | CliRunner tests; covers `cli.py` |
+| `tests/test_tools.py.jinja` | extend | +2 handler tests (status, summarize) |
+| `tests/test_smoke.py.jinja` | extend | +1 branch test (`register_apps` env-var) |
+| `copier.yml` | edit | Add `tests/test_cli.py` to `_skip_if_exists` |
+| `README.md.jinja` | extend | +3 sections (post-setup, secrets, local dev) |
+
+## Validation
+
+Local render + gate (per project CLAUDE.md):
+
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+uv sync --all-extras --dev
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/
+uv run pytest -x -q   # must pass with --fail-under=80
+```
+
+Then push and wait for `template-ci.yml` to run the same gate on
+Python 3.11–3.14.
+
+## Rollout
+
+- Template release: standard `template-release.yml` `workflow_dispatch`
+  with `bump=patch` (no breaking change). **Manual trigger only** —
+  not run autonomously per project conventions.
+- Downstream pickup: weekly `copier-update.yml` cron picks up the
+  template change. Existing downstreams (markdown-vault-mcp,
+  image-gen-mcp, scholar-mcp) are unaffected because their copies of
+  `test_smoke.py`, `test_cli.py`, and `README.md` already exist
+  (`_skip_if_exists` preserves them).

--- a/docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md
+++ b/docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md
@@ -3,6 +3,8 @@
 **Date:** 2026-04-23
 **Issues:** [#50](https://github.com/pvliesdonk/fastmcp-server-template/issues/50), [#51](https://github.com/pvliesdonk/fastmcp-server-template/issues/51)
 
+> **Revision 2026-04-23 (post-implementation):** Section 2 originally extended `tests/test_tools.py.jinja`, but that file is in `copier.yml`'s `_exclude` block — copier **never renders it**, on copy or update. The resource + prompt tests were folded into `tests/test_smoke.py.jinja` (which IS in `_skip_if_exists`) so they reach greenfield scaffolds as intended. Sections 2 + 3 below are kept as the original design record; the File changes table (§ "File changes") and the implementation plan reflect the corrected landing place.
+
 ## Problem
 
 Two papercuts surface on the first greenfield use of the template
@@ -126,8 +128,10 @@ async def test_summarize_prompt_includes_context(client: Client) -> None:
     assert "hello world" in result.messages[0].content.text
 ```
 
-`test_tools.py` is in `_exclude` — never re-rendered after first copy,
-so existing downstreams aren't affected.
+`test_tools.py` is in `_exclude` — copier never renders it (on copy
+or on update), so the plan landed these tests in
+`tests/test_smoke.py.jinja` instead. See the revision banner at the
+top of this document.
 
 ### 3. Extend `tests/test_smoke.py.jinja`
 
@@ -207,10 +211,12 @@ sections stay unchanged.
 | File | Change | Notes |
 |---|---|---|
 | `tests/test_cli.py.jinja` | **new** | CliRunner tests; covers `cli.py` |
-| `tests/test_tools.py.jinja` | extend | +2 handler tests (status, summarize) |
-| `tests/test_smoke.py.jinja` | extend | +1 branch test (`register_apps` env-var) |
+| `tests/test_smoke.py.jinja` | extend | +3 tests: `register_apps` env-var branch, `status` resource, `summarize` prompt |
+| `tests/conftest.py.jinja` | edit | `Client[Any]` on the `client` fixture (strict mypy) |
 | `copier.yml` | edit | Add `tests/test_cli.py` to `_skip_if_exists` |
-| `README.md.jinja` | extend | +3 sections (post-setup, secrets, local dev) |
+| `pyproject.toml.jinja` | edit | Add `tests/test_smoke.py` to ruff TC002 per-file ignores |
+| `README.md.jinja` | extend | +3 sections (post-scaffold checklist, GitHub secrets, local dev) |
+| `CLAUDE.md` | edit | Document `--vcs-ref=HEAD` for local iteration |
 
 ## Validation
 

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -76,6 +76,7 @@ ignore = ["E501"]
 "src/{{ python_module }}/resources.py" = ["B008", "TC001", "TC002"]
 "src/{{ python_module }}/prompts.py" = ["B008", "TC002"]
 "tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002"]
 "tests/test_tools.py" = ["TC002"]
 # Add project-specific overrides below as needed.
 

--- a/tests/conftest.py.jinja
+++ b/tests/conftest.py.jinja
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
 from fastmcp import Client
@@ -20,7 +21,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-async def client() -> AsyncIterator[Client]:
+async def client() -> AsyncIterator[Client[Any]]:
     """Return an in-memory FastMCP client connected to a fresh server."""
     server = make_server()
     async with Client(server) as c:

--- a/tests/test_cli.py.jinja
+++ b/tests/test_cli.py.jinja
@@ -31,7 +31,10 @@ def test_no_args_shows_help() -> None:
     """Bare invocation shows help text via ``no_args_is_help=True``.
 
     Typer/Click exits with code 2 (missing command) but still prints the
-    help output — assert on the output, not the exit code.
+    help output.  Pinning the exit code locks in the documented behaviour
+    so a future typer version that routes bare invocation to a different
+    code (e.g. 1 for runtime error) surfaces as a test failure.
     """
     result = CliRunner().invoke(app, [])
+    assert result.exit_code == 2
     assert "serve" in result.output

--- a/tests/test_cli.py.jinja
+++ b/tests/test_cli.py.jinja
@@ -1,9 +1,9 @@
 """CLI tests for {{ human_name }}.
 
-Borrowed from scholar-mcp's ``test_cli.py`` typer pattern. ``--help``
-exits via typer before any command body runs, so these tests don't
-import ``server.py`` or start uvicorn — keeping them fast and free
-of side effects.
+Uses the standard typer ``CliRunner`` pattern: ``--help`` exits via
+typer before any command body runs, so these tests don't import
+``server.py`` or start uvicorn — keeping them fast and free of side
+effects.
 """
 
 from __future__ import annotations

--- a/tests/test_cli.py.jinja
+++ b/tests/test_cli.py.jinja
@@ -1,0 +1,37 @@
+"""CLI tests for {{ human_name }}.
+
+Borrowed from scholar-mcp's ``test_cli.py`` typer pattern. ``--help``
+exits via typer before any command body runs, so these tests don't
+import ``server.py`` or start uvicorn — keeping them fast and free
+of side effects.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from {{ python_module }}.cli import app
+
+
+def test_help_exits_zero() -> None:
+    """`{{ project_name }} --help` lists the serve command."""
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_serve_help_exits_zero() -> None:
+    """`{{ project_name }} serve --help` documents the transport flag."""
+    result = CliRunner().invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "stdio" in result.output
+
+
+def test_no_args_shows_help() -> None:
+    """Bare invocation shows help text via ``no_args_is_help=True``.
+
+    Typer/Click exits with code 2 (missing command) but still prints the
+    help output — assert on the output, not the exit code.
+    """
+    result = CliRunner().invoke(app, [])
+    assert "serve" in result.output

--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -25,22 +26,29 @@ def test_register_apps_logs_when_app_domain_set(
 
     Covers the ``if app_domain:`` branch of ``_server_apps.register_apps``,
     which the default smoke tests miss because no ``{{ env_prefix }}_APP_DOMAIN``
-    is set in the test env.
+    is set in the test env.  Pass a real ``FastMCP`` instance so the test
+    keeps working if a downstream maintainer adds real registrations to the
+    branch (the scaffold's no-op branch ignores the argument today).
     """
     monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
     with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
-        # Pass None for the FastMCP instance — register_apps doesn't touch it
-        # in the scaffold's no-op branch.
-        register_apps(None)  # type: ignore[arg-type]
+        register_apps(make_server())
     assert any("example.com" in r.message for r in caplog.records)
 
 
 async def test_status_resource_reports_ready(client: Client[Any]) -> None:
-    """The example ``status://`` resource returns the running service's state."""
+    """The example ``status://`` resource reports a started service.
+
+    The lifespan calls ``service.start()``, so the resource payload must
+    contain ``ready: true`` — asserting the value (not just the key name)
+    catches a future regression where the lifespan stops starting the
+    service.  Content is a union; narrow defensively — scaffold stays
+    generic on purpose so users copying it don't need to adjust types.
+    """
     result = await client.read_resource("status://{{ project_name }}")
     first = result[0]
     text = first.text if hasattr(first, "text") else str(first)
-    assert "ready" in text
+    assert json.loads(text) == {"ready": True}
 
 
 async def test_summarize_prompt_includes_context(client: Client[Any]) -> None:

--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+from {{ python_module }}._server_apps import register_apps
 from {{ python_module }}.server import make_server
 
 
@@ -9,3 +15,37 @@ def test_make_server_constructs() -> None:
     """make_server() returns a FastMCP instance without raising."""
     server = make_server()
     assert server is not None
+
+
+def test_register_apps_logs_when_app_domain_set(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """register_apps logs the configured app domain when the env var is set.
+
+    Covers the ``if app_domain:`` branch of ``_server_apps.register_apps``,
+    which the default smoke tests miss because no ``{{ env_prefix }}_APP_DOMAIN``
+    is set in the test env.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
+    with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
+        # Pass None for the FastMCP instance — register_apps doesn't touch it
+        # in the scaffold's no-op branch.
+        register_apps(None)  # type: ignore[arg-type]
+    assert any("example.com" in r.message for r in caplog.records)
+
+
+async def test_status_resource_reports_ready(client: Client[Any]) -> None:
+    """The example ``status://`` resource returns the running service's state."""
+    result = await client.read_resource("status://{{ project_name }}")
+    first = result[0]
+    text = first.text if hasattr(first, "text") else str(first)
+    assert "ready" in text
+
+
+async def test_summarize_prompt_includes_context(client: Client[Any]) -> None:
+    """The example ``summarize`` prompt round-trips its ``context`` argument."""
+    result = await client.get_prompt("summarize", {"context": "hello world"})
+    content = result.messages[0].content
+    text = content.text if hasattr(content, "text") else str(content)
+    assert "hello world" in text

--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -42,18 +42,21 @@ async def test_status_resource_reports_ready(client: Client[Any]) -> None:
     The lifespan calls ``service.start()``, so the resource payload must
     contain ``ready: true`` — asserting the value (not just the key name)
     catches a future regression where the lifespan stops starting the
-    service.  Content is a union; narrow defensively — scaffold stays
-    generic on purpose so users copying it don't need to adjust types.
+    service.
     """
     result = await client.read_resource("status://{{ project_name }}")
     first = result[0]
-    text = first.text if hasattr(first, "text") else str(first)
-    assert json.loads(text) == {"ready": True}
+    assert hasattr(first, "text"), (
+        f"expected text resource content, got {type(first).__name__}"
+    )
+    assert json.loads(first.text) == {"ready": True}
 
 
 async def test_summarize_prompt_includes_context(client: Client[Any]) -> None:
     """The example ``summarize`` prompt round-trips its ``context`` argument."""
     result = await client.get_prompt("summarize", {"context": "hello world"})
     content = result.messages[0].content
-    text = content.text if hasattr(content, "text") else str(content)
-    assert "hello world" in text
+    assert hasattr(content, "text"), (
+        f"expected text prompt content, got {type(content).__name__}"
+    )
+    assert "hello world" in content.text

--- a/tests/test_tools.py.jinja
+++ b/tests/test_tools.py.jinja
@@ -1,4 +1,4 @@
-"""Golden-path smoke tests for the example tool, resource, and prompt."""
+"""Golden-path smoke test for the example ``ping`` tool."""
 
 from __future__ import annotations
 
@@ -9,16 +9,3 @@ async def test_ping_returns_pong(client: Client) -> None:
     """The example ``ping`` tool round-trips cleanly through the MCP client."""
     result = await client.call_tool("ping", {})
     assert result.content[0].text == "pong"
-
-
-async def test_status_resource_reports_ready(client: Client) -> None:
-    """The example ``status://`` resource returns the running service's state."""
-    result = await client.read_resource("status://{{ project_name }}")
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    assert "ready" in text
-
-
-async def test_summarize_prompt_includes_context(client: Client) -> None:
-    """The example ``summarize`` prompt round-trips its ``context`` argument."""
-    result = await client.get_prompt("summarize", {"context": "hello world"})
-    assert "hello world" in result.messages[0].content.text

--- a/tests/test_tools.py.jinja
+++ b/tests/test_tools.py.jinja
@@ -1,4 +1,4 @@
-"""Golden-path smoke test for the example ``ping`` tool."""
+"""Golden-path smoke tests for the example tool, resource, and prompt."""
 
 from __future__ import annotations
 
@@ -9,3 +9,16 @@ async def test_ping_returns_pong(client: Client) -> None:
     """The example ``ping`` tool round-trips cleanly through the MCP client."""
     result = await client.call_tool("ping", {})
     assert result.content[0].text == "pong"
+
+
+async def test_status_resource_reports_ready(client: Client) -> None:
+    """The example ``status://`` resource returns the running service's state."""
+    result = await client.read_resource("status://{{ project_name }}")
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    assert "ready" in text
+
+
+async def test_summarize_prompt_includes_context(client: Client) -> None:
+    """The example ``summarize`` prompt round-trips its ``context`` argument."""
+    result = await client.get_prompt("summarize", {"context": "hello world"})
+    assert "hello world" in result.messages[0].content.text


### PR DESCRIPTION
## Summary

- **#50** — Pristine scaffold now clears its own 80% coverage gate: 58.82% → **81.18%** (4 new tests in `test_smoke.py.jinja`, 3 new CliRunner tests in new `test_cli.py.jinja` borrowing scholar-mcp's typer pattern).
- **#51** — `README.md.jinja` gains a `## Post-scaffold checklist`, `## GitHub secrets` table (RELEASE_TOKEN / CODECOV_TOKEN / CLAUDE_CODE_OAUTH_TOKEN with generation links and `gh secret set` snippet), and `## Local development` section.
- Side fixes surfaced while iterating: `Client[Any]` annotation on the `conftest.py.jinja` client fixture (strict mypy), ruff TC002 per-file ignore for `test_smoke.py`, and `CLAUDE.md` now documents `--vcs-ref=HEAD` (copier reads from the git index — without the flag, uncommitted `.jinja` edits are silently ignored).

## Test plan

- [x] Full gate on rendered scaffold (`/tmp/smoke` via `--vcs-ref=HEAD`): `ruff check`, `ruff format --check`, `mypy src/ tests/`, `pytest --cov` all green
- [x] Coverage 81.18% (> 80% `--fail-under` gate)
- [x] Rendered README shows all three new sections + all three secrets with correct workflow attributions
- [x] `test_status_resource_reports_ready` asserts full `{"ready": True}` dict (not just key-name substring)
- [x] `test_register_apps_logs_when_app_domain_set` uses a real `make_server()` instance, not `None`
- [x] `test_no_args_shows_help` pins `exit_code == 2` to match typer's `no_args_is_help=True` contract
- [x] Downstream `_skip_if_exists` protection verified against the three consumer repos — all three already have their own `test_smoke.py` / `test_cli.py` / `README.md`; weekly `copier-update.yml` cron is a no-op for them
- [ ] `template-ci.yml` runs the same gate on Python 3.11–3.14 (checked on PR)

Spec: [`docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md`](docs/superpowers/specs/2026-04-23-scaffold-coverage-and-readme-extension-design.md)
Plan: [`docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md`](docs/superpowers/plans/2026-04-23-scaffold-coverage-and-readme-extension.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)