### PR TITLE
feat(scaffold): commented Lucide-icon registration in tools.py + static/icons/

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -107,6 +107,10 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `{{ env_prefix }}_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+### Tool icons
+
+Drop SVG / PNG / ICO / JPEG files into `src/{{ python_module }}/static/icons/` and bulk-attach them to registered tools via `fastmcp_pvl_core.register_tool_icons(mcp, {"tool_name": "filename.svg"}, static_dir=...)` at the end of `register_tools()` — or attach at decoration time with `@mcp.tool(icons=[make_icon(STATIC / "x.svg")])` (where `STATIC = Path(__file__).parent / "static" / "icons"` is a shorthand you define at module level). The scaffold ships an empty `static/icons/` directory; commented-out wiring lives in `tools.py`.
+
 ### Dockerfile extension points
 
 These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add domain-specific apt packages, uv extras, state subdirs, and volume mounts inside them:

--- a/src/{{python_module}}/tools.py.jinja
+++ b/src/{{python_module}}/tools.py.jinja
@@ -31,3 +31,21 @@ def register_tools(mcp: FastMCP) -> None:
         https://gofastmcp.com/servers/tools#async-tools for async + DI.
         """
         return await service.ping()
+
+    # Optional: attach Lucide-compatible SVG/PNG/ICO/JPEG icons to tools.
+    # Drop files into src/{{ python_module }}/static/icons/, lift the imports
+    # and the STATIC constant to module level, and pick one of the patterns
+    # below.
+    #
+    # (At module level, above this function:)
+    # from pathlib import Path
+    # from fastmcp_pvl_core import make_icon, register_tool_icons
+    # STATIC = Path(__file__).parent / "static" / "icons"
+    #
+    # Bulk (call here at the end of register_tools, after all @mcp.tool defs;
+    # rename the mapping to your tool→file pairs):
+    # register_tool_icons(mcp, {"ping": "ping.svg"}, static_dir=STATIC)
+    #
+    # Per-tool decoration (replace the @mcp.tool line above; preserve the
+    # existing annotations to avoid losing readOnlyHint / etc.):
+    # @mcp.tool(icons=[make_icon(STATIC / "ping.svg")], annotations={"readOnlyHint": True})


### PR DESCRIPTION
## Summary

Pure scaffolding addition — no behavioural change unless the project opts in. Closes #71.

\`fastmcp-pvl-core 1.2.0\` ships \`register_tool_icons(mcp, mapping, *, static_dir)\` and \`make_icon(path, *, sizes=None) -> Icon\` for attaching SVG/PNG/ICO/JPEG icons to FastMCP tools. This PR scaffolds the convention so generated projects can opt in without inventing the layout each time:

- Empty \`src/{python_module}/static/icons/.gitkeep\` ships the directory in fresh clones.
- Commented-out example at the end of \`register_tools()\` in \`tools.py.jinja\` showing both the bulk path (\`register_tool_icons\`) and the per-tool decoration path (\`make_icon\`). Imports lifted into a single "(At module level, above this function:)" block so either pattern works when uncommented in isolation.
- One-paragraph "Tool icons" subsection in \`CLAUDE.md.jinja\` under "Config & Customization Contract".

## Why this scope

\`tools.py\` is in \`_skip_if_exists\`, so the example only ships in fresh scaffolds (existing projects don't get a re-rendered \`tools.py\` over their edits). \`CLAUDE.md.jinja\` is template-owned and re-renders on \`copier update\`, so existing consumers learn the convention via the propagating CLAUDE.md note and apply it manually using their existing \`tools.py\`.

## Test plan

- [x] Render template with \`--vcs-ref=HEAD\` against \`tests/fixtures/smoke-answers.yml\`. Rendered project ships \`src/smoke_mcp/static/icons/.gitkeep\`.
- [x] Full gate green: \`ruff check\`, \`mypy src/ tests/\`, \`pytest -x -q\` (10 passed).
- [x] **Empirically verified the example works when uncommented**: dropped a minimal \`ping.svg\` into the rendered project's static/icons/, ran \`register_tool_icons(server, {"ping": "ping.svg"}, static_dir=...)\` against \`make_server()\` — succeeded. \`make_icon(path)\` returned an \`Icon\` instance. (Per the \`feedback_subagent_diff_only_review.md\` calibration memory — local reviewers reason from the diff; verifying API behavior empirically catches the kind of mistake that the \`CurrentContext()\` round caught at bot review last week.)
- [x] Local circus: 2 rounds. Round 1 caught a real \`Path\` import gap in the decoration block (would have NameError'd on partial uncomment) — restructured to lift imports out. Round 2 clean both reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)