### PR TITLE
fix(readme): genericise Quick start library-usage pointer

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -87,7 +87,7 @@ Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON
 {{ project_name }} serve --transport http --port 8000   # streamable HTTP
 ```
 
-For library usage (embedding the domain logic without the MCP transport), import from the `{{ python_module }}` package directly — see `src/{{ python_module }}/domain.py` for the entry point scaffold.
+For library usage (embedding the domain logic without the MCP transport), import from the `{{ python_module }}` package directly — see the project's domain modules under `src/{{ python_module }}/` for entry points.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The rendered README's Quick start section pointed at \`src/<pkg>/domain.py\` as the library-usage entry point. That file is a scaffold convention but not every downstream keeps it — e.g. scholar-mcp has multiple backend client modules (\`_s2_client.py\`, \`_epo_client.py\`) and no \`domain.py\`. Because this text is in the TEMPLATE-OWNED region, downstreams couldn't amend it without diverging and conflicting on every \`copier update\`.

Implements Option A from the issue body: drop the specific file reference; point at the package's domain modules generically.

Closes #67.

## Test plan

- [x] Render the template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`. Rendered line reads "see the project's domain modules under \`src/smoke_mcp/\` for entry points." — matches expected wording.
- [x] Full gate green: \`ruff check\`, \`ruff format --check\`, \`mypy src/ tests/\` (no issues, 13 source files), \`pytest -x -q\` (9 passed).
- [x] Local review circus clean (pr-review-toolkit + superpowers, both nothing flagged at any severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)