### PR TITLE
feat(docs): extend sentinel-protection to remaining docs/ files (#106)

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -60,7 +60,12 @@ _skip_if_exists:
 # those changes get re-applied.  The DOMAIN markers and the
 # ===== TEMPLATE-OWNED ===== banner comments are a human/agent convention
 # — copier itself doesn't act on them.  README.md was moved out of
-# _skip_if_exists in #57.
+# _skip_if_exists in #57.  The same hybrid pattern applies to
+# docs/*.md.jinja files: docs/deployment/* and docs/guides/authentication.md
+# moved out in #29 (PR #108); the remaining top-level docs/*.md files
+# (index, installation, configuration, tools/index, prompts) moved out in #106.
+# Those docs files use topic-specific DOMAIN-{TOPIC}-{KIND} sentinels
+# rather than the bare DOMAIN-START used in CLAUDE.md / README.md.
 
 # Files in the template repo that should never land in generated projects.
 # Setting _exclude in copier.yml REPLACES copier's default exclude list

--- a/copier.yml
+++ b/copier.yml
@@ -41,16 +41,6 @@ _skip_if_exists:
   - "packaging/mcpb/build.sh"
   - "scripts/bump_manifests.py"
   - ".gitignore"
-  # mkdocs nav pages — rendered as starter content on first copy so a fresh
-  # project's `mkdocs build --strict` passes.  Projects that customise these
-  # keep their edits across `copier update`.  Moved here from `_exclude` in
-  # #56 because the shipped mkdocs.yml references them; excluding them
-  # unconditionally broke the docs workflow out of the box.
-  - "docs/index.md"
-  - "docs/installation.md"
-  - "docs/configuration.md"
-  - "docs/tools/index.md"
-  - "docs/prompts.md"
   # nfpm env template — users customise with domain-specific env vars; installs
   # to /etc/{project}/env.example with config|noreplace so operators copy it to
   # /etc/{project}/env locally anyway, but keep the source customisation across

--- a/docs/configuration.md.jinja
+++ b/docs/configuration.md.jinja
@@ -34,6 +34,8 @@ shared by every co-deployed server:
 | `MCP_EXCHANGE_ID` | persisted in `.exchange-id` | Optional explicit exchange-group identifier; first server to start writes a UUID into `${MCP_EXCHANGE_DIR}/.exchange-id`, subsequent starts must agree. |
 | `MCP_EXCHANGE_NAMESPACE` | the server's `namespace=` argument | Override the namespace used in `exchange://` URIs for this process. |
 
+<!-- DOMAIN-CONFIG-VARS-START -->
 ## Domain variables
 
 Document your project-specific variables here.
+<!-- DOMAIN-CONFIG-VARS-END -->

--- a/docs/index.md.jinja
+++ b/docs/index.md.jinja
@@ -7,3 +7,15 @@
 - [Installation](installation.md)
 - [Configuration](configuration.md)
 - [Tools](tools/index.md)
+
+<!-- DOMAIN-INDEX-FEATURES-START -->
+## Features
+
+- _Add features specific to your server here._
+<!-- DOMAIN-INDEX-FEATURES-END -->
+
+<!-- DOMAIN-INDEX-USE-CASES-START -->
+## What you can do
+
+- _Add usage examples here._
+<!-- DOMAIN-INDEX-USE-CASES-END -->

--- a/docs/installation.md.jinja
+++ b/docs/installation.md.jinja
@@ -19,3 +19,12 @@ git clone https://github.com/{{ github_org }}/{{ project_name }}
 cd {{ project_name }}
 uv sync --all-extras --all-groups
 ```
+
+<!-- DOMAIN-INSTALL-EXTRA-START -->
+
+## Project-specific notes
+
+_Add domain-specific install notes here, e.g. system dependencies, optional
+extras, or custom configuration steps._
+
+<!-- DOMAIN-INSTALL-EXTRA-END -->

--- a/docs/prompts.md.jinja
+++ b/docs/prompts.md.jinja
@@ -4,12 +4,6 @@ MCP prompts are reusable prompt templates exposed to clients. The scaffold
 ships a minimal set defined in `src/{{ python_module }}/prompts.py`; add
 domain-specific prompts there and document them in this page.
 
-## Built-in prompts
-
-_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
-`src/{{ python_module }}/prompts.py` and list them here with their arguments,
-usage, and example output.
-
 ## Example
 
 ```python
@@ -21,3 +15,11 @@ def summarize(topic: str) -> str:
 
 See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
 for the full prompt API.
+
+<!-- DOMAIN-PROMPTS-LIST-START -->
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/{{ python_module }}/prompts.py` and list them here with their arguments,
+usage, and example output.
+<!-- DOMAIN-PROMPTS-LIST-END -->

--- a/docs/superpowers/plans/2026-05-07-docs-sentinel-extend.md
+++ b/docs/superpowers/plans/2026-05-07-docs-sentinel-extend.md
@@ -1,0 +1,498 @@
+# Docs sentinel-extend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the 5 remaining `docs/` files out of `_skip_if_exists` and add per-file `<!-- DOMAIN-{TOPIC}-{KIND}-START/END -->` sentinel blocks so future template improvements flow to downstream consumers via `copier update` while their domain-specific content survives.
+
+**Architecture:** Six independent edits in a single PR — five `.jinja` files each get a sentinel block (mid-file for `index.md.jinja`, end-of-file for the others), and `copier.yml` loses the five `_skip_if_exists` entries. Tasks 1-5 can be done in any order; Task 6 must be last because dropping `_skip_if_exists` is meaningless until the sentinels are in place to receive operator content.
+
+**Tech Stack:** `copier` (template renderer), `mkdocs-material` + `mkdocs-llmstxt` (docs site, validated via `mkdocs build --strict`), HTML comments inside Markdown for sentinel markers (matches established convention in `CLAUDE.md.jinja`, `README.md.jinja`, and #29's `docs/deployment/*` and `docs/guides/*`).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-docs-sentinel-extend-design.md`
+
+**Branch:** `feat/docs-sentinel-extend` (already created and tracking `origin/main`; spec already committed).
+
+---
+
+## File Map
+
+| File | Created/Modified | Responsibility |
+|------|-----------------|---------------|
+| `copier.yml` | Modified | Drop 5 lines from `_skip_if_exists` (Task 6) |
+| `docs/index.md.jinja` | Modified | Add 2 DOMAIN blocks for Features + Use cases (Task 1) |
+| `docs/installation.md.jinja` | Modified | Append `DOMAIN-INSTALL-EXTRA` block (Task 2) |
+| `docs/configuration.md.jinja` | Modified | Wrap existing `## Domain variables` in `DOMAIN-CONFIG-VARS` (Task 3) |
+| `docs/tools/index.md.jinja` | Modified | Replace placeholder with framing + `DOMAIN-TOOLS-LIST` block (Task 4) |
+| `docs/prompts.md.jinja` | Modified | Reorder Example before catalog + wrap "Built-in prompts" in `DOMAIN-PROMPTS-LIST` (Task 5) |
+
+No new files. All changes are within the template repo; downstream consumers receive the changes via `copier update`.
+
+---
+
+## Verification Pattern (used in every task)
+
+Each task follows the same verification pattern: render the template, grep for the new sentinel, spot-check the rendered output. The smoke-render command is:
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+```
+
+The `--vcs-ref=HEAD` flag is required so copier renders from the latest commit (default is the latest tag, which doesn't include the unreleased changes). All edits must be committed before the smoke render reflects them.
+
+---
+
+## Task 1: Add DOMAIN blocks to `docs/index.md.jinja`
+
+**Files:**
+- Modify: `docs/index.md.jinja`
+
+- [ ] **Step 1: Verify the sentinels are NOT yet in the rendered file**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-INDEX-FEATURES" /tmp/smoke-106/docs/index.md || true
+```
+Expected: `0` (sentinel does not yet exist).
+
+- [ ] **Step 2: Replace the file content**
+
+Replace the entire content of `docs/index.md.jinja` with:
+
+```markdown
+# {{ human_name }}
+
+{{ domain_description }}
+
+## Getting started
+
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Tools](tools/index.md)
+
+<!-- DOMAIN-INDEX-FEATURES-START -->
+## Features
+
+- _Add features specific to your server here._
+<!-- DOMAIN-INDEX-FEATURES-END -->
+
+<!-- DOMAIN-INDEX-USE-CASES-START -->
+## What you can do
+
+- _Add usage examples here._
+<!-- DOMAIN-INDEX-USE-CASES-END -->
+```
+
+- [ ] **Step 3: Commit so smoke render picks up the change**
+
+```bash
+git add docs/index.md.jinja
+git commit -m "feat(docs): add DOMAIN-INDEX blocks to index.md.jinja (#106)"
+```
+
+- [ ] **Step 4: Re-render and verify both sentinels appear**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-INDEX-FEATURES-START" /tmp/smoke-106/docs/index.md
+grep -c "DOMAIN-INDEX-FEATURES-END" /tmp/smoke-106/docs/index.md
+grep -c "DOMAIN-INDEX-USE-CASES-START" /tmp/smoke-106/docs/index.md
+grep -c "DOMAIN-INDEX-USE-CASES-END" /tmp/smoke-106/docs/index.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 5: Spot-check rendered output**
+
+```bash
+cat /tmp/smoke-106/docs/index.md
+```
+Expected: title from `human_name` answer, description from `domain_description` answer, then `## Getting started` link list, then the two DOMAIN blocks each containing the placeholder bullet.
+
+---
+
+## Task 2: Add `DOMAIN-INSTALL-EXTRA` block to `docs/installation.md.jinja`
+
+**Files:**
+- Modify: `docs/installation.md.jinja`
+
+- [ ] **Step 1: Verify the sentinel is NOT yet in the rendered file**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-INSTALL-EXTRA" /tmp/smoke-106/docs/installation.md || true
+```
+Expected: `0`.
+
+- [ ] **Step 2: Append the block to the existing file**
+
+Append the following to `docs/installation.md.jinja` (preserve the existing content; add a blank line first to separate from the preceding `## From source` section):
+
+```markdown
+
+<!-- DOMAIN-INSTALL-EXTRA-START -->
+
+## Project-specific notes
+
+_Add domain-specific install notes here, e.g. system dependencies, optional
+extras, or custom configuration steps._
+
+<!-- DOMAIN-INSTALL-EXTRA-END -->
+```
+
+The blank line BEFORE `<!-- DOMAIN-INSTALL-EXTRA-START -->` is required to separate it from the preceding section. The blank lines INSIDE the block (above and below the heading and paragraph) make the rendered output read cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/installation.md.jinja
+git commit -m "feat(docs): add DOMAIN-INSTALL-EXTRA block to installation.md.jinja (#106)"
+```
+
+- [ ] **Step 4: Re-render and verify the sentinel appears**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-INSTALL-EXTRA-START" /tmp/smoke-106/docs/installation.md
+grep -c "DOMAIN-INSTALL-EXTRA-END" /tmp/smoke-106/docs/installation.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 5: Spot-check rendered output**
+
+```bash
+tail -15 /tmp/smoke-106/docs/installation.md
+```
+Expected: ends with the DOMAIN-INSTALL-EXTRA block, with the `## Project-specific notes` heading visible inside.
+
+---
+
+## Task 3: Wrap `## Domain variables` in `DOMAIN-CONFIG-VARS` in `docs/configuration.md.jinja`
+
+**Files:**
+- Modify: `docs/configuration.md.jinja:37-39` (the existing `## Domain variables` section at end of file)
+
+- [ ] **Step 1: Verify the sentinel is NOT yet in the rendered file**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-CONFIG-VARS" /tmp/smoke-106/docs/configuration.md || true
+```
+Expected: `0`.
+
+- [ ] **Step 2: Wrap the existing `## Domain variables` section**
+
+Replace the last 3 lines of `docs/configuration.md.jinja`:
+
+```markdown
+## Domain variables
+
+Document your project-specific variables here.
+```
+
+With:
+
+```markdown
+<!-- DOMAIN-CONFIG-VARS-START -->
+## Domain variables
+
+Document your project-specific variables here.
+<!-- DOMAIN-CONFIG-VARS-END -->
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/configuration.md.jinja
+git commit -m "feat(docs): wrap Domain variables section in DOMAIN-CONFIG-VARS sentinels (#106)"
+```
+
+- [ ] **Step 4: Re-render and verify the sentinel appears**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-CONFIG-VARS-START" /tmp/smoke-106/docs/configuration.md
+grep -c "DOMAIN-CONFIG-VARS-END" /tmp/smoke-106/docs/configuration.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 5: Spot-check rendered output**
+
+```bash
+tail -10 /tmp/smoke-106/docs/configuration.md
+```
+Expected: ends with the wrapped `## Domain variables` section inside the sentinels, preceded by the unchanged "MCP File Exchange" table.
+
+---
+
+## Task 4: Replace placeholder body in `docs/tools/index.md.jinja` with framing + `DOMAIN-TOOLS-LIST` block
+
+**Files:**
+- Modify: `docs/tools/index.md.jinja`
+
+- [ ] **Step 1: Verify the sentinel is NOT yet in the rendered file**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-TOOLS-LIST" /tmp/smoke-106/docs/tools/index.md || true
+```
+Expected: `0`.
+
+- [ ] **Step 2: Replace the entire file content**
+
+Replace the content of `docs/tools/index.md.jinja` with:
+
+```markdown
+# Tools
+
+The tools registered in this server are listed below. See the
+[FastMCP tools documentation](https://gofastmcp.com/servers/tools)
+for the full tool API.
+
+<!-- DOMAIN-TOOLS-LIST-START -->
+## ping
+
+Health-check tool — returns `"pong"` if the service is alive.
+Replace with real tools per the scaffold in
+`src/{{ python_module }}/tools.py`.
+<!-- DOMAIN-TOOLS-LIST-END -->
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/tools/index.md.jinja
+git commit -m "feat(docs): add framing + DOMAIN-TOOLS-LIST to tools/index.md.jinja (#106)"
+```
+
+- [ ] **Step 4: Re-render and verify the sentinel appears**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-TOOLS-LIST-START" /tmp/smoke-106/docs/tools/index.md
+grep -c "DOMAIN-TOOLS-LIST-END" /tmp/smoke-106/docs/tools/index.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 5: Spot-check rendered output**
+
+```bash
+cat /tmp/smoke-106/docs/tools/index.md
+```
+Expected: `# Tools` header, intro paragraph with FastMCP-docs link, then the DOMAIN-TOOLS-LIST block containing the `ping` example with `{{ python_module }}` resolved to the smoke fixture's value.
+
+---
+
+## Task 5: Reorder + add `DOMAIN-PROMPTS-LIST` block to `docs/prompts.md.jinja`
+
+**Files:**
+- Modify: `docs/prompts.md.jinja`
+
+- [ ] **Step 1: Verify the sentinel is NOT yet in the rendered file**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-PROMPTS-LIST" /tmp/smoke-106/docs/prompts.md || true
+```
+Expected: `0`.
+
+- [ ] **Step 2: Replace the entire file content**
+
+Replace the content of `docs/prompts.md.jinja` with (note the reorder: framing → Example → FastMCP link → DOMAIN-PROMPTS-LIST block, where the catalog moves to the end):
+
+```markdown
+# Prompts
+
+MCP prompts are reusable prompt templates exposed to clients. The scaffold
+ships a minimal set defined in `src/{{ python_module }}/prompts.py`; add
+domain-specific prompts there and document them in this page.
+
+## Example
+
+```python
+@mcp.prompt()
+def summarize(topic: str) -> str:
+    """Summarize the given topic in three sentences."""
+    return f"Write a three-sentence summary of: {topic}"
+```
+
+See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
+for the full prompt API.
+
+<!-- DOMAIN-PROMPTS-LIST-START -->
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/{{ python_module }}/prompts.py` and list them here with their arguments,
+usage, and example output.
+<!-- DOMAIN-PROMPTS-LIST-END -->
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/prompts.md.jinja
+git commit -m "feat(docs): reorder + add DOMAIN-PROMPTS-LIST to prompts.md.jinja (#106)"
+```
+
+- [ ] **Step 4: Re-render and verify the sentinel appears**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+grep -c "DOMAIN-PROMPTS-LIST-START" /tmp/smoke-106/docs/prompts.md
+grep -c "DOMAIN-PROMPTS-LIST-END" /tmp/smoke-106/docs/prompts.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 5: Spot-check rendered output**
+
+```bash
+cat /tmp/smoke-106/docs/prompts.md
+```
+Expected: `# Prompts` header, framing paragraph, `## Example` with the Python code block, FastMCP-docs link line, then the DOMAIN-PROMPTS-LIST block containing `## Built-in prompts`. Verify the Example block sits BEFORE the catalog (reorder applied correctly).
+
+---
+
+## Task 6: Drop the 5 `docs/*.md` entries from `copier.yml`'s `_skip_if_exists` and run the full gate
+
+**Files:**
+- Modify: `copier.yml:49-53` (the 5 `docs/*.md` entries inside `_skip_if_exists`)
+
+- [ ] **Step 1: Confirm the 5 lines are present in the current `_skip_if_exists`**
+
+```bash
+sed -n '27,60p' copier.yml | grep -E '"docs/(index|installation|configuration|tools/index|prompts)\.md"'
+```
+Expected: 5 matching lines listed in this order:
+
+```
+  - "docs/index.md"
+  - "docs/installation.md"
+  - "docs/configuration.md"
+  - "docs/tools/index.md"
+  - "docs/prompts.md"
+```
+
+- [ ] **Step 2: Remove the 5 lines from `_skip_if_exists`**
+
+Apply this exact diff to `copier.yml` (the surrounding context is the existing `_skip_if_exists` list):
+
+```diff
+@@ around line 49 @@
+   - "docs/superpowers"
+-  - "docs/index.md"
+-  - "docs/installation.md"
+-  - "docs/configuration.md"
+-  - "docs/tools/index.md"
+-  - "docs/prompts.md"
+   - "docs/design.md"
+```
+
+(The exact line numbers and surrounding context may differ slightly — what matters is that the 5 `docs/*.md` lines listed above are deleted and no other lines in `_skip_if_exists` are touched.)
+
+- [ ] **Step 3: Verify the 5 lines are gone**
+
+```bash
+grep -E '"docs/(index|installation|configuration|tools/index|prompts)\.md"' copier.yml
+```
+Expected: no output (the 5 lines no longer appear anywhere in `copier.yml`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add copier.yml
+git commit -m "feat(template): drop docs/*.md entries from _skip_if_exists (#106)"
+```
+
+- [ ] **Step 5: Final smoke render and verify all 6 new sentinels are present**
+
+```bash
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+
+# All 6 new sentinels must be present:
+grep -c "DOMAIN-INDEX-FEATURES-START" /tmp/smoke-106/docs/index.md
+grep -c "DOMAIN-INDEX-USE-CASES-START" /tmp/smoke-106/docs/index.md
+grep -c "DOMAIN-INSTALL-EXTRA-START" /tmp/smoke-106/docs/installation.md
+grep -c "DOMAIN-CONFIG-VARS-START" /tmp/smoke-106/docs/configuration.md
+grep -c "DOMAIN-TOOLS-LIST-START" /tmp/smoke-106/docs/tools/index.md
+grep -c "DOMAIN-PROMPTS-LIST-START" /tmp/smoke-106/docs/prompts.md
+```
+Expected: each grep returns `1`.
+
+- [ ] **Step 6: Run the full generated-project gate inside the smoke render**
+
+```bash
+cd /tmp/smoke-106
+uv sync --all-extras --all-groups
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy src/ tests/
+uv run pytest -x -q
+uv run mkdocs build --strict
+cd -
+```
+Expected: all six commands exit `0`. The mkdocs build is the one that exercises the new docs files; if any of the new sentinel comments break Markdown parsing or break a link, `mkdocs build --strict` will fail.
+
+- [ ] **Step 7: Verify the rendered docs site renders the new domain sections cleanly**
+
+```bash
+ls /tmp/smoke-106/site/docs/
+ls /tmp/smoke-106/site/installation/
+ls /tmp/smoke-106/site/configuration/
+ls /tmp/smoke-106/site/tools/
+ls /tmp/smoke-106/site/prompts/
+```
+Expected: each directory contains an `index.html`. Optionally open one of them and verify the operator-owned sections render as expected (HTML comments are stripped from the output but the contained content appears).
+
+---
+
+## After Task 6
+
+The branch is ready for the local code-review circus and PR open. Per the global PR Discipline rules:
+
+1. **Run two local code-reviewer subagents** in parallel on the cumulative diff (one with `pr-review-toolkit:code-reviewer`, one with `feature-dev:code-reviewer` for the second-opinion pass). Pass them the diff `git diff origin/main...HEAD` and instruct them to read full file context, not just the hunks.
+2. **Address every flagged finding** at any severity (or defend in writing if the reviewer is wrong) before pushing.
+3. **Push as draft**: `git push -u origin feat/docs-sentinel-extend` then `gh pr create --draft --title "feat(docs): extend sentinel-protection to remaining docs/ files (#106)" --body "<from spec>"`.
+4. Wait for `claude-review` (always runs) to LGTM. If anything found, address → re-run BOTH local subagents → push.
+5. `gh pr ready <N>` to flip to ready, which triggers `gemini-code-assist`.
+6. Wait for `gemini-code-assist` LGTM (HIGH severity threshold per `.gemini/config.yaml`).
+7. Surface the merged-PR link to the user; do NOT run `gh pr merge` autonomously.
+
+The PR description should include the expected per-downstream conflict shape from the spec's Migration story so the user (or the agent doing copier-update review) knows what "good" looks like during the next downstream `copier update`.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Goal (5 files out of `_skip_if_exists` + sentinel blocks added) — covered by Tasks 1-6.
+- Per-file designs (5 files, exact content) — covered by Tasks 1-5; each task includes the verbatim file content from the spec.
+- Sentinel naming convention table — sentinel names in tasks match the spec's table exactly: `DOMAIN-INDEX-FEATURES`, `DOMAIN-INDEX-USE-CASES`, `DOMAIN-INSTALL-EXTRA`, `DOMAIN-CONFIG-VARS`, `DOMAIN-TOOLS-LIST`, `DOMAIN-PROMPTS-LIST`.
+- Migration story — referenced in "After Task 6" for inclusion in PR description; the implementation itself doesn't touch downstreams.
+- Verification commands (spec section "Verification") — Tasks 1-5 cover per-file grep verification; Task 6 covers the full-suite verification + mkdocs build.
+
+**Placeholder scan:** No "TBD"/"TODO"/"implement later" strings in the plan. The `_Add features here_` markers in Task 1's Step 2 file content are intentional — they ship as placeholder content in the rendered template, not plan placeholders.
+
+**Type/name consistency:** Sentinel names used identically across all task references (verified by re-reading each task's grep + edit steps). The branch name `feat/docs-sentinel-extend` is consistent with what's already created. The smoke-render directory `/tmp/smoke-106` is consistent across tasks.

--- a/docs/superpowers/specs/2026-05-07-docs-sentinel-extend-design.md
+++ b/docs/superpowers/specs/2026-05-07-docs-sentinel-extend-design.md
@@ -1,0 +1,240 @@
+# Extend sentinel-protection to remaining `docs/` files
+
+**Date:** 2026-05-07
+**Tracks:** [#106](https://github.com/pvliesdonk/fastmcp-server-template/issues/106)
+**Builds on:** [#29 / PR #108](https://github.com/pvliesdonk/fastmcp-server-template/issues/29) — sentinel-protected `docs/deployment/*` and `docs/guides/authentication.md`
+
+## Goal
+
+Move the remaining five `docs/` files out of `_skip_if_exists` and add per-file `<!-- DOMAIN-{TOPIC}-{KIND}-START/END -->` sentinel blocks so future template improvements (link updates, new framing paragraphs, new shared sections) flow to downstream consumers via `copier update` while their domain-specific content survives.
+
+The five files:
+
+- `docs/index.md` — landing page
+- `docs/installation.md` — install instructions
+- `docs/configuration.md` — env vars / config
+- `docs/tools/index.md` — tool catalog
+- `docs/prompts.md` — prompt catalog
+
+After this change, `_skip_if_exists` no longer contains any `docs/*.md` entries — the docs tree becomes fully template-owned with sentinel-protected domain zones.
+
+## Architecture
+
+Two-part atomic change in a single PR:
+
+1. **Drop five lines** from `copier.yml`'s `_skip_if_exists`:
+
+   ```diff
+   -  - "docs/index.md"
+   -  - "docs/installation.md"
+   -  - "docs/configuration.md"
+   -  - "docs/tools/index.md"
+   -  - "docs/prompts.md"
+   ```
+
+2. **Add `<!-- DOMAIN-{TOPIC}-{KIND}-START/END -->` sentinel blocks** to each of the five `.jinja` files at the natural per-file shape (see "Per-file designs" below).
+
+Sentinel naming follows the topic-specific family established by #29 (`DOMAIN-DOCKER-EXTRA`, `DOMAIN-OIDC-EXTRA`, `DOMAIN-AUTH-EXTRA`). Bare anonymous `<!-- DOMAIN-START -->` (used in README.md.jinja and CLAUDE.md.jinja) is **not** used here — every block on every file is greppable by topic.
+
+## Tech Stack
+
+- `copier` (template renderer, reads `copier.yml`)
+- `mkdocs-material` + `mkdocs-llmstxt` (docs site, validated via `mkdocs build --strict` in `template-ci.yml`'s `downstream-gate` job)
+- HTML comments inside Markdown for sentinel markers (matches the pre-existing convention in CLAUDE.md.jinja, README.md.jinja, and the #29-introduced `docs/deployment/*` and `docs/guides/*`)
+
+## Files to change
+
+| File | Change | Result |
+|------|--------|--------|
+| `copier.yml` | Remove 5 lines from `_skip_if_exists` | Five docs files now flow through copier-update |
+| `docs/index.md.jinja` | Add 2 DOMAIN blocks at end | Template owns title + description + Getting started; operator owns Features + Use cases below |
+| `docs/installation.md.jinja` | Append 1 DOMAIN-INSTALL-EXTRA block | Template owns install instructions; operator appends notes |
+| `docs/configuration.md.jinja` | Wrap existing `## Domain variables` in DOMAIN-CONFIG-VARS | Template owns common-vars + File Exchange table; operator owns domain vars |
+| `docs/tools/index.md.jinja` | Replace placeholder body with framing + DOMAIN-TOOLS-LIST | Template owns intro + FastMCP-docs link; operator owns tool catalog |
+| `docs/prompts.md.jinja` | Reorder: framing → Example → FastMCP link → DOMAIN-PROMPTS-LIST | Template owns framing + Example + FastMCP link; operator owns prompt catalog |
+
+## Per-file designs
+
+### 1. `docs/index.md.jinja`
+
+```markdown
+# {{ human_name }}
+
+{{ domain_description }}
+
+## Getting started
+
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Tools](tools/index.md)
+
+<!-- DOMAIN-INDEX-FEATURES-START -->
+## Features
+
+- _Add features specific to your server here._
+<!-- DOMAIN-INDEX-FEATURES-END -->
+
+<!-- DOMAIN-INDEX-USE-CASES-START -->
+## What you can do
+
+- _Add usage examples here._
+<!-- DOMAIN-INDEX-USE-CASES-END -->
+```
+
+The `{{ human_name }}` title and `{{ domain_description }}` introduction render from copier answers (re-rendered on every `copier update`, so they stay in sync if the operator changes their answer). The "Getting started" link list stays template-owned and sits immediately after the description — the template knows which docs ship and updates the list when docs are added or removed. The two operator-owned DOMAIN blocks (Features, Use cases) sit below the navigation, so a visitor landing on the page sees the install/config/tools links before the operator's pitch.
+
+### 2. `docs/installation.md.jinja`
+
+Append at end of file:
+
+```markdown
+<!-- DOMAIN-INSTALL-EXTRA-START -->
+
+## Project-specific notes
+
+_Add domain-specific install notes here, e.g. system dependencies, optional
+extras, or custom configuration steps._
+
+<!-- DOMAIN-INSTALL-EXTRA-END -->
+```
+
+Matches the #29 EXTRA pattern exactly: blank line before `<!-- DOMAIN-INSTALL-EXTRA-START -->` separates it from the preceding `## From source` section; the `## Project-specific notes` heading inside the block gives the rendered docs site a labeled section even when the operator hasn't customized.
+
+### 3. `docs/configuration.md.jinja`
+
+Wrap the existing `## Domain variables` placeholder section in sentinels:
+
+```markdown
+<!-- DOMAIN-CONFIG-VARS-START -->
+## Domain variables
+
+Document your project-specific variables here.
+<!-- DOMAIN-CONFIG-VARS-END -->
+```
+
+The "Common variables" + "MCP File Exchange" sections above remain template-owned (they describe core `fastmcp-pvl-core` variables and the shared file-exchange contract — both update via the template). Sentinel name uses `VARS` for brevity, matching the section heading "variables".
+
+### 4. `docs/tools/index.md.jinja`
+
+Replace the current 7-line placeholder with framing + DOMAIN-TOOLS-LIST block:
+
+```markdown
+# Tools
+
+The tools registered in this server are listed below. See the
+[FastMCP tools documentation](https://gofastmcp.com/servers/tools)
+for the full tool API.
+
+<!-- DOMAIN-TOOLS-LIST-START -->
+## ping
+
+Health-check tool — returns `"pong"` if the service is alive.
+Replace with real tools per the scaffold in
+`src/{{ python_module }}/tools.py`.
+<!-- DOMAIN-TOOLS-LIST-END -->
+```
+
+The intro paragraph + FastMCP-docs link become template-owned (so they update if FastMCP's docs URL changes or the framing improves). The catalog body (currently the `ping` placeholder) becomes operator-owned. Operators replace the `ping` example with their actual tool catalog inside the sentinel block.
+
+### 5. `docs/prompts.md.jinja`
+
+Reorder so the Example block sits *before* the DOMAIN block (more natural reading order: framing → example → catalog), and wrap the "Built-in prompts" section in sentinels:
+
+```markdown
+# Prompts
+
+MCP prompts are reusable prompt templates exposed to clients. The scaffold
+ships a minimal set defined in `src/{{ python_module }}/prompts.py`; add
+domain-specific prompts there and document them in this page.
+
+## Example
+
+```python
+@mcp.prompt()
+def summarize(topic: str) -> str:
+    """Summarize the given topic in three sentences."""
+    return f"Write a three-sentence summary of: {topic}"
+```
+
+See the [FastMCP prompts documentation](https://gofastmcp.com/servers/prompts)
+for the full prompt API.
+
+<!-- DOMAIN-PROMPTS-LIST-START -->
+## Built-in prompts
+
+_None in the scaffold._ Define prompts with `@mcp.prompt(...)` decorators in
+`src/{{ python_module }}/prompts.py` and list them here with their arguments,
+usage, and example output.
+<!-- DOMAIN-PROMPTS-LIST-END -->
+```
+
+The framing + Example + FastMCP-docs link stay template-owned. The catalog (currently empty placeholder) is operator-owned.
+
+## Sentinel naming convention
+
+All sentinel blocks introduced by this PR use topic-specific names from the `DOMAIN-{TOPIC}-{KIND}` family. No bare `<!-- DOMAIN-START -->` blocks are introduced — every block is greppable.
+
+| Sentinel | File | Purpose |
+|----------|------|---------|
+| `DOMAIN-INDEX-FEATURES-START/END` | `docs/index.md.jinja` | Operator-owned features bullets |
+| `DOMAIN-INDEX-USE-CASES-START/END` | `docs/index.md.jinja` | Operator-owned usage examples |
+| `DOMAIN-INSTALL-EXTRA-START/END` | `docs/installation.md.jinja` | Operator-appended install notes |
+| `DOMAIN-CONFIG-VARS-START/END` | `docs/configuration.md.jinja` | Operator-owned env-var documentation |
+| `DOMAIN-TOOLS-LIST-START/END` | `docs/tools/index.md.jinja` | Operator-owned tool catalog |
+| `DOMAIN-PROMPTS-LIST-START/END` | `docs/prompts.md.jinja` | Operator-owned prompt catalog |
+
+The existing pre-#106 sentinels (`DOMAIN-DOCKER-EXTRA`, `DOMAIN-OIDC-EXTRA`, `DOMAIN-AUTH-EXTRA` from #29; `DOMAIN-START`/`DOMAIN-END` in README and CLAUDE.md from earlier work) are unchanged.
+
+## Migration story
+
+**Same approach as #29 / PR #108.** After merge, downstream consumers receive the new sentinel structure on their next `copier update` — either via the weekly `copier-update.yml` cron or a manual run.
+
+**Expected per-downstream conflict shape:**
+
+- **`docs/index.md`, `docs/installation.md`, `docs/configuration.md`** — operators are unlikely to have customized these (they were placeholder content); copier-update should land cleanly. If an operator did customize, the conflict resolves by accepting the new template + moving their content into the appropriate DOMAIN block.
+- **`docs/tools/index.md`** — operators almost certainly have a real tool catalog here. Conflict on first update; resolution: keep the operator's catalog, move it inside the new `DOMAIN-TOOLS-LIST` block, accept the new template framing above.
+- **`docs/prompts.md`** — same as tools: operators may have a real prompt catalog. Same resolution pattern.
+
+**Downstream consumers:**
+
+1. `pvliesdonk/image-generation-mcp`
+2. `pvliesdonk/markdown-vault-mcp`
+3. `pvliesdonk/paperless-mcp`
+4. `pvliesdonk/reqeng-mcp`
+
+The PR description for the implementation PR will document the expected conflict shape so the user (or the agent doing copier-update review) knows what "good" looks like during conflict resolution.
+
+## Verification
+
+Run on the implementation branch (works pre-merge via `--vcs-ref=HEAD`):
+
+```bash
+# 1. _skip_if_exists no longer contains the 5 docs files
+grep -E "docs/(index|installation|configuration|tools/index|prompts)\.md" copier.yml
+# Expected: only matches outside the _skip_if_exists block (none in the dropped lines)
+
+# 2. All 6 new sentinels present in rendered output
+rm -rf /tmp/smoke-106
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke-106
+
+grep "DOMAIN-INDEX-FEATURES-START" /tmp/smoke-106/docs/index.md
+grep "DOMAIN-INDEX-USE-CASES-START" /tmp/smoke-106/docs/index.md
+grep "DOMAIN-INSTALL-EXTRA-START" /tmp/smoke-106/docs/installation.md
+grep "DOMAIN-CONFIG-VARS-START" /tmp/smoke-106/docs/configuration.md
+grep "DOMAIN-TOOLS-LIST-START" /tmp/smoke-106/docs/tools/index.md
+grep "DOMAIN-PROMPTS-LIST-START" /tmp/smoke-106/docs/prompts.md
+
+# 3. mkdocs build still passes (downstream-gate)
+cd /tmp/smoke-106
+uv sync --all-extras --all-groups
+uv run mkdocs build --strict
+```
+
+## Out of scope
+
+- **Other docs files** beyond the five listed (e.g. `docs/design.md.jinja`, `docs/deployment/*` from #29, `docs/guides/*` from #29) — this PR does not touch them.
+- **Sentinel-protection of non-docs files** (Python sources, workflows, etc.) — separate concerns, separate issues.
+- **Adding new content** to the framing sections — this PR preserves the current framing as template-owned. Improvements to the framing land in follow-up PRs that flow through the new sentinel structure.
+- **Downstream-side rebases** — the user dispatches `copier update` per the standard manual-release workflow; this PR does not auto-open downstream PRs.
+- **Renaming pre-existing sentinels** — the bare `<!-- DOMAIN-START -->` blocks in README.md.jinja and CLAUDE.md.jinja stay as-is.

--- a/docs/tools/index.md.jinja
+++ b/docs/tools/index.md.jinja
@@ -1,7 +1,13 @@
 # Tools
 
+The tools registered in this server are listed below. See the
+[FastMCP tools documentation](https://gofastmcp.com/servers/tools)
+for the full tool API.
+
+<!-- DOMAIN-TOOLS-LIST-START -->
 ## ping
 
 Health-check tool — returns `"pong"` if the service is alive.
 Replace with real tools per the scaffold in
 `src/{{ python_module }}/tools.py`.
+<!-- DOMAIN-TOOLS-LIST-END -->


### PR DESCRIPTION
## Summary

Move the 5 remaining `docs/*.md` files out of `_skip_if_exists` in `copier.yml` and add per-file `<!-- DOMAIN-{TOPIC}-{KIND}-START/END -->` sentinel blocks so future template improvements (link updates, framing changes, new shared sections) flow to downstream consumers via `copier update` while their domain-specific content survives.

After this lands, `_skip_if_exists` no longer contains any `docs/*.md` entries — the docs tree becomes fully template-owned with sentinel-protected domain zones.

## Per-file changes

| File | Sentinel(s) added | Shape |
|------|------------------|-------|
| `docs/index.md.jinja` | `DOMAIN-INDEX-FEATURES`, `DOMAIN-INDEX-USE-CASES` | 2 blocks at end (after Getting-started navigation) |
| `docs/installation.md.jinja` | `DOMAIN-INSTALL-EXTRA` | Append at end (matches #29 EXTRA pattern) |
| `docs/configuration.md.jinja` | `DOMAIN-CONFIG-VARS` | Wrap existing `## Domain variables` placeholder (tight wrap) |
| `docs/tools/index.md.jinja` | `DOMAIN-TOOLS-LIST` | Replace placeholder with template-owned framing + DOMAIN block around catalog |
| `docs/prompts.md.jinja` | `DOMAIN-PROMPTS-LIST` | Reorder (Example → catalog) + wrap "Built-in prompts" |

Plus `copier.yml`: drop the 5 `docs/*.md` lines from `_skip_if_exists` along with the now-orphan 5-line comment that described them.

## Convention notes

- All new sentinels use topic-specific names from the `DOMAIN-{TOPIC}-{KIND}` family (no bare `<!-- DOMAIN-START -->` introduced; the pre-existing bare blocks in `README.md.jinja` and `CLAUDE.md.jinja` are intentionally untouched).
- The new EXTRA / LIST / VARS blocks deliberately omit the inline `<!-- Project-specific notes for X; kept across copier update. -->` HTML comments that #29's `DOMAIN-DOCKER-EXTRA` / `DOMAIN-OIDC-EXTRA` / `DOMAIN-AUTH-EXTRA` blocks include — the spec prescribes lean blocks.

## Migration story for downstream consumers

After merge, the 4 downstream consumers (`image-generation-mcp`, `markdown-vault-mcp`, `paperless-mcp`, `reqeng-mcp`) will receive the changes via the next `copier update` (weekly cron or manual run). Expected per-downstream conflict shape:

- **`docs/index.md`, `docs/installation.md`, `docs/configuration.md`** — operators are unlikely to have customized these (they were placeholder content); should land cleanly.
- **`docs/tools/index.md`** — operators almost certainly have a real tool catalog. Conflict on first update; resolution: keep operator catalog, move it inside the new `DOMAIN-TOOLS-LIST` block, accept the new template framing above.
- **`docs/prompts.md`** — same as tools.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-07-docs-sentinel-extend-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-docs-sentinel-extend.md`

## Test plan

- [x] Smoke render at HEAD shows all 6 new sentinels in rendered output
- [x] `mkdocs build --strict` passes (1.45s, no warnings)
- [x] Generated-project gate passes (ruff, ruff format, mypy, pytest 10/10)
- [x] Two local code-reviewers (pr-review-toolkit + feature-dev) both clean on cumulative diff
- [ ] claude-review LGTM on first pass
- [ ] gemini-code-assist LGTM on flip-to-ready

Closes #106