### PR TITLE
feat(scaffold): commented opt-in authorization stubs + pin pvl-core 2.0

### DIFF
--- a/.env.example.jinja
+++ b/.env.example.jinja
@@ -9,6 +9,7 @@
 
 # --- Auth (pick one flavor) ---
 # {{ env_prefix }}_BEARER_TOKEN=<secret>
+# {{ env_prefix }}_BEARER_TOKENS_FILE=/etc/{{ project_name }}/tokens.toml   # mapped per-token subjects (overrides BEARER_TOKEN)
 
 # {{ env_prefix }}_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
 # {{ env_prefix }}_OIDC_CLIENT_ID=<client-id>
@@ -16,5 +17,8 @@
 # {{ env_prefix }}_OIDC_AUDIENCE=
 # {{ env_prefix }}_OIDC_REQUIRED_SCOPES=openid
 # {{ env_prefix }}_OIDC_JWT_SIGNING_KEY=<hex-string>
+
+# --- Authorization (optional opt-in) ---
+# {{ env_prefix }}_ACL_PATH=/etc/{{ project_name }}/acl.toml
 
 # --- Domain (populate from your ProjectConfig) ---

--- a/.env.example.jinja
+++ b/.env.example.jinja
@@ -9,6 +9,7 @@
 
 # --- Auth (pick one flavor) ---
 # {{ env_prefix }}_BEARER_TOKEN=<secret>
+
 # {{ env_prefix }}_BEARER_TOKENS_FILE=/etc/{{ project_name }}/tokens.toml   # mapped per-token subjects (overrides BEARER_TOKEN)
 
 # {{ env_prefix }}_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -127,7 +127,9 @@ Wire it in by uncommenting the `acl_path` field in `src/{{ python_module }}/conf
 
 ### Subject ↔ bearer-token alignment
 
-The subject string used as a *value* in the bearer-tokens TOML (`{{ env_prefix }}_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  In stdio mode the subject is the literal `"local"`; reference it as the ACL key for stdio-only deployments.
+The subject string used as a *value* in the bearer-tokens TOML (`{{ env_prefix }}_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide for the bearer-tokens TOML schema.
+
+In single-token mode (`{{ env_prefix }}_BEARER_TOKEN`) every authenticated caller shares one subject — by default `"bearer-anon"`, override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  In stdio mode the subject is the literal `"local"`.
 
 ### Load semantics
 

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -105,6 +105,43 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 
+## Authorization (opt-in)
+
+This server inherits opt-in per-subject authorization from `fastmcp-pvl-core`.  The default posture is **off** — every authenticated caller can use every tool, resource, and prompt.  Turn it on by pointing `{{ env_prefix }}_ACL_PATH` at a TOML ACL file; the middleware is installed only when the path is set, and individual tools opt in by declaring `meta={"required_scope": "<scope>"}` at registration.  A tool without `required_scope` is unrestricted regardless of caller.
+
+Wire it in by uncommenting the `acl_path` field in `src/{{ python_module }}/config.py` and the `AuthorizationMiddleware` stanza in `src/{{ python_module }}/server.py` — both ship as commented stubs in the scaffold.
+
+### ACL TOML schema
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode subject
+```
+
+- **Subject strings are opaque.** The `<kind>:<id>` convention is documentation only; the library treats each subject as a literal string.
+- **`*` is the only library-treated special scope** — it grants every required scope.  Subject-side wildcards (`*` as an ACL key) are rejected at load time.
+- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is encoded into the scope string itself (e.g. `read:project-foo`, `write:vault/personal`); `fastmcp-pvl-core` treats every scope except `*` as opaque.
+
+### Subject ↔ bearer-token alignment
+
+The subject string used as a *value* in the bearer-tokens TOML (`{{ env_prefix }}_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  In stdio mode the subject is the literal `"local"`; reference it as the ACL key for stdio-only deployments.
+
+### Load semantics
+
+The ACL file is loaded **once at server startup**.  Restart the server to pick up changes; live reload is not part of the initial implementation.  `load_acl` fails fast with `ConfigurationError` on every malformed condition, so a typo in the ACL file aborts startup rather than silently denying requests.
+
+### Privacy default
+
+Denied requests are logged at WARNING with the subject string for audit attribution.  The wire-side error payload **omits** the subject by default to limit cross-user information disclosure.  For internal-only servers where the subject is safe to surface to clients, construct the middleware with `AuthorizationMiddleware(..., expose_subject_in_error=True)`.
+
+### See also
+
+- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
+- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+
 ## Post-scaffold checklist
 
 After `copier copy` and `gh repo create --push`:

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -129,7 +129,7 @@ Wire it in by uncommenting the `acl_path` field in `src/{{ python_module }}/conf
 
 The subject string used as a *value* in the bearer-tokens TOML (`{{ env_prefix }}_BEARER_TOKENS_FILE`) is the same string used as a *key* in the ACL TOML.  Same string, opposite roles — keep the two files consistent when adding or removing a principal.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject) in the authentication guide for the bearer-tokens TOML schema.
 
-In single-token mode (`{{ env_prefix }}_BEARER_TOKEN`) every authenticated caller shares one subject — by default `"bearer-anon"`, override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  In stdio mode the subject is the literal `"local"`.
+In single-token mode (`{{ env_prefix }}_BEARER_TOKEN`) every authenticated caller shares one subject — the library's default (currently `"bearer-anon"`), override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`; reference *that* string as the ACL key.  In stdio mode the subject is the literal `"local"`.
 
 ### Load semantics
 

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -61,7 +61,7 @@ Authorization: Bearer your-generated-token
 
 ### Mapped bearer tokens (multi-subject)
 
-Single-token mode shares one subject across every authenticated caller (default `bearer-anon`; override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `{{ env_prefix }}_BEARER_TOKENS_FILE` at a TOML file:
+The bearer-token mode above shares one subject across every authenticated caller — by default the library's `bearer-anon`, override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`.  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `{{ env_prefix }}_BEARER_TOKENS_FILE` at a TOML file:
 
 ```toml
 # tokens.toml
@@ -72,7 +72,7 @@ Single-token mode shares one subject across every authenticated caller (default 
 
 Each token resolves to a distinct subject string for downstream attribution.  Subject strings are opaque — the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only.  When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present).  A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
 
-For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](../../README.md#authorization-opt-in) in the README.
+For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/{{ github_org }}/{{ project_name }}/blob/main/README.md#authorization-opt-in) in the project README.
 
 ---
 

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -59,6 +59,21 @@ Authorization: Bearer your-generated-token
 - Development and testing environments
 - Any scenario where full OIDC is overkill
 
+### Mapped bearer tokens (multi-subject)
+
+Single-token mode shares one subject across every authenticated caller (default `bearer-anon`; override with `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).  For audit logs and authorization that distinguish callers, switch to mapped-token mode by pointing `{{ env_prefix }}_BEARER_TOKENS_FILE` at a TOML file:
+
+```toml
+# tokens.toml
+[tokens]
+"ghp_alice_xxxxxxxx" = "user:alice@example.com"
+"sk_ci_yyyyyyyy"     = "service:ci-bot"
+```
+
+Each token resolves to a distinct subject string for downstream attribution.  Subject strings are opaque — the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only.  When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present).  A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
+
+For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](../../README.md#authorization-opt-in) in the README.
+
 ---
 
 ## OIDC

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -16,7 +16,7 @@ classifiers = [
     "License :: Other/Proprietary License",  # starter: TODO update when you pick a license (see LICENSE)
 ]
 dependencies = [
-    "fastmcp-pvl-core>=1.2.0,<2",
+    "fastmcp-pvl-core>=2.0.0,<3",
     "typer>=0.12",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     # PROJECT-DEPS-END

--- a/src/{{python_module}}/config.py.jinja
+++ b/src/{{python_module}}/config.py.jinja
@@ -26,6 +26,8 @@ class ProjectConfig:
     server: ServerConfig = field(default_factory=ServerConfig)
 
     # CONFIG-FIELDS-START — add domain fields below; kept across copier update
+    # (uncommenting the Path-typed examples below also requires adding
+    #  ``from pathlib import Path`` to the imports at the top of this file.)
     # (example)
     # vault_path: Path = Path("/data/vault")
     #

--- a/src/{{python_module}}/config.py.jinja
+++ b/src/{{python_module}}/config.py.jinja
@@ -28,6 +28,11 @@ class ProjectConfig:
     # CONFIG-FIELDS-START — add domain fields below; kept across copier update
     # (example)
     # vault_path: Path = Path("/data/vault")
+    #
+    # (example: enable optional authorization — see fastmcp-pvl-core's
+    #  README "Authorization" section for the full opt-in story.  Absence
+    #  of the path means no authorization middleware is installed.)
+    # acl_path: Path | None = None
     # CONFIG-FIELDS-END
 
     @classmethod
@@ -38,5 +43,9 @@ class ProjectConfig:
             # CONFIG-FROM-ENV-START — populate domain fields below; kept across copier update
             # (example)
             # vault_path=Path(env(_ENV_PREFIX, "VAULT_PATH", "/data/vault")),
+            #
+            # (example: load ``acl_path`` from ``{{ env_prefix }}_ACL_PATH``;
+            #  unset env var means no authorization middleware.)
+            # acl_path=Path(env(_ENV_PREFIX, "ACL_PATH")) if env(_ENV_PREFIX, "ACL_PATH") else None,
             # CONFIG-FROM-ENV-END
         )

--- a/src/{{python_module}}/config.py.jinja
+++ b/src/{{python_module}}/config.py.jinja
@@ -46,6 +46,6 @@ class ProjectConfig:
             #
             # (example: load ``acl_path`` from ``{{ env_prefix }}_ACL_PATH``;
             #  unset env var means no authorization middleware.)
-            # acl_path=Path(env(_ENV_PREFIX, "ACL_PATH")) if env(_ENV_PREFIX, "ACL_PATH") else None,
+            # acl_path=Path(_p) if (_p := env(_ENV_PREFIX, "ACL_PATH")) else None,
             # CONFIG-FROM-ENV-END
         )

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -93,6 +93,22 @@ def make_server(
 
     wire_middleware_stack(mcp)
 
+    # Optional: enable opt-in per-subject authorization on tools / resources /
+    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
+    # design.  Tools, resources, and prompts opt in by setting
+    # ``meta={"required_scope": "<scope>"}``; absence of the key means
+    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
+    #
+    # from fastmcp_pvl_core import (
+    #     AuthorizationMiddleware,
+    #     load_acl,
+    #     make_acl_authorizer,
+    # )
+    #
+    # if config.acl_path is not None:
+    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
+    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+
     register_tools(mcp)
     register_resources(mcp)
     register_prompts(mcp)


### PR DESCRIPTION
## Summary

Bundles the three opt-in authorization scaffold issues into one PR, plus the prerequisite `fastmcp-pvl-core` pin bump that gives generated projects access to the authorization submodule.

- **`pyproject.toml.jinja`** — bumps `fastmcp-pvl-core>=1.2.0,<2` → `>=2.0.0,<3`. The 2.x line ships `AuthorizationMiddleware` / `load_acl` / `make_acl_authorizer`. The only 2.0.0 behavioural change touching the template's existing call sites is `build_auth` raising `ConfigurationError` on remote/multi misconfiguration instead of returning `None`; the template's existing call site lets the exception propagate, which matches the upstream-documented intent.
- **`config.py.jinja`** (#94) — commented `acl_path: Path | None = None` stub in the CONFIG-FIELDS sentinel + matching loader stanza in CONFIG-FROM-ENV reading `{PREFIX}_ACL_PATH` (walrus-form one-liner: `Path(_p) if (_p := env(_ENV_PREFIX, "ACL_PATH")) else None`).
- **`server.py.jinja`** (#95) — commented `AuthorizationMiddleware` wiring after `wire_middleware_stack(mcp)`. Local imports at the top of the stanza so the entire opt-in is self-contained.
- **`README.md.jinja`** (#96) — operator-focused "Authorization (opt-in)" section between Configuration and Post-scaffold checklist. Covers ACL TOML schema, bearer-mapped subject ↔ ACL key alignment (both single-token and mapped-token modes), load-once-at-startup semantics, domain-defined scope vocabulary, privacy default, and pointers to upstream docs.
- **`docs/guides/authentication.md.jinja`** — new "Mapped bearer tokens (multi-subject)" subsection documenting the `{{ env_prefix }}_BEARER_TOKENS_FILE` TOML schema, plus a cross-link to the README's authorization section. Surfaced by local review: the README needed an in-repo home for the bearer-tokens TOML format.
- **`.env.example.jinja`** — commented `BEARER_TOKENS_FILE` (in the Auth block) and `ACL_PATH` (in a new Authorization block) entries so the optional opt-in env vars sit alongside the other operator-discoverable env vars.

Closes #94, closes #95, closes #96.

## Test plan

- [x] `git diff origin/main..HEAD` clean — six files, no extraneous edits.
- [x] Local render via `copier copy --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke` succeeds.
- [x] `uv sync --all-extras --all-groups` resolves `fastmcp-pvl-core==2.0.0` in the rendered project's venv.
- [x] `uv run ruff check .` — all checks passed.
- [x] `uv run ruff format --check .` — 17 files already formatted.
- [x] `uv run mypy src/ tests/` — no issues found in 13 source files.
- [x] `uv run pytest -x -q` — 10 passed.
- [x] `python -c "from fastmcp_pvl_core import AuthorizationMiddleware, load_acl, make_acl_authorizer"` resolves cleanly in the rendered venv (load-bearing claim of the PR — the commented stubs reference real symbols at the pinned version).
- [x] Anchor targets verified in both directions: README `#authorization-opt-in` ↔ auth-guide `#mapped-bearer-tokens-multi-subject`.
- [x] Local review circus on cumulative diff: two-reviewer pass through pr-review-toolkit:code-reviewer (round 2 clean after addressing round-1 second-opinion findings about template-wide consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)