### PR TITLE
fix(aggregator): three follow-ups from #109 review (#110)

### DIFF
--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -143,28 +143,33 @@ def _render_job_a(data: dict | None, conflict_count: int) -> str:
     if status != "ok":
         return _placeholder("🔧 Conflict resolutions", "error")
 
-    lines = ["### 🔧 Conflict resolutions", ""]
+    content: list[str] = []
     auto = data.get("auto_resolved", [])
     if auto:
-        lines.append("**Auto-committed by claude-code** — VERIFY before merging:")
-        lines.append("")
+        content.append("**Auto-committed by claude-code** — VERIFY before merging:")
+        content.append("")
         for item in auto:
-            lines.append(
+            content.append(
                 f"- `{item['file']}` (commit {item['commit_sha']}): "
                 f"_{item['articulation']}_"
             )
-        lines.append("")
+        content.append("")
     review = data.get("needs_review", [])
     if review:
-        lines.append(
+        content.append(
             "**Needs review** — conflict markers remain, operator must resolve:"
         )
-        lines.append("")
+        content.append("")
         for item in review:
-            lines.append(f"- `{item['file']}`: {item['reasoning']}")
-            lines.append(f"  Recommended approach: {item['recommended_resolution']}")
-        lines.append("")
-    return "\n".join(lines)
+            content.append(f"- `{item['file']}`: {item['reasoning']}")
+            content.append(f"  Recommended approach: {item['recommended_resolution']}")
+        content.append("")
+    if not content:
+        # Status was "ok" but the LLM reported neither auto-resolved nor
+        # needs-review entries.  Suppress the section entirely rather than
+        # emitting an orphaned `### 🔧` header above empty content.
+        return ""
+    return "\n".join(["### 🔧 Conflict resolutions", "", *content])
 
 
 def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
@@ -208,20 +213,20 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
         cls = e.get("classification")
         by_class[cls if cls in by_class else "informational"].append(e)
 
-    lines = ["### ✨ New features in this update", ""]
+    content: list[str] = []
     if by_class["needs-opt-in"]:
-        lines.append("**Needs your attention** (action-required):")
-        lines.append("")
+        content.append("**Needs your attention** (action-required):")
+        content.append("")
         for e in by_class["needs-opt-in"]:
-            lines.append(f"- {_pr_label(e)} {e['title']} — needs opt-in.")
-            lines.append(f"  {e['summary']}")
-        lines.append("")
+            content.append(f"- {_pr_label(e)} {e['title']} — needs opt-in.")
+            content.append(f"  {e['summary']}")
+        content.append("")
     if by_class["ships-automatically"]:
-        lines.append("**Ships through automatically** (informational):")
-        lines.append("")
+        content.append("**Ships through automatically** (informational):")
+        content.append("")
         for e in by_class["ships-automatically"]:
-            lines.append(f"- {_pr_label(e)} {e['title']} — applied this run")
-        lines.append("")
+            content.append(f"- {_pr_label(e)} {e['title']} — applied this run")
+        content.append("")
     if by_class["informational"]:
         # Drop entries with null pr_number from the rollup — they'd render
         # as the literal "#None" otherwise (LLM-emitted malformed entries
@@ -236,11 +241,16 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
         if rollup:
             ids = ", ".join(_pr_label(e) for e in rollup)
             n = len(rollup)
-            lines.append(
+            content.append(
                 f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
             )
-            lines.append("")
-    return "\n".join(lines)
+            content.append("")
+    if not content:
+        # Entries existed but every stratum filtered out (e.g. all
+        # informational with null pr_number); suppress the section entirely
+        # rather than emit an orphaned `### ✨` header above empty content.
+        return ""
+    return "\n".join(["### ✨ New features in this update", "", *content])
 
 
 def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
@@ -277,20 +287,20 @@ def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
         cls = f.get("classification")
         by_class[cls if cls in by_class else "informational"].append(f)
 
-    lines = ["### 📦 Excluded-file upstream changes", ""]
+    content: list[str] = []
     if by_class["recommend-port"]:
-        lines.append("**Recommended to port** (action-required):")
-        lines.append("")
+        content.append("**Recommended to port** (action-required):")
+        content.append("")
         for f in by_class["recommend-port"]:
-            lines.append(f"- {_file_label(f)}: {f['summary']}")
-            lines.append(f"  Diff: {f['diff_summary']}")
-        lines.append("")
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+            content.append(f"  Diff: {f['diff_summary']}")
+        content.append("")
     if by_class["informational"]:
-        lines.append("**Informational**:")
-        lines.append("")
+        content.append("**Informational**:")
+        content.append("")
         for f in by_class["informational"]:
-            lines.append(f"- {_file_label(f)}: {f['summary']}")
-        lines.append("")
+            content.append(f"- {_file_label(f)}: {f['summary']}")
+        content.append("")
     if by_class["skip"]:
         # Drop entries with null file from the rollup — same rationale as
         # Job B's informational rollup (see :func:`_render_job_b`).
@@ -298,11 +308,17 @@ def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
         if rollup:
             names = ", ".join(_file_label(f) for f in rollup)
             n = len(rollup)
-            lines.append(
+            content.append(
                 f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
             )
-            lines.append("")
-    return "\n".join(lines)
+            content.append("")
+    if not content:
+        # Files existed but the skip rollup was the only non-empty
+        # stratum and every entry in it had null file (so the rollup
+        # got filtered out).  Suppress the section entirely rather
+        # than emit an orphaned `### 📦` header above empty content.
+        return ""
+    return "\n".join(["### 📦 Excluded-file upstream changes", "", *content])
 
 
 _DISABLED_NOTICE = (

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -108,6 +108,28 @@ def _placeholder(section_title: str, status: str) -> str:
     return f"### {section_title}\n\n{msg}\n"
 
 
+def _pr_label(entry: dict) -> str:
+    """Render an entry's pr_number as ``#N``, or ``#?`` when null/missing.
+
+    LLM-emitted entries without a PR reference would otherwise render as
+    the literal ``#None`` in the body via Python's ``None.__str__`` inside
+    an f-string.  Used by Job B's three render strata.
+    """
+    pr = entry.get("pr_number")
+    return f"#{pr}" if pr is not None else "#?"
+
+
+def _file_label(entry: dict) -> str:
+    """Render an entry's file as ``\\`name\\```, or ``\\`(unnamed)\\``` when null/missing.
+
+    Same null-safety rationale as :func:`_pr_label` but for Job C's file
+    field; without coercion a null ``file`` renders as the literal
+    backticked ``\\`None\\```.
+    """
+    name = entry.get("file")
+    return f"`{name}`" if name is not None else "`(unnamed)`"
+
+
 def _render_job_a(data: dict | None, conflict_count: int) -> str:
     """Render the 🔧 Conflict resolutions section."""
     if conflict_count == 0:
@@ -191,25 +213,28 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
         lines.append("**Needs your attention** (action-required):")
         lines.append("")
         for e in by_class["needs-opt-in"]:
-            lines.append(f"- #{e['pr_number']} {e['title']} — needs opt-in.")
+            lines.append(f"- {_pr_label(e)} {e['title']} — needs opt-in.")
             lines.append(f"  {e['summary']}")
         lines.append("")
     if by_class["ships-automatically"]:
         lines.append("**Ships through automatically** (informational):")
         lines.append("")
         for e in by_class["ships-automatically"]:
-            lines.append(f"- #{e['pr_number']} {e['title']} — applied this run")
+            lines.append(f"- {_pr_label(e)} {e['title']} — applied this run")
         lines.append("")
     if by_class["informational"]:
         # Drop entries with null pr_number from the rollup — they'd render
         # as the literal "#None" otherwise (LLM-emitted malformed entries
         # without a PR reference can't be looked up anyway, so dropping
         # them from the displayed list is preferable to a placeholder).
+        # The bullet strata above use ``_pr_label`` which coerces null to
+        # ``#?`` — preserves the entry where its prose detail is useful;
+        # the rollup is a tally so dropping is cleaner there.
         rollup = [
             e for e in by_class["informational"] if e.get("pr_number") is not None
         ]
         if rollup:
-            ids = ", ".join(f"#{e['pr_number']}" for e in rollup)
+            ids = ", ".join(_pr_label(e) for e in rollup)
             n = len(rollup)
             lines.append(
                 f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
@@ -257,22 +282,26 @@ def _render_job_c(data: dict | None, template_advanced: bool = True) -> str:
         lines.append("**Recommended to port** (action-required):")
         lines.append("")
         for f in by_class["recommend-port"]:
-            lines.append(f"- `{f['file']}`: {f['summary']}")
+            lines.append(f"- {_file_label(f)}: {f['summary']}")
             lines.append(f"  Diff: {f['diff_summary']}")
         lines.append("")
     if by_class["informational"]:
         lines.append("**Informational**:")
         lines.append("")
         for f in by_class["informational"]:
-            lines.append(f"- `{f['file']}`: {f['summary']}")
+            lines.append(f"- {_file_label(f)}: {f['summary']}")
         lines.append("")
     if by_class["skip"]:
-        names = ", ".join(f"`{f['file']}`" for f in by_class["skip"])
-        n = len(by_class["skip"])
-        lines.append(
-            f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
-        )
-        lines.append("")
+        # Drop entries with null file from the rollup — same rationale as
+        # Job B's informational rollup (see :func:`_render_job_b`).
+        rollup = [f for f in by_class["skip"] if f.get("file") is not None]
+        if rollup:
+            names = ", ".join(_file_label(f) for f in rollup)
+            n = len(rollup)
+            lines.append(
+                f"**Skipped (template-internal)** ({n} {'file' if n == 1 else 'files'}): {names}"
+            )
+            lines.append("")
     return "\n".join(lines)
 
 

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -201,12 +201,20 @@ def _render_job_b(data: dict | None, template_advanced: bool = True) -> str:
             lines.append(f"- #{e['pr_number']} {e['title']} — applied this run")
         lines.append("")
     if by_class["informational"]:
-        ids = ", ".join(f"#{e['pr_number']}" for e in by_class["informational"])
-        n = len(by_class["informational"])
-        lines.append(
-            f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
-        )
-        lines.append("")
+        # Drop entries with null pr_number from the rollup — they'd render
+        # as the literal "#None" otherwise (LLM-emitted malformed entries
+        # without a PR reference can't be looked up anyway, so dropping
+        # them from the displayed list is preferable to a placeholder).
+        rollup = [
+            e for e in by_class["informational"] if e.get("pr_number") is not None
+        ]
+        if rollup:
+            ids = ", ".join(f"#{e['pr_number']}" for e in rollup)
+            n = len(rollup)
+            lines.append(
+                f"**Internal / no downstream effect** ({n} {'entry' if n == 1 else 'entries'}): {ids}"
+            )
+            lines.append("")
     return "\n".join(lines)
 
 
@@ -281,7 +289,7 @@ def _disabled_section(section_title: str) -> str:
 
 def compose_body(inputs: AggregatorInputs) -> str:
     """Compose the full PR body from existing #49 content + agent JSON outputs."""
-    parts = [inputs.existing_body.rstrip(), "", "---", "", "## Agent analysis", ""]
+    agent_sections: list[str] = []
 
     if not inputs.agent_enabled:
         # Per-section disabled placeholders so structure is consistent across
@@ -289,42 +297,52 @@ def compose_body(inputs: AggregatorInputs) -> str:
         # gets a skip notice; sections gated out (e.g. Job A with no conflicts)
         # are omitted entirely.
         if inputs.conflict_count > 0:
-            parts.append(_disabled_section("🔧 Conflict resolutions"))
+            agent_sections.append(_disabled_section("🔧 Conflict resolutions"))
         if inputs.template_advanced:
-            parts.append(_disabled_section("✨ New features in this update"))
-            parts.append(_disabled_section("📦 Excluded-file upstream changes"))
-        return "\n".join(parts) + "\n"
+            agent_sections.append(_disabled_section("✨ New features in this update"))
+            agent_sections.append(
+                _disabled_section("📦 Excluded-file upstream changes")
+            )
+    else:
+        # Each render is wrapped in try/except so a malformed item in one job's
+        # JSON (e.g. LLM emitted entry missing a required field) degrades to
+        # that section's error placeholder without nuking the other two
+        # sections.  See spec § Aggregator's four-state contract — sections
+        # must be independently failing.
+        section_a = _safe_render(
+            "🔧 Conflict resolutions",
+            lambda: _render_job_a(
+                _read_job_json(inputs.job_a_path), inputs.conflict_count
+            ),
+        )
+        if section_a:
+            agent_sections.append(section_a)
 
-    # Each render is wrapped in try/except so a malformed item in one job's
-    # JSON (e.g. LLM emitted entry missing a required field) degrades to that
-    # section's error placeholder without nuking the other two sections.
-    # See spec § Aggregator's four-state contract — sections must be
-    # independently failing.
-    section_a = _safe_render(
-        "🔧 Conflict resolutions",
-        lambda: _render_job_a(_read_job_json(inputs.job_a_path), inputs.conflict_count),
-    )
-    if section_a:
-        parts.append(section_a)
+        section_b = _safe_render(
+            "✨ New features in this update",
+            lambda: _render_job_b(
+                _read_job_json(inputs.job_b_path), inputs.template_advanced
+            ),
+        )
+        if section_b:
+            agent_sections.append(section_b)
 
-    section_b = _safe_render(
-        "✨ New features in this update",
-        lambda: _render_job_b(
-            _read_job_json(inputs.job_b_path), inputs.template_advanced
-        ),
-    )
-    if section_b:
-        parts.append(section_b)
+        section_c = _safe_render(
+            "📦 Excluded-file upstream changes",
+            lambda: _render_job_c(
+                _read_job_json(inputs.job_c_path), inputs.template_advanced
+            ),
+        )
+        if section_c:
+            agent_sections.append(section_c)
 
-    section_c = _safe_render(
-        "📦 Excluded-file upstream changes",
-        lambda: _render_job_c(
-            _read_job_json(inputs.job_c_path), inputs.template_advanced
-        ),
-    )
-    if section_c:
-        parts.append(section_c)
-
+    parts = [inputs.existing_body.rstrip()]
+    # Suppress the agent-analysis header entirely when no sections will follow
+    # it (e.g. agent_enabled=True with conflict_count=0 + template_advanced=False,
+    # or agent_disabled with both gates closed) — otherwise the body emits an
+    # orphaned `## Agent analysis` separator with nothing under it.
+    if agent_sections:
+        parts.extend(["", "---", "", "## Agent analysis", "", *agent_sections])
     return "\n".join(parts) + "\n"
 
 

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -470,8 +470,13 @@ def test_overflow_section_boundary_ignores_agent_subheaders(
     a `### Sub-header` line. The boundary search instead uses the next known
     marker so agent text is preserved intact.
     """
+    # ~6000 lines * ~12 chars/line ~= 72k chars — enough to push the body
+    # past BODY_LIMIT (60k) so overflow actually triggers.  The previous
+    # 800-line filler stayed under the limit, leaving the overflow branch
+    # unverified (the `assert overflow` below now fails the test if that
+    # regresses).
     long_summary = "intro paragraph\n\n### Background subsection\n\n" + (
-        "filler line\n" * 800
+        "filler line\n" * 6000
     )
     job_b = write_job_json(
         "agent-job-b",
@@ -497,12 +502,14 @@ def test_overflow_section_boundary_ignores_agent_subheaders(
         conflict_count=0,
     )
     body, overflow = agg.compose_body_with_overflow(inputs, overflow_dir=overflow_dir)
-    if overflow:
-        spilled = overflow[0].read_text(encoding="utf-8")
-        # The full agent summary including the `### Background subsection`
-        # line must travel with the section, not be left orphaned in body.
-        assert "Background subsection" in spilled
-        assert "Background subsection" not in body
+    assert overflow, (
+        "expected overflow with 6000-line filler (~72k chars > 60k BODY_LIMIT)"
+    )
+    spilled = overflow[0].read_text(encoding="utf-8")
+    # The full agent summary including the `### Background subsection`
+    # line must travel with the section, not be left orphaned in body.
+    assert "Background subsection" in spilled
+    assert "Background subsection" not in body
 
 
 def test_overflow_spills_longest_section(write_job_json, tmp_path: Path) -> None:
@@ -826,3 +833,125 @@ def test_agent_disabled_renders_per_section_placeholders() -> None:
     # multiple times — once under each section's heading)
     assert body.count("Agent disabled") >= 3
     assert "CLAUDE_CODE_OAUTH_TOKEN" in body
+
+
+def test_no_agent_sections_suppresses_agent_analysis_header() -> None:
+    """Agent-analysis header is suppressed when no sections will follow it.
+
+    Edge case: agent_enabled=True with all gates closed (no conflicts,
+    template_advanced=False) — previously emitted an orphaned `## Agent
+    analysis` separator with nothing under it.
+    """
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.0.0 (re-run)\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=None,
+        job_c_path=None,
+        conflict_count=0,
+        template_advanced=False,
+    )
+    body = agg.compose_body(inputs)
+    assert "## Agent analysis" not in body
+    assert "---" not in body  # the separator preceding the header is also gone
+
+
+def test_agent_disabled_no_gates_suppresses_agent_analysis_header() -> None:
+    """Same suppression holds when agent_enabled=False and both gates closed."""
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.0.0 (re-run)\n",
+        agent_enabled=False,
+        job_a_path=None,
+        job_b_path=None,
+        job_c_path=None,
+        conflict_count=0,
+        template_advanced=False,
+    )
+    body = agg.compose_body(inputs)
+    assert "## Agent analysis" not in body
+    assert "Agent disabled" not in body  # nothing to disable; no section emitted
+
+
+def test_job_b_informational_rollup_drops_null_pr_numbers(write_job_json) -> None:
+    """Informational entries with pr_number=null are dropped from the rollup.
+
+    Without filtering, an LLM-emitted entry with `pr_number: null` rendered
+    as the literal "#None" inside the rollup line.
+    """
+    job_b = write_job_json(
+        "agent-job-b",
+        {
+            "status": "ok",
+            "entries": [
+                {
+                    "pr_number": None,
+                    "title": "internal merge with no PR",
+                    "classification": "informational",
+                    "summary": "",
+                },
+                {
+                    "pr_number": 87,
+                    "title": "real PR",
+                    "classification": "informational",
+                    "summary": "",
+                },
+                {
+                    "pr_number": 91,
+                    "title": "another real PR",
+                    "classification": "informational",
+                    "summary": "",
+                },
+            ],
+        },
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=job_b,
+        job_c_path=None,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "#None" not in body
+    assert "#87" in body
+    assert "#91" in body
+    # Count reflects the displayed entries (2), not the raw bucket (3).
+    assert "(2 entries)" in body
+
+
+def test_job_b_informational_rollup_all_null_pr_numbers_omits_rollup_line(
+    write_job_json,
+) -> None:
+    """If every informational entry has null pr_number, the rollup line is omitted entirely."""
+    job_b = write_job_json(
+        "agent-job-b",
+        {
+            "status": "ok",
+            "entries": [
+                {
+                    "pr_number": None,
+                    "title": "internal a",
+                    "classification": "informational",
+                    "summary": "",
+                },
+                {
+                    "pr_number": None,
+                    "title": "internal b",
+                    "classification": "informational",
+                    "summary": "",
+                },
+            ],
+        },
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=job_b,
+        job_c_path=None,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "#None" not in body
+    assert "Internal / no downstream effect" not in body

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -665,7 +665,18 @@ def test_cli_entry_point_writes_body_file(tmp_path: Path, write_job_json) -> Non
 
     job_a = write_job_json(
         "agent-job-a",
-        {"status": "ok", "auto_resolved": [], "needs_review": []},
+        {
+            "status": "ok",
+            "auto_resolved": [
+                {
+                    "file": "docs/foo.md",
+                    "region": "L1-L5",
+                    "articulation": "trivial",
+                    "commit_sha": "abc1234",
+                }
+            ],
+            "needs_review": [],
+        },
     )
     existing = tmp_path / "existing.md"
     existing.write_text("## Template update: v1.0.0 → v1.1.0\n", encoding="utf-8")
@@ -1047,6 +1058,120 @@ def test_job_c_bullet_strata_coerce_null_file_to_placeholder(
     assert "`None`" not in body
     assert "`(unnamed)`: Untracked port — file path missing." in body
     assert "`(unnamed)`: Trivial change without path." in body
+
+
+def test_job_a_no_resolutions_suppresses_section_header(write_job_json) -> None:
+    """Job A returns empty when status=ok with both auto_resolved and needs_review empty.
+
+    Edge case: agent ran on a real conflict (conflict_count > 0), reported
+    status=ok, but neither stratum populated.  Previously emitted an
+    orphaned `### 🔧 Conflict resolutions` header with nothing under it;
+    now the whole section is suppressed and (since this was the only
+    section) the parent `## Agent analysis` header is suppressed too.
+    """
+    job_a = write_job_json(
+        "agent-job-a",
+        {"status": "ok", "auto_resolved": [], "needs_review": []},
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=job_a,
+        job_b_path=None,
+        job_c_path=None,
+        conflict_count=2,
+        template_advanced=False,  # only Job A would run; suppression cascades
+    )
+    body = agg.compose_body(inputs)
+    assert "🔧 Conflict resolutions" not in body
+    assert "## Agent analysis" not in body
+
+
+def test_job_b_only_informational_with_null_pr_suppresses_section_header(
+    write_job_json,
+) -> None:
+    """Job B returns empty when entries exist but every stratum filters out.
+
+    Edge case: every entry is informational with null pr_number — the rollup
+    drops them all, leaving no content under the `### ✨` header.  Also
+    pass an empty Job C JSON so its render returns "" cleanly (rather than
+    the error placeholder a missing job_c_path would produce while
+    template_advanced=True).
+    """
+    job_b = write_job_json(
+        "agent-job-b",
+        {
+            "status": "ok",
+            "entries": [
+                {
+                    "pr_number": None,
+                    "title": "untracked a",
+                    "classification": "informational",
+                    "summary": "",
+                },
+                {
+                    "pr_number": None,
+                    "title": "untracked b",
+                    "classification": "informational",
+                    "summary": "",
+                },
+            ],
+        },
+    )
+    job_c_empty = write_job_json("agent-job-c", {"status": "ok", "files": []})
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=job_b,
+        job_c_path=job_c_empty,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "✨ New features in this update" not in body
+    assert "## Agent analysis" not in body
+
+
+def test_job_c_only_skip_with_null_file_suppresses_section_header(
+    write_job_json,
+) -> None:
+    """Job C returns empty when only skip entries exist and every one has null file.
+
+    Empty Job B JSON paired with the null-file Job C so the missing-data
+    error placeholder doesn't smear the assertion.
+    """
+    job_c = write_job_json(
+        "agent-job-c",
+        {
+            "status": "ok",
+            "files": [
+                {
+                    "file": None,
+                    "classification": "skip",
+                    "summary": "untracked a",
+                    "diff_summary": "",
+                },
+                {
+                    "file": None,
+                    "classification": "skip",
+                    "summary": "untracked b",
+                    "diff_summary": "",
+                },
+            ],
+        },
+    )
+    job_b_empty = write_job_json("agent-job-b", {"status": "ok", "entries": []})
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=job_b_empty,
+        job_c_path=job_c,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "📦 Excluded-file upstream changes" not in body
+    assert "## Agent analysis" not in body
 
 
 def test_job_c_skip_rollup_drops_null_file(write_job_json) -> None:

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -842,8 +842,9 @@ def test_no_agent_sections_suppresses_agent_analysis_header() -> None:
     template_advanced=False) — previously emitted an orphaned `## Agent
     analysis` separator with nothing under it.
     """
+    existing = "## Template update: v1.0.0 → v1.0.0 (re-run)\n"
     inputs = agg.AggregatorInputs(
-        existing_body="## Template update: v1.0.0 → v1.0.0 (re-run)\n",
+        existing_body=existing,
         agent_enabled=True,
         job_a_path=None,
         job_b_path=None,
@@ -853,13 +854,19 @@ def test_no_agent_sections_suppresses_agent_analysis_header() -> None:
     )
     body = agg.compose_body(inputs)
     assert "## Agent analysis" not in body
-    assert "---" not in body  # the separator preceding the header is also gone
+    # Body is just the existing body (single trailing newline).  Asserting
+    # equality rather than `"---" not in body` because the real workflow's
+    # existing-body construction may include horizontal rules for unrelated
+    # reasons; the regression invariant is "nothing was appended after the
+    # existing body", not "no horizontal rule appears anywhere".
+    assert body.rstrip() == existing.rstrip()
 
 
 def test_agent_disabled_no_gates_suppresses_agent_analysis_header() -> None:
     """Same suppression holds when agent_enabled=False and both gates closed."""
+    existing = "## Template update: v1.0.0 → v1.0.0 (re-run)\n"
     inputs = agg.AggregatorInputs(
-        existing_body="## Template update: v1.0.0 → v1.0.0 (re-run)\n",
+        existing_body=existing,
         agent_enabled=False,
         job_a_path=None,
         job_b_path=None,
@@ -870,6 +877,7 @@ def test_agent_disabled_no_gates_suppresses_agent_analysis_header() -> None:
     body = agg.compose_body(inputs)
     assert "## Agent analysis" not in body
     assert "Agent disabled" not in body  # nothing to disable; no section emitted
+    assert body.rstrip() == existing.rstrip()
 
 
 def test_job_b_informational_rollup_drops_null_pr_numbers(write_job_json) -> None:
@@ -955,3 +963,124 @@ def test_job_b_informational_rollup_all_null_pr_numbers_omits_rollup_line(
     body = agg.compose_body(inputs)
     assert "#None" not in body
     assert "Internal / no downstream effect" not in body
+
+
+def test_job_b_bullet_strata_coerce_null_pr_number_to_placeholder(
+    write_job_json,
+) -> None:
+    """needs-opt-in and ships-automatically bullets coerce null pr_number to #?.
+
+    Bullet entries carry prose detail (title, summary) that's useful even
+    when the PR number is missing, so they're preserved with a placeholder
+    rather than dropped (which is the rollup's choice).
+    """
+    job_b = write_job_json(
+        "agent-job-b",
+        {
+            "status": "ok",
+            "entries": [
+                {
+                    "pr_number": None,
+                    "title": "untracked merge a",
+                    "classification": "needs-opt-in",
+                    "summary": "Pulled in via cherry-pick; manual opt-in needed.",
+                },
+                {
+                    "pr_number": None,
+                    "title": "untracked merge b",
+                    "classification": "ships-automatically",
+                    "summary": "",
+                },
+            ],
+        },
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=job_b,
+        job_c_path=None,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "#None" not in body
+    assert "#? untracked merge a — needs opt-in." in body
+    assert "#? untracked merge b — applied this run" in body
+    # Prose detail is preserved
+    assert "Pulled in via cherry-pick" in body
+
+
+def test_job_c_bullet_strata_coerce_null_file_to_placeholder(
+    write_job_json,
+) -> None:
+    """recommend-port and informational bullets coerce null file to `(unnamed)`."""
+    job_c = write_job_json(
+        "agent-job-c",
+        {
+            "status": "ok",
+            "files": [
+                {
+                    "file": None,
+                    "classification": "recommend-port",
+                    "summary": "Untracked port — file path missing.",
+                    "diff_summary": "+10 lines on something",
+                },
+                {
+                    "file": None,
+                    "classification": "informational",
+                    "summary": "Trivial change without path.",
+                    "diff_summary": "1 line",
+                },
+            ],
+        },
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=None,
+        job_c_path=job_c,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    # Backticked literal `None` must not leak into the body
+    assert "`None`" not in body
+    assert "`(unnamed)`: Untracked port — file path missing." in body
+    assert "`(unnamed)`: Trivial change without path." in body
+
+
+def test_job_c_skip_rollup_drops_null_file(write_job_json) -> None:
+    """skip rollup mirrors Job B informational rollup: null file dropped, count adjusts."""
+    job_c = write_job_json(
+        "agent-job-c",
+        {
+            "status": "ok",
+            "files": [
+                {
+                    "file": None,
+                    "classification": "skip",
+                    "summary": "untracked",
+                    "diff_summary": "",
+                },
+                {
+                    "file": ".github/workflows/template-ci.yml",
+                    "classification": "skip",
+                    "summary": "Template-CI plumbing only.",
+                    "diff_summary": "+2 lines",
+                },
+            ],
+        },
+    )
+    inputs = agg.AggregatorInputs(
+        existing_body="## Template update: v1.0.0 → v1.1.0\n",
+        agent_enabled=True,
+        job_a_path=None,
+        job_b_path=None,
+        job_c_path=job_c,
+        conflict_count=0,
+    )
+    body = agg.compose_body(inputs)
+    assert "`None`" not in body
+    assert "`.github/workflows/template-ci.yml`" in body
+    # Count reflects the displayed entry (1), not the raw bucket (2).
+    assert "(1 file)" in body


### PR DESCRIPTION
## Summary

Three small quality/cosmetic fixes in `scripts/copier_update_aggregator.py` and its tests that surfaced during PR #109's review, plus a fourth fix in the same orphaned-header family caught by claude-review on this PR's draft.

- **Vacuous regression test** — `test_overflow_section_boundary_ignores_agent_subheaders` had filler too small (800 lines, ~9.6k chars) to cross BODY_LIMIT (60k); the `if overflow:` guard always passed without running its assertions. Bumped filler to 6000 lines (~72k chars) and replaced the conditional with `assert overflow, "..."` so a future regression in either the filler arithmetic or the overflow logic fails loudly.
- **`#None` display** — null `pr_number` rendered as the literal `#None` in three Job B render sites (needs-opt-in / ships-automatically / informational rollup). Same shape applied to Job C with null `file` (recommend-port / informational / skip rollup → `` `None` ``). Added `_pr_label(entry)` and `_file_label(entry)` helpers; bullet strata coerce nulls to `#?` / `(unnamed)` to preserve prose detail; rollup strata filter nulls entirely (cleaner display, count adjusts to displayed entries).
- **Orphaned `## Agent analysis` parent header** — when all three job sections were empty (e.g. `agent_enabled=True` with `conflict_count=0` + `template_advanced=False`), the body emitted the separator with nothing under it. Refactored `compose_body` to collect agent sections into a list first and emit the header only when the list is non-empty. Merges the agent_enabled / agent_disabled paths through a single `agent_sections` accumulator.
- **Orphaned `### ✨` / `### 🔧` / `### 📦` sub-section headers** (round-3) — claude-review on this PR's draft surfaced that when a render function runs successfully but every stratum filters out (e.g. Job B with all informational entries having null pr_number), the function returned just the section header with no content. Same shape exists in Job A (status=ok with both auto + review empty) and Job C (skip rollup with all-null files plus empty other strata). Each `_render_job_X` now collects content into a list and emits the section header only when content is non-empty — mirrors the parent `compose_body` pattern.

Closes #110.

## Test plan

- [x] All aggregator tests pass: `uv run --with pytest pytest scripts/tests/ -v` → 34/34 passed (was 24; +10 new regression tests across all four fixes).
- [x] Ruff lint matches downstream: `uv run --with ruff ruff check --select E,W,F,I,B,C4,UP,ARG,SIM,TC,PTH,RUF --ignore E501 --line-length 88 scripts/copier_update_aggregator.py scripts/tests/` → clean.
- [x] Ruff format matches downstream: `uv run --with ruff ruff format --check --line-length 88 ...` → 3 files already formatted.
- [x] Template renders cleanly via `copier copy --vcs-ref=HEAD`; the aggregator copies verbatim into the rendered project (not a Jinja template).
- [x] CLI surface unchanged: `AggregatorInputs` dataclass, `compose_body`, `compose_body_with_overflow`, `_parse_args` — all byte-identical to `origin/main`. The downstream invocation in `copier-update.yml.jinja` continues to work unchanged.
- [x] Local review circus on cumulative diff:
  - Round-1 surfaced two findings (the `#None` fix should extend to all six render sites; a brittle `"---" not in body` assertion).
  - Round-2 addressed both; round-2 reviewers explicit clean.
  - claude-review on the draft caught a related pre-existing edge case (orphaned sub-section header when content all-filters-out); round-3 commit addresses it across all three render functions.
  - Round-3 reviewers explicit clean — both walked through the two-level suppression composition and verified byte-identical trailing newlines.

## Notes

- Job A's two render sites (`_render_job_a` lines 132 / 142) use the same `f"`{item['file']}`"` pattern as Job B/C bullets. Job A uses bracket access (`item['file']`) so a missing key raises KeyError → caught by `_safe_render` → renders the error placeholder (acceptable). An explicit null would still render as `` `None` ``, but Job A's prompt schema documents `file` as a required string and Job A only fires when `conflict_count > 0`, so the practical risk is small. Out of scope for this PR; can be tracked separately if the same hardening is wanted across the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)