### PR TITLE
refactor(pyproject): migrate dev/docs to PEP 735 dependency-groups

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -23,7 +23,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run ruff check
         run: uv run ruff check src/ tests/
@@ -46,7 +46,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run mypy
         run: uv run mypy src/ tests/
@@ -82,7 +82,7 @@ jobs:
         run: uv python install {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-groups
 
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=xml
@@ -193,10 +193,13 @@ jobs:
         run: uv python install 3.12
 
       - name: Export dependency list (excluding local project)
-        # Exclude `dev` and `docs` extras — they bring in tooling (pip-audit,
-        # ruff, mypy, mkdocs, ...) that does not run in production. pip-audit's
-        # own dep on `pip` triggers spurious CVE reports against pip itself.
-        run: uv export --all-extras --no-extra dev --no-extra docs --frozen --no-emit-project --no-hashes -o {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
+        # `dev` is uv's only auto-activated default group, so --no-default-groups
+        # excludes it; `docs` is non-default and never exported unless explicitly
+        # requested via --group/--all-groups (neither passed here). Net effect:
+        # only runtime + user-defined extras land in the audit input — avoids
+        # spurious CVE reports against tooling (pip-audit's own `pip` dep, etc.)
+        # that does not run in production.
+        run: uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes -o {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
 
       - name: Run pip-audit
         run: uvx pip-audit --strict --progress-spinner off -r {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt

--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -48,7 +48,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --extra docs --frozen
+        run: uv sync --no-default-groups --group docs --frozen
 
       - name: Build documentation
         run: uv run mkdocs build --strict

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install rendered project
         working-directory: /tmp/smoke
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --all-groups
 
       - name: ruff check
         working-directory: /tmp/smoke
@@ -161,9 +161,9 @@ jobs:
             --data-file tests/fixtures/smoke-answers.yml \
             . /tmp/smoke
 
-      - name: Install rendered project (with docs extra)
+      - name: Install rendered project (with all extras and groups)
         working-directory: /tmp/smoke
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --all-groups
 
       - name: Install nfpm
         # Pin matches release.yml.jinja so we exercise the same version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ create new projects.
    uv run --no-project --with copier copier copy --trust --defaults \
      --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
    cd /tmp/smoke
-   uv sync --all-extras --dev
+   uv sync --all-extras --all-groups
    uv run ruff check . && uv run ruff format --check .
    uv run mypy src/ tests/ && uv run pytest -x -q
    ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ uv run --no-project --with copier \
 
 # Answer the prompts, then:
 cd my-new-service
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 uv run pytest
 uv run my-new-service serve
 ```

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -55,7 +55,7 @@ If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END`
 ```bash
 git clone https://github.com/{{ github_org }}/{{ project_name }}.git
 cd {{ project_name }}
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 ```
 
 ### Docker
@@ -107,7 +107,7 @@ After `copier copy` and `gh repo create --push`:
 
 1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
 2. Configure GitHub secrets — see below.
-3. Install dev dependencies: `uv sync --all-extras --dev`.
+3. Install dev + docs tooling: `uv sync --all-extras --all-groups`.
 4. Install pre-commit hooks: `uv run pre-commit install`.
 5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
 6. Push the first commit — CI should be green.
@@ -152,7 +152,7 @@ Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yam
 
 ```bash
 rm -rf .venv
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 ```
 
 `uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).

--- a/docs/installation.md.jinja
+++ b/docs/installation.md.jinja
@@ -17,5 +17,5 @@ docker pull {{ docker_registry }}/{{ project_name }}:latest
 ```bash
 git clone https://github.com/{{ github_org }}/{{ project_name }}
 cd {{ project_name }}
-uv sync --all-extras --dev
+uv sync --all-extras --all-groups
 ```

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -26,12 +26,9 @@ dependencies = [
 # PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
 # PROJECT-EXTRAS-END
 
-docs = [
-    "mkdocs-material>=9.7.6",
-    "mkdocstrings[python]>=0.28",
-    "mkdocs-llmstxt>=0.5",
-]
-
+# Tooling lives under PEP 735 [dependency-groups] (not [project.optional-dependencies])
+# so it never ships to PyPI consumers and never lands in the security-audit input.
+[dependency-groups]
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
@@ -41,6 +38,12 @@ dev = [
     "mypy>=1.11",
     "pre-commit>=3",
     "pip-audit>=2.7",
+]
+
+docs = [
+    "mkdocs-material>=9.7.6",
+    "mkdocstrings[python]>=0.28",
+    "mkdocs-llmstxt>=0.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Moves \`dev\` and \`docs\` out of \`[project.optional-dependencies]\` (extras shipped to PyPI consumers) into PEP 735 \`[dependency-groups]\` (tooling-only, never published). User-defined runtime extras stay in \`[project.optional-dependencies]\` via the existing \`PROJECT-EXTRAS-START/END\` sentinels.

Closes #81. Supersedes #80 (already closed) — \`--no-default-groups\` makes the missing-group hard-error structurally impossible.

## Migration mapping

| Before | After |
|---|---|
| \`uv sync --all-extras [--dev]\` | \`uv sync --all-extras --all-groups\` |
| \`uv sync --extra docs --frozen\` (docs build) | \`uv sync --no-default-groups --group docs --frozen\` |
| \`uv export --all-extras --no-extra dev --no-extra docs ...\` (audit) | \`uv export --all-extras --no-default-groups ...\` |

\`Dockerfile.jinja\` already uses \`--no-dev\` which uv aliases to \`--no-group dev\` under PEP 735 — no change needed.

## Files modified

- \`pyproject.toml.jinja\` — restructure
- \`.github/workflows/ci.yml.jinja\` — 3 sync calls + audit export
- \`.github/workflows/docs.yml.jinja\` — sync call
- \`.github/workflows/template-ci.yml\` — 2 sync calls + 1 step name
- \`README.md.jinja\`, \`docs/installation.md.jinja\` — sync calls
- \`README.md\`, \`CLAUDE.md\` (template-repo) — sync calls

## Note: overlap with #85

PR #85 (\`chore/bump-mkdocs-deps-add-llmstxt\`) edits the same \`docs = [...]\` block while it still lives under \`[project.optional-dependencies]\`. After #81 merges, that block has moved to \`[dependency-groups]\` — whichever PR merges second needs a manual rebase to re-apply the \`mkdocs-material>=9.7.6\` floor bump and \`mkdocs-llmstxt>=0.5\` addition to the new section. Trivial mechanical fix; calling out so the post-merge agent doesn't lose minutes diagnosing.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`.
- [x] \`uv sync --all-extras --all-groups\` installs runtime + dev + docs cleanly.
- [x] \`uv sync --no-default-groups --group docs --frozen\` installs docs-only environment; \`mkdocs build --strict\` succeeds.
- [x] \`uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes\` produces a requirements list with zero tooling packages (grep for \`pytest|ruff|mypy|mkdocs|pre-commit|diff-cover|pip-audit\` returns empty).
- [x] Full gate green: \`ruff check\`, \`ruff format --check\` (16 files), \`mypy src/ tests/\` (no issues), \`pytest -x -q\` (9 passed).
- [x] Local review circus clean (pr-review-toolkit + superpowers, both nothing flagged at any severity after fixing two stale-reference findings from round 1).
- [ ] template-ci.yml runs the full Python 3.11–3.14 matrix once landed.
- [ ] Downstream consumers must run \`uv lock\` after \`copier update\` accepts this change (the \`uv.lock refresh\` section in README.md.jinja already documents this for any dep change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)