### PR TITLE
fix: three scaffolding-time bugs blocking downstream CI and releases

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -59,6 +59,12 @@ _skip_if_exists:
   - "docs/installation.md"
   - "docs/configuration.md"
   - "docs/tools/index.md"
+  - "docs/prompts.md"
+  # nfpm env template — users customise with domain-specific env vars; installs
+  # to /etc/{project}/env.example with config|noreplace so operators copy it to
+  # /etc/{project}/env locally anyway, but keep the source customisation across
+  # template updates.
+  - "packaging/env.example"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the

--- a/copier.yml
+++ b/copier.yml
@@ -50,6 +50,15 @@ _skip_if_exists:
   - "docs/deployment/docker.md"
   - "docs/deployment/oidc.md"
   - "docs/guides/authentication.md"
+  # mkdocs nav pages — rendered as starter content on first copy so a fresh
+  # project's `mkdocs build --strict` passes.  Projects that customise these
+  # keep their edits across `copier update`.  Moved here from `_exclude` in
+  # #56 because the shipped mkdocs.yml references them; excluding them
+  # unconditionally broke the docs workflow out of the box.
+  - "docs/index.md"
+  - "docs/installation.md"
+  - "docs/configuration.md"
+  - "docs/tools/index.md"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the
@@ -89,10 +98,6 @@ _exclude:
   # this repo as maintainer-facing reference content.
   - "tests/test_tools.py"
   - "docs/design.md"
-  - "docs/index.md"
-  - "docs/tools/index.md"
-  - "docs/configuration.md"
-  - "docs/installation.md"
 
 # --- Variables ---
 

--- a/docs/prompts.md.jinja
+++ b/docs/prompts.md.jinja
@@ -1,0 +1,23 @@
+# Prompts
+
+MCP prompts are reusable prompt templates exposed to clients. The scaffold
+ships a minimal set defined in `src/{{ python_module }}/prompts.py`; add
+domain-specific prompts there and document them in this page.
+
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/{{ python_module }}/prompts.py` and list them here with their arguments,
+usage, and example output.
+
+## Example
+
+```python
+@mcp.prompt()
+def summarize(topic: str) -> str:
+    """Summarize the given topic in three sentences."""
+    return f"Write a three-sentence summary of: {topic}"
+```
+
+See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
+for the full prompt API.

--- a/packaging/env.example.jinja
+++ b/packaging/env.example.jinja
@@ -1,0 +1,19 @@
+# {{ human_name }} environment configuration
+#
+# Installed to /etc/{{ project_name }}/env.example.
+# Copy to /etc/{{ project_name }}/env and edit for your deployment; the
+# systemd unit (/usr/lib/systemd/system/{{ project_name }}.service) sources
+# /etc/{{ project_name }}/env via EnvironmentFile=.
+
+# --- Logging ---
+# DEBUG | INFO | WARNING | ERROR
+FASTMCP_LOG_LEVEL=INFO
+# Set to false for plain/structured JSON output instead of Rich formatting.
+FASTMCP_ENABLE_RICH_LOGGING=true
+
+# --- Domain configuration ---
+# All domain env vars use the {{ env_prefix }}_ prefix.
+# See the README and `{{ project_name }} serve --help` for the full list.
+#
+# Example:
+# {{ env_prefix }}_EXAMPLE_VAR=value

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -26,6 +26,11 @@ dependencies = [
 # PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
 # PROJECT-EXTRAS-END
 
+docs = [
+    "mkdocs-material>=9",
+    "mkdocstrings[python]>=0.28",
+]
+
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -127,6 +127,9 @@ ignore_missing_imports = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+# src-layout editable installs use a .pth shim that Pyright does not execute;
+# point Pyright at src/ directly so IDE import resolution matches runtime.
+extraPaths = ["src"]
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]


### PR DESCRIPTION
## Summary

Three unrelated one-shot fixes that each break a freshly-scaffolded project on a different axis. Bundled because they're all in the shape of "fresh scaffold doesn't work out of the box" and share no file-level coupling.

- **Closes #53** — `fix(pyright)`: add `extraPaths = ["src"]` under `[tool.pyright]` so IDE language servers resolve src-layout imports the same way `uv run` does at runtime.
- **Closes #56** — `fix(docs)`: add the `docs` optional-dependency group to `pyproject.toml.jinja`; scaffold the missing `docs/prompts.md.jinja` stub; move `docs/{index,installation,configuration,tools/index}.md` from `_exclude` to `_skip_if_exists` in `copier.yml` (the template's `mkdocs.yml` references them but they were never rendered).
- **Closes #59** — `fix(packaging)`: ship `packaging/env.example.jinja` referenced by `nfpm.yaml.jinja:30`. Installs to `/etc/{project}/env.example` with `config|noreplace`.

## Verification

Rendered the template at HEAD against `tests/fixtures/smoke-answers.yml` and ran the full downstream gate on `/tmp/smoke`:

- `uv sync --all-extras --dev` — green (pulls `mkdocs-material` + `mkdocstrings[python]`).
- `uv run ruff check .` / `ruff format --check .` — green.
- `uv run mypy src/ tests/` — green.
- `uv run pytest -x -q` — 7 passed.
- `uv run mkdocs build --strict` — built cleanly, all nav entries resolve.
- `nfpm package --packager deb` — produced `smoke-mcp_1.0.0_amd64.deb` with `/etc/smoke-mcp/env.example` present in `data.tar.gz`.
- `nfpm package --packager rpm` — produced `smoke-mcp.rpm`.

## Downstream rollout note

The new `docs` extra adds two dependencies (`mkdocs-material>=9`, `mkdocstrings[python]>=0.28`). Because `docs.yml` runs `uv sync --extra docs --frozen`, each downstream consumer must refresh `uv.lock` when accepting the next weekly copier-update PR — `uv lock` (or `uv lock --upgrade-package mkdocs-material --upgrade-package mkdocstrings`) before merging. This can't be automated from the template since `uv.lock` is in `copier.yml`'s `_exclude`.

## Follow-ups

- **#61** (filed) — `template-ci.yml` doesn't currently exercise `mkdocs build --strict` or `nfpm package` against the rendered smoke project, which is exactly why #56 and #59 shipped unnoticed. Deferred out-of-scope; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)