### PR TITLE
feat(template): sentinel-protect recurring copier-update conflict zones

### DIFF
--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -37,12 +37,15 @@ theme:
 plugins:
   - search
   # Generates llms.txt + llms-full.txt for the README badge.
-  # Sections mirror `nav:` below — keep them aligned when customising.
+  # Sections mirror `nav:` below — keep them aligned when customising
+  # (both blocks are sentinel-protected so customise both as a unit).
   # `guides/*.md` and `deployment/*.md` use globs deliberately so new pages
   # in those directories are auto-indexed without a sections-list update.
   - llmstxt:
       full_output: llms-full.txt
       sections:
+        # PROJECT-LLMSTXT-SECTIONS-START — keep aligned with `nav:` below;
+        # kept across copier update.
         Getting Started:
           - index.md
           - installation.md
@@ -54,6 +57,7 @@ plugins:
           - prompts.md
         Deployment:
           - deployment/*.md
+        # PROJECT-LLMSTXT-SECTIONS-END
   - mkdocstrings:
       handlers:
         python:
@@ -86,6 +90,9 @@ markdown_extensions:
   - md_in_html
 
 nav:
+  # PROJECT-NAV-START — replace with your real navigation; kept across copier
+  # update. Keep aligned with the `llmstxt` plugin's sentinel-protected
+  # `sections:` block above.
   - Home: index.md
   - Getting Started:
       - Installation: installation.md
@@ -99,3 +106,4 @@ nav:
   - Deployment:
       - Docker: deployment/docker.md
       - OIDC Authentication: deployment/oidc.md
+  # PROJECT-NAV-END

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -78,6 +78,10 @@ ignore = ["E501"]
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002/TC003.
+# PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below
+# for your project's real source/test paths (split _server_apps.py into
+# per-domain modules, rename tests, add per-file overrides as needed); kept
+# across copier update.
 "src/{{ python_module }}/cli.py" = ["B008"]
 "src/{{ python_module }}/_server_deps.py" = ["B008", "TC002", "TC003"]
 "src/{{ python_module }}/_server_apps.py" = ["B008", "TC001", "TC002"]
@@ -87,7 +91,7 @@ ignore = ["E501"]
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]
 "tests/test_tools.py" = ["TC002"]
-# Add project-specific overrides below as needed.
+# PROJECT-RUFF-IGNORES-END
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ python_module }}"]

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -116,6 +116,12 @@ def make_server(
         # DOMAIN-UPSTREAM-END
     )
 
+    # DOMAIN-WIRING-START — project-specific wiring (custom HTTP routes,
+    # transforms, mode toggles, alternative middleware, additional registrations);
+    # kept across copier update. Leave empty for projects that don't customise
+    # make_server() beyond the standard scaffold.
+    # DOMAIN-WIRING-END
+
     # To publish files from a tool body, capture the returned handle
     # — see docs/guides/file-exchange.md for the module-level singleton
     # pattern (e.g. ``_file_exchange = register_file_exchange(...)``).


### PR DESCRIPTION
## Summary

Three template-owned files were producing conflict markers on **every** \`copier update\` because their content is highly project-specific but no sentinels delimited project-extensible regions:

1. **\`pyproject.toml.jinja\` \`[tool.ruff.lint.per-file-ignores]\`** — template ships placeholder paths; real projects rename and split files (image-generation-mcp: \`_server_tools.py\` / \`_server_resources.py\` / \`service.py\` / \`providers/*.py\` / etc.). Conflict every update.
2. **\`mkdocs.yml.jinja\` \`nav:\` AND the \`llmstxt\` plugin's \`sections:\`** — both ship sample defaults; real projects diverge entirely from both, and the two need to stay aligned.
3. **\`src/{python_module}/server.py.jinja\`** — projects add custom routes, transforms, mode toggles; no sentinel for project-specific wiring inside \`make_server()\`.

Adopts the **sentinel-based approach** from issue #83 (vs. the alternative thin-shim refactor):

- \`pyproject.toml.jinja\`: \`# PROJECT-RUFF-IGNORES-START\` / \`-END\` wraps **all** per-file-ignores entries (including \`cli.py\` / \`_server_deps.py\`) so downstream can replace, extend, or override the full set.
- \`mkdocs.yml.jinja\`: \`# PROJECT-NAV-START\` / \`-END\` AND \`# PROJECT-LLMSTXT-SECTIONS-START\` / \`-END\` — both sentinel-protected so downstream customises them as a unit (cross-reference comments in both blocks note the alignment requirement).
- \`src/{python_module}/server.py.jinja\`: \`# DOMAIN-WIRING-START\` / \`-END\` block between \`register_apps(mcp)\` and \`register_file_exchange(...)\` for project-specific wiring (custom routes, transforms, alternative middleware). Empty by default.

Closes #83.

## Downstream impact

First \`copier update\` after this lands brings the sentinel comments in. Projects with stable \`nav:\` / \`sections:\` / per-file-ignores customisation see those preserved automatically via the 3-way merge (their custom content sits where the new sentinel markers wrap). Projects with **inline server.py customisation** that predates the \`DOMAIN-WIRING\` block need a one-time relocation.

## Note: overlap with PR #89

PR #89 (\`feat(template): wire register_server_info_tool with upstream sentinel\`) also touches \`server.py.jinja\` in the same gap between \`register_apps\` and \`register_file_exchange\`. After both PRs land, the order will be:

\`\`\`
register_apps → register_server_info_tool(... DOMAIN-UPSTREAM ...) → DOMAIN-WIRING block → register_file_exchange
\`\`\`

Whichever lands second needs a trivial rebase to re-apply the new content in the post-#89 layout. Calling out so the post-merge agent doesn't lose minutes diagnosing.

## Out of scope (tracked separately)

The CLAUDE.md.jinja "Domain-only fix" enumeration line still says only \`DOMAIN-START\`/\`DOMAIN-END\` (template main) — it should generalise to \`DOMAIN-*\`, \`CONFIG-*\`, \`PROJECT-*\` to capture the new sentinel families. PR #89 already generalises to \`DOMAIN-*\` / \`CONFIG-*\`; a one-line follow-up after both PRs land can add \`PROJECT-*\`.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`.
- [x] Full gate green: \`ruff check\`, \`ruff format --check\` (16 files), \`mypy src/ tests/\` (no issues), \`pytest -x -q\` (9 passed).
- [x] \`mkdocs build --strict\` succeeds; \`site/llms.txt\` + \`site/llms-full.txt\` still produced.
- [x] Verified image-generation-mcp's current \`_server_deps.py\` per-file-ignores line matches template default — no immediate impact when wider sentinel scope picks them up.
- [x] Local review circus clean (pr-review-toolkit + superpowers, both rounds; round 1 caught \`sections:\` as next-conflict-zone + fragile carve-out; round 2 caught stale commit message after fixes; round 3 clean).
- [ ] template-ci.yml runs full Python 3.11–3.14 matrix once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)