### PR TITLE
docs(claude-md): enumerate Dockerfile sentinels as extension points

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -107,6 +107,15 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `{{ env_prefix }}_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+### Dockerfile extension points
+
+These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add domain-specific apt packages, uv extras, state subdirs, and volume mounts inside them:
+
+- `# DOCKERFILE-APT-DEPS-START` / `-END` — extra apt packages installed into the runtime image
+- `# DOCKERFILE-UV-EXTRAS-START` / `-END` — `--extra <name>` flags added to both `uv sync` invocations (deps cache layer + project install — adding only to one breaks the cache layer)
+- `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
+- `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
+
 ## Server Info Tool (`get_server_info`)
 
 `make_server()` registers `get_server_info` (via `fastmcp_pvl_core.register_server_info_tool`) so operators can answer "is the latest fix actually deployed?" with a single MCP call. The default response carries `server_name`, `server_version`, and `core_version`.


### PR DESCRIPTION
## Summary

Adds a 9-line \`### Dockerfile extension points\` subsection to \`CLAUDE.md.jinja\` under "Config & Customization Contract" enumerating the four \`# DOCKERFILE-*-START\` / \`-END\` sentinel pairs:

- \`DOCKERFILE-APT-DEPS\` — extra apt packages installed into the runtime image
- \`DOCKERFILE-UV-EXTRAS\` — \`--extra <name>\` flags appended to the final \`uv sync\`
- \`DOCKERFILE-STATE-DIRS\` — state subdirectories created under \`/data\`
- \`DOCKERFILE-VOLUMES\` — \`VOLUME\` declarations on the final image

Closes #47. The sentinels were referenced inline in \`Dockerfile.jinja\` itself but had no enumerated overview in the rendered CLAUDE.md — closes that prose gap.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`. Rendered CLAUDE.md shows the new subsection correctly.
- [x] Full gate green: \`ruff check\`, \`mypy src/ tests/\`, \`pytest -x -q\` (9 passed).
- [x] All 4 sentinel name references verified accurate against \`Dockerfile.jinja\` (line 3, 7, 16, 28, 38, 40, 49, 51).
- [x] Local review clean (pr-review-toolkit, nothing flagged at any severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)