### PR TITLE
feat(release): gate publish-linux-packages on !inputs.prerelease

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -221,7 +221,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && !inputs.prerelease
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary

Single-line edit on \`release.yml.jinja\` line 224. Adds the missing \`&& !inputs.prerelease\` gate on \`publish-linux-packages\` so a pre-release run no longer ships .deb/.rpm packages with the rc version into the same channel as stable releases.

Closes #77.

## Why this is a one-line change

Investigation found that **most** of the prerelease wiring is already in place in this template's \`release.yml.jinja\`:

- ✅ \`prerelease: boolean\` workflow_dispatch input (default \`true\`)
- ✅ \`prerelease: \${{ inputs.prerelease }}\` and \`prerelease_token: rc\` threaded to PSR
- ✅ \`publish-pypi\` gated on \`!inputs.prerelease\`
- ✅ \`publish-claude-plugin-pr\` (catalog bump PR) gated on \`!inputs.prerelease\`
- ✅ \`publish-registry\` (MCP Registry) gated on \`!inputs.prerelease\`
- ✅ Docker tags via \`docker/metadata-action\`'s \`enable=\` modifier (\`:latest\`/\`:vX.Y\`/\`:vX\` stable-only; \`:unstable\` rc-only)

The only missing piece per the issue body's acceptance was \`publish-linux-packages\`. This PR adds that gate.

## What stays ungated on rc (intentional)

- **Docker rc tag (\`vX.Y.Z-rc.N\`) and \`:unstable\`** — discrete, opt-in tags; ops pull a specific version.
- **\`build-mcpb\` / \`publish-mcpb\`** — bundle attaches to the GitHub release for the rc tag; .mcpb has no shared channel concept (operators install a specific file by version).

## Downstream rollout note

The same gate is missing in markdown-vault-mcp's release.yml (and likely the other two pvliesdonk downstream consumers — image-generation-mcp, scholar-mcp). This template fix means new template-generated projects get the correct gate; downstream rollouts will pick it up via \`copier update\`. May be worth filing tracker issues per downstream once this lands.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`. Rendered \`release.yml\` line 224 shows \`if: needs.release.outputs.released == 'true' && !inputs.prerelease\`.
- [x] Full gate green: ruff, mypy, pytest (9 passed).
- [x] Local review circus clean (pr-review-toolkit + superpowers, both nothing flagged at any severity). Both confirmed: scope is right (don't gate mcpb), inversion logic is sound, dependent-job chains hold, \`inputs.prerelease\` is always defined (\`workflow_dispatch\` is the only trigger).
- [ ] Tested at runtime — release-pipeline behavior is hard to dry-run; first downstream copier-update + release-dispatch will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)