### PR TITLE
fix(release): use pypi_name in publish-pypi environment URL

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/{{ project_name }}
+      url: https://pypi.org/p/{{ pypi_name }}
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Single-character template edit on \`.github/workflows/release.yml.jinja:106\`. The GitHub Environment URL on the \`publish-pypi\` job built from \`{{ project_name }}\` (repo basename) instead of \`{{ pypi_name }}\` (PyPI distribution name). When a project sets \`pypi_name != project_name\` (e.g. \`pvliesdonk-reqeng-mcp\` PyPI name for a \`reqeng-mcp\` repo to avoid squatting collisions), the env-page link from the GitHub Actions UI 404'd.

Closes #90.

## Cosmetic, not functional

PyPI Trusted Publisher matching uses the OIDC claim's repository+workflow+environment triple plus the distribution name read from the wheel metadata. The publish itself succeeds either way — only the click-through link from the Actions UI was broken.

Other \`{{ project_name }}\` references in the same file (OCI image label, MCP server name, deb/rpm/mcpb package basenames, repo URL) intentionally left unchanged — they want the repo basename, not the distribution name.

## Test plan

- [x] Render with smoke-answers (\`pypi_name == project_name == "smoke-mcp"\`) → URL renders as \`https://pypi.org/p/smoke-mcp\` (unchanged for that case).
- [x] Render with divergent fixture (\`project_name=reqeng-mcp\`, \`pypi_name=pvliesdonk-reqeng-mcp\`) → URL renders as \`https://pypi.org/p/pvliesdonk-reqeng-mcp\` (the bug-fix scenario).
- [x] Full gate green on smoke render: ruff, mypy, pytest (10 passed).
- [x] Local review clean (pr-review-toolkit, nothing flagged at any severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)