### PR TITLE
fix(ci): exclude dev/docs extras from pip-audit input

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -193,7 +193,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Export dependency list (excluding local project)
-        run: uv export --all-extras --frozen --no-emit-project --no-hashes -o {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
+        # Exclude `dev` and `docs` extras — they bring in tooling (pip-audit,
+        # ruff, mypy, mkdocs, ...) that does not run in production. pip-audit's
+        # own dep on `pip` triggers spurious CVE reports against pip itself.
+        run: uv export --all-extras --no-extra dev --no-extra docs --frozen --no-emit-project --no-hashes -o {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
 
       - name: Run pip-audit
         run: uvx pip-audit --strict --progress-spinner off -r {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt


### PR DESCRIPTION
## Summary

- Exclude `dev` and `docs` extras when exporting deps for pip-audit so the audit only sees runtime code, not tooling.
- Closes #78.

## Why

`audit` job ran:

```yaml
uv export --all-extras --frozen --no-emit-project --no-hashes -o requirements.txt
uvx pip-audit --strict -r requirements.txt
```

`--all-extras` pulls in the `dev` extra → `pip-audit` → `pip` itself, which currently has an unfixed CVE (`CVE-2026-3219`, no fix version published). Downstream consumers' audit jobs broke for a vulnerability in a build-time tool that never ships.

The `docs` extra has the same shape (mkdocs-material etc. pulled in for nothing).

## Fix

Single-line change to the export command:

```diff
-        run: uv export --all-extras --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
+        run: uv export --all-extras --no-extra dev --no-extra docs --frozen --no-emit-project --no-hashes -o ${{ runner.temp }}/requirements.txt
```

User-defined runtime extras (anything they add inside the `PROJECT-EXTRAS` sentinels) remain audited via `--all-extras`. Only the two tooling extras the template owns are excluded.

## Test plan

- [x] Render template with `--vcs-ref=HEAD` and confirm rendered `ci.yml` carries the new flags
- [x] `uv export ... --no-extra dev --no-extra docs` no longer contains `pip`, `pip-audit`, `ruff`, `mypy`, `mkdocs*`
- [x] `uvx pip-audit --strict -r <exported>` reports "No known vulnerabilities found"
- [ ] `template-ci.yml` passes on this PR (Python 3.11–3.14)
- [ ] Bot reviewers (claude-code-review, gemini-code-assist) clean

## Downstream rollout

Picked up via `copier update`; no changes needed in downstream repos beyond the standard update PR.

## Follow-ups (filed during code review)

- #80 — `uv export --no-extra <missing>` is a hard error, so a downstream that intentionally deletes the `dev` extra would break the audit job on its next run. Narrow risk; tracked separately.
- #81 — Structural fix: migrate `dev`/`docs` from `[project.optional-dependencies]` to PEP 735 `[dependency-groups]`. This subsumes #80 (audit can use `--no-default-groups` instead of named excludes). Out of scope here because it touches sync callsites and install docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)