### PR TITLE
feat: pre-commit gate + PR-issue discipline in template CLAUDE.md

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -1,0 +1,38 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        language: system
+        entry: uv run ruff check --fix
+        types: [python]
+        pass_filenames: true
+
+      - id: ruff-format
+        name: ruff format
+        language: system
+        entry: uv run ruff format
+        types: [python]
+        pass_filenames: true
+
+      - id: mypy
+        name: mypy
+        language: system
+        entry: uv run mypy
+        files: ^(src|tests)/
+        pass_filenames: false
+        args: [src/, tests/]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-json
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -33,6 +33,6 @@ repos:
       - id: check-json
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.30.1
     hooks:
       - id: gitleaks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -20,6 +20,7 @@ repos:
         language: system
         entry: uv run mypy
         files: ^(src|tests)/
+        types: [python]
         pass_filenames: false
         args: [src/, tests/]
 

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -44,7 +44,7 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 
-The config is in `_skip_if_exists`, so domain-specific additions (gitleaks, project-specific linters, additional file checks) survive `copier update`.
+The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
 
 ## PR Discipline
 

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -36,6 +36,16 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
 
+## Pre-commit Hooks
+
+This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), mypy on `src/` and `tests/`, gitleaks secret scanning, and standard whitespace/YAML/JSON checks — aligned with the `ci.yml` lint/typecheck/secrets jobs so a clean pre-commit run implies a clean CI lane.
+
+- **Install once per clone:** `uv run pre-commit install`.
+- **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+- **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
+
+The config is in `_skip_if_exists`, so domain-specific additions (gitleaks, project-specific linters, additional file checks) survive `copier update`.
+
 ## GitHub Review Types
 
 GitHub has two distinct review mechanisms — **both must be read and addressed**:

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -46,6 +46,12 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 
 The config is in `_skip_if_exists`, so domain-specific additions (gitleaks, project-specific linters, additional file checks) survive `copier update`.
 
+## PR Discipline
+
+**Every PR must have at least one associated issue.** If the work doesn't have one yet — a bug found in the wild, an opportunistic cleanup, a small improvement — create the issue first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single PR may close multiple issues (`Closes #A, closes #B`) — bundling related fixes is fine; the rule is "no orphan PRs", not "one PR per issue". This keeps the changelog, release notes, and cross-repo history coherent.
+
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
+
 ## GitHub Review Types
 
 GitHub has two distinct review mechanisms — **both must be read and addressed**:

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -21,8 +21,9 @@ After `copier copy` and `gh repo create --push`:
 
 1. Configure GitHub secrets (see below).
 2. Install dev dependencies: `uv sync --all-extras --dev`.
-3. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/ tests/`.
-4. Push the first commit — CI should be green.
+3. Install pre-commit hooks: `uv run pre-commit install`.
+4. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/ tests/`.
+5. Push the first commit — CI should be green.
 
 ## GitHub secrets
 

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -22,7 +22,7 @@ After `copier copy` and `gh repo create --push`:
 1. Configure GitHub secrets (see below).
 2. Install dev dependencies: `uv sync --all-extras --dev`.
 3. Install pre-commit hooks: `uv run pre-commit install`.
-4. Run the gate locally: `uv run pytest -x -q && uv run ruff check . && uv run mypy src/ tests/`.
+4. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
 5. Push the first commit — CI should be green.
 
 ## GitHub secrets

--- a/copier.yml
+++ b/copier.yml
@@ -65,6 +65,9 @@ _skip_if_exists:
   # /etc/{project}/env locally anyway, but keep the source customisation across
   # template updates.
   - "packaging/env.example"
+  # pre-commit hook config — users add domain-specific hooks (gitleaks,
+  # project-specific linters, etc.); preserve customisation across updates.
+  - ".pre-commit-config.yaml"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by
 # sentinel blocks, and copier's 3-way merge needs to re-render the

--- a/copier.yml
+++ b/copier.yml
@@ -65,8 +65,9 @@ _skip_if_exists:
   # /etc/{project}/env locally anyway, but keep the source customisation across
   # template updates.
   - "packaging/env.example"
-  # pre-commit hook config — users add domain-specific hooks (gitleaks,
-  # project-specific linters, etc.); preserve customisation across updates.
+  # pre-commit hook config — users add domain-specific hooks (shellcheck,
+  # yamllint, project-specific linters, etc.) on top of the shipped defaults;
+  # preserve customisation across updates.
   - ".pre-commit-config.yaml"
 # Note: CLAUDE.md is deliberately NOT in _skip_if_exists — it's a
 # hybrid file with template-owned and domain-owned sections marked by


### PR DESCRIPTION
## Summary

Two template-owned additions to CLAUDE.md.jinja, plus a default pre-commit config scaffold, bundled because they're both PR-workflow-adjacent and share `CLAUDE.md.jinja`.

### Closes #58 — pre-commit gate

- New `.pre-commit-config.yaml.jinja` scaffolded into every generated project. **Aligned with `ci.yml.jinja`** so a clean local pre-commit run implies a clean CI lane:
  - `ruff check` + `ruff format` (local hooks; CI runs `--check` to verify pre-commit was applied).
  - `mypy src/ tests/` — matches CI's `uv run mypy src/ tests/` (earlier src-only draft was misaligned with CI).
  - `gitleaks v8.21.2` — matches CI's `gitleaks-action` secrets job.
  - Standard `pre-commit-hooks@v5.0.0`: trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, check-json.
- `pip-audit` and `pytest` stay CI-only (network/time).
- Added to `copier.yml` `_skip_if_exists` so downstream customisation (extra domain hooks) survives `copier update`.
- New `## Pre-commit Hooks` section in `CLAUDE.md.jinja` adjacent to "Hard PR Acceptance Gates": install-once, run-on-demand, never-bypass-with-`--no-verify`.
- `uv run pre-commit install` added to the post-scaffold checklist in `README.md.jinja`.

### Closes #60 — PR Discipline

- New `## PR Discipline` section in `CLAUDE.md.jinja` stating the "every PR must have at least one associated issue" rule, with the explicit "multiple issues per PR is fine; the rule is against orphan PRs, not for one-PR-per-issue" clarification. Trivial-exception carve-out for typos and Dependabot/Renovate.

## Verification

- `copier copy` render with `tests/fixtures/smoke-answers.yml` → clean.
- `uv sync --all-extras --dev` → green.
- `uv run pre-commit install && uv run pre-commit run --all-files` on the rendered project → **all 9 hooks pass** (ruff-check, ruff-format, mypy, trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, check-json, gitleaks).
- `uv run ruff check .`, `ruff format --check .`, `mypy src/ tests/`, `pytest -x -q` on rendered project → all green.

## Notes

Opening as draft per the new "open draft → `/code-review` → mark ready" workflow (itself a personal-CLAUDE.md rule, not template-owned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)