### PR TITLE
chore(deps): bump mkdocs-material floor + add mkdocs-llmstxt

### DIFF
--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -36,6 +36,24 @@ theme:
 
 plugins:
   - search
+  # Generates llms.txt + llms-full.txt for the README badge.
+  # Sections mirror `nav:` below — keep them aligned when customising.
+  # `guides/*.md` and `deployment/*.md` use globs deliberately so new pages
+  # in those directories are auto-indexed without a sections-list update.
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - index.md
+          - installation.md
+          - configuration.md
+        Guides:
+          - guides/*.md
+        MCP Interface:
+          - tools/index.md
+          - prompts.md
+        Deployment:
+          - deployment/*.md
   - mkdocstrings:
       handlers:
         python:

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -27,8 +27,9 @@ dependencies = [
 # PROJECT-EXTRAS-END
 
 docs = [
-    "mkdocs-material>=9",
+    "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=0.28",
+    "mkdocs-llmstxt>=0.5",
 ]
 
 dev = [


### PR DESCRIPTION
## Summary

- Bumps \`mkdocs-material>=9\` → \`>=9.7.6\` so dependabot stops trying to bump it independently in each downstream repo.
- Adds \`mkdocs-llmstxt>=0.5\` to the docs extra and wires its plugin into \`mkdocs.yml.jinja\` so generated projects produce \`site/llms.txt\` and \`site/llms-full.txt\`.
- README badge for \`llms.txt\` now resolves on a fresh deploy instead of 404'ing.

Closes #74, closes #75.

## Plugin section design

The new \`llmstxt:\` block lists sections that mirror the scaffolded \`nav:\`:
- Getting Started → \`index.md\`, \`installation.md\`, \`configuration.md\`
- Guides → \`guides/*.md\`
- MCP Interface → \`tools/index.md\`, \`prompts.md\`
- Deployment → \`deployment/*.md\`

Downstream projects that customise their nav adjust both \`nav:\` and \`sections:\` together — same pattern as the existing template-owned \`nav:\` block.

## Test plan

- [x] Render template against \`tests/fixtures/smoke-answers.yml\` with \`--vcs-ref=HEAD\`.
- [x] \`uv sync --extra docs\` succeeds with the bumped floor + new dep.
- [x] \`uv run mkdocs build --strict\` passes; produces \`site/llms.txt\` (831 B, structured TOC) and \`site/llms-full.txt\` (35 KB, full expansion).
- [x] Full gate green: \`ruff check\`, \`ruff format --check\`, \`mypy src/ tests/\`, \`pytest -x -q\` (9 passed).
- [x] Local review circus clean (pr-review-toolkit + superpowers, both nothing flagged at any severity).
- [x] Schema verified against [mkdocs-llmstxt docs](https://pawamoy.github.io/mkdocs-llmstxt/) — \`site_url\` (already present), \`sections:\` mapping shape, optional \`full_output\`.
- [x] Spot-checked mkdocs-material 9.0 → 9.7.6 release notes; no breaking changes for the templated palette/features/icon config.
- [ ] template-ci.yml runs the full Python 3.11–3.14 matrix once landed on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)