### PR TITLE
fix(release): bump mcp-publisher to v1.7.6 for new OIDC audience

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -405,8 +405,13 @@ jobs:
 
       - name: Install mcp-publisher
         env:
-          MCP_PUBLISHER_VERSION: v1.5.0
-          MCP_PUBLISHER_SHA256: 79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5
+          # v1.7.x is the first that requests the per-deployment OIDC audience
+          # the registry now requires (PR modelcontextprotocol/registry#1229,
+          # merged 2026-04-30 — production registry expects audience
+          # `https://registry.modelcontextprotocol.io`; v1.5.0 still requests
+          # `mcp-registry` and fails token exchange with HTTP 401).
+          MCP_PUBLISHER_VERSION: v1.7.6
+          MCP_PUBLISHER_SHA256: bcc96ca630cae4cf503b4550bd4a17462d42ad4819273bee56f4385bb059ddee
         run: |
           curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" -o mcp-publisher.tar.gz
           echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c


### PR DESCRIPTION
Closes #101

## Summary

Bumps `mcp-publisher` from v1.5.0 → v1.7.6 in `release.yml.jinja` so generated projects' `publish-registry` job authenticates correctly against the MCP Registry's tightened OIDC audience validation ([modelcontextprotocol/registry#1229](https://github.com/modelcontextprotocol/registry/pull/1229), merged 2026-04-30).

v1.5.0 requests OIDC audience `mcp-registry`; v1.7.x requests `https://registry.modelcontextprotocol.io`, which is what production now expects. The mismatch surfaces as HTTP 401 in the `Authenticate to MCP Registry` step and was first hit in markdown-vault-mcp's v1.28.0 release.

## My review

This is a constants-only change (version + SHA-256) with a comment explaining why for future maintainers. The SHA-256 was verified by downloading the v1.7.6 tarball locally and running `sha256sum`. No publish-time behavior change in the v1.6/v1.7 changelogs that would affect generated projects' `server.json` shape — the listed publisher changes (`mcpName as authoritative server name in init`, `copy version from package.json`) are interactive `init`-time, not the `publish` path the workflow uses.

## Downstream

Every generated project (markdown-vault-mcp, image-generation-mcp, scholar-mcp, …) needs a `copier update` to pick up the bumped pin before its next release. The weekly `copier-update.yml` cron will handle most of them automatically; markdown-vault-mcp is currently blocked on this and will need a manual dispatch as soon as this lands + a template release goes out.

## Test plan

- [x] Pre-commit clean on the changed file (yaml/whitespace/eof).
- [x] SHA-256 verified against the upstream tarball.
- [ ] CI green (claude-review on push, gemini auto-review on flip-to-ready).
- [ ] After merge + template release, dispatch `copier-update` on a downstream project (markdown-vault-mcp) to verify the pin propagates and the next release succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)