### PR TITLE
docs(claude-md): include PROJECT-* in domain-only-fix enumeration

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -135,7 +135,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 
 - **Library-level fix** (anything you'd change in `fastmcp_pvl_core`): open a PR on `pvliesdonk/fastmcp-pvl-core`. After merge + release, bump `fastmcp-pvl-core` in this project's `pyproject.toml`. (Copier update alone won't pick it up unless the template's version constraint in `pyproject.toml.jinja` is also bumped.)
 - **Template-level fix** (anything template-owned — `Dockerfile`, workflows, `server.py` skeleton, `CLAUDE.md` sections): open a PR on `pvliesdonk/fastmcp-server-template`. After merge + release, this project gets the fix on the next weekly `copier update` cron (or dispatch the workflow manually).
-- **Domain-only fix** (anything inside a `DOMAIN-*` or `CONFIG-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
+- **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 


### PR DESCRIPTION
## Summary

One-line generalisation of the "Contributing fixes upstream" → "Domain-only fix" bullet in \`CLAUDE.md.jinja\`. Adds \`PROJECT-*\` to the previously-enumerated \`DOMAIN-*\` / \`CONFIG-*\` sentinel families so the new \`PROJECT-RUFF-IGNORES\` / \`PROJECT-NAV\` / \`PROJECT-LLMSTXT-SECTIONS\` sentinels (added in #91) are explicitly scoped as domain-only fixes.

Closes #92.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`. Rendered CLAUDE.md line reads as expected.
- [x] Full gate green: \`ruff check\`, \`mypy src/ tests/\`, \`pytest -x -q\` (10 passed).
- [x] Local review clean (pr-review-toolkit, nothing flagged at any severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)