### PR TITLE
docs(claude-md): add bot-reviewer-as-gate paragraph (#107)

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -52,6 +52,8 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+
 ## GitHub Review Types
 
 GitHub has two distinct review mechanisms — **both must be read and addressed**:


### PR DESCRIPTION
## Summary

Adds one paragraph to the `## PR Discipline` section of `CLAUDE.md.jinja` (rendered into generated projects' `CLAUDE.md`) restating that bot reviewers (`claude-review`, `gemini-code-assist`) are merge gates, not pair reviewers, and that local code-review must converge before `gh pr create`.

Defense-in-depth — the operator's global CLAUDE.md already has a stricter version of this rule, but downstream agents reasoning project-locally (because the project CLAUDE.md is what the system prompt's `claudeMd` block surfaces most prominently) were treating the project policy as the canonical operational checklist and missing the global's stricter requirements.

## Phrasing note

The issue body proposed wording that included the operator-jargon parenthetical "(subagent reviewers on the cumulative diff)". Local second-opinion review flagged this as relying on operator-specific tooling vocabulary that downstream agents wouldn't have. Replaced with "Run a local code-review pass on the cumulative diff" — keeps the issue body's stated "intentionally vague on which exact subagents — that's the operator's choice" intent while staying portable.

## Verification

```
$ rm -rf /tmp/smoke-107
$ uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-107
$ grep -A 1 'Bot reviewers' /tmp/smoke-107/CLAUDE.md
**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review converges before the PR opens. ...
```

## Test plan

- [x] Renders cleanly into generated `CLAUDE.md` between "Trivial exceptions" line and `## GitHub Review Types` header.
- [x] Local review (two reviewers, two different prompt templates) returned clean on the final diff.
- [ ] claude-review LGTM on first pass.
- [ ] gemini-code-assist LGTM on flip-to-ready.

Closes #107