### PR TITLE
fix(copier-update): OIDC permission + bare Write for Jobs B/C

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -235,8 +235,11 @@ jobs:
       # Each agent step constrains tool access via `claude_args
       # --allowed-tools` to enforce the spec's per-job tool boundaries
       # (Job A: file read/write + git commit on the working tree; Jobs B/C:
-      # read-only). Without this, a prompt-injection-vulnerable model could
-      # bypass the prose constraints in the prompt body.
+      # read on the working tree and the cloned template, plus a path-scoped
+      # write on their single output JSON at /tmp/agent-job-{b,c}.json).
+      # Without this, a prompt-injection-vulnerable model could bypass the
+      # prose constraints in the prompt body — e.g. attempt to write a
+      # workflow file or clobber another job's output JSON.
 
       - name: Pre-render Job A prompt
         id: prepare-prompt-a
@@ -305,7 +308,7 @@ jobs:
           claude_code_oauth_token: {{ '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}' }}
           prompt: {{ '${{ steps.prepare-prompt-b.outputs.prompt }}' }}
           claude_args: |
-            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write(//tmp/agent-job-b.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job C prompt
         id: prepare-prompt-c
@@ -339,7 +342,7 @@ jobs:
           claude_code_oauth_token: {{ '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}' }}
           prompt: {{ '${{ steps.prepare-prompt-c.outputs.prompt }}' }}
           claude_args: |
-            --allowed-tools "Read,Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write(//tmp/agent-job-c.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -235,11 +235,12 @@ jobs:
       # Each agent step constrains tool access via `claude_args
       # --allowed-tools` to enforce the spec's per-job tool boundaries
       # (Job A: file read/write + git commit on the working tree; Jobs B/C:
-      # read on the working tree and the cloned template, plus a path-scoped
-      # write on their single output JSON at /tmp/agent-job-{b,c}.json).
-      # Without this, a prompt-injection-vulnerable model could bypass the
-      # prose constraints in the prompt body — e.g. attempt to write a
-      # workflow file or clobber another job's output JSON.
+      # read everywhere, plus a bare Write — narrowed to the single output
+      # JSON at /tmp/agent-job-{b,c}.json by prose in each job's prompt).
+      # The path-scoped Write(//tmp/agent-job-b.json) form documented at
+      # code.claude.com/docs/en/permissions empirically doesn't match the
+      # agent's single-slash invocations under the SDK shipped with
+      # claude-code-action@v1, so the prose constraint is what's narrow.
 
       - name: Pre-render Job A prompt
         id: prepare-prompt-a
@@ -308,7 +309,7 @@ jobs:
           claude_code_oauth_token: {{ '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}' }}
           prompt: {{ '${{ steps.prepare-prompt-b.outputs.prompt }}' }}
           claude_args: |
-            --allowed-tools "Read,Write(//tmp/agent-job-b.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job C prompt
         id: prepare-prompt-c
@@ -342,7 +343,7 @@ jobs:
           claude_code_oauth_token: {{ '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}' }}
           prompt: {{ '${{ steps.prepare-prompt-c.outputs.prompt }}' }}
           claude_args: |
-            --allowed-tools "Read,Write(//tmp/agent-job-c.json),Bash(cat:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Write,Bash(cat:*),Bash(git -C /tmp/template:*)"
 
       - name: Ensure PR labels exist
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required by anthropics/claude-code-action@v1: setupGitHubToken() mints
+      # a Claude-app GitHub token via OIDC token exchange, which needs
+      # id-token: write at the job level. Without it the agent steps retry
+      # 3x then abort on "Could not fetch an OIDC token".
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Three related fixes in `.github/workflows/copier-update.yml.jinja` that together unblock end-to-end agent enrichment of copier-update PRs.

### 1. OIDC permission (closes #122)
- Adds `id-token: write` to the `update` job's `permissions:` block.
- Carries a 4-line comment naming the upstream symptom (`Could not fetch an OIDC token`) and its cause (`claude-code-action@v1`'s `setupGitHubToken()` OIDC → Claude-app-token exchange).

### 2. Bare Write for Jobs B and C (closes #124)
- Switches Jobs B and C `--allowed-tools` to bare `Write`, matching Job A's working pattern.
- Earlier commits on this branch tried `Write,...` then `Write(//tmp/agent-job-{b,c}.json),...`. The path-scoped form per [Claude Code permissions docs](https://code.claude.com/docs/en/permissions) **empirically doesn't work** under the SDK shipping in `claude-code-action@v1`. A diagnostic run with `show_full_output: true` captured the smoking gun:
  - Agent invokes `Write(file_path="/tmp/agent-job-b.json")` (single slash)
  - SDK denies against rule `Write(//tmp/agent-job-b.json)` (double slash): *"Claude requested permissions to write to /tmp/agent-job-b.json, but you haven't granted it yet."*
- Bare Write matches anything; Job A has used it since this workflow was scaffolded and works without issues.

### 3. Comment block at lines 235-243 (bundled with #2)
- Was originally "Jobs B/C: read-only" — became stale + actively misleading once Write was added.
- Now accurately describes the new state (bare Write narrowed by prose in each job's prompt) and documents the docs/SDK mismatch so a future maintainer doesn't "fix" the bare Write back to the broken path-scoped form.

## Trade-off acknowledgment

Bare Write means Jobs B/C agents have unrestricted file-write within the ephemeral runner — the same posture Job A has had all along, on the same runner, reading the same public-content inputs. The narrowing to a single output JSON now lives in prose in each job's prompt body (`scripts/copier_update_prompts/job_{b,c}.md`: "NO file writes other than the output JSON"), not mechanically in the allowlist.

## Iteration history (for transparency)

1. Initial: bundled OIDC fix only (PR opened 2026-05-10).
2. Round 2: added bare `Write,` for Jobs B/C, claude-review LGTM.
3. Round 3: changed to path-scoped `Write(//tmp/agent-job-{b,c}.json)` per primary subagent's confidence-95 critical finding (prompt-injection defense argument), citing the Claude Code docs that document `//absolute-path` as the correct syntax.
4. Round 4 (this commit): diagnostic capture proved path-scoping isn't honored by the SDK; reverted to bare Write. The subagent's reasoning was correct in theory but the SDK doesn't reconcile docs and behavior. Upstream bug to file at `anthropics/claude-code-action`.

## Downstream rollout

Both fixes ship to consumers via a new template patch version. Parallel hotfixes on markdown-vault-mcp:
- pvliesdonk/markdown-vault-mcp#447 (OIDC, merged)
- pvliesdonk/markdown-vault-mcp#449 (path-scoped Write — superseded; deliberately leaving merged history rather than rewriting)
- pvliesdonk/markdown-vault-mcp#452 (show_full_output diagnostic, merged)
- pvliesdonk/markdown-vault-mcp#454 (bare Write + diagnostic revert — opening alongside this PR)

Once a new template version ships and is consumed downstream, copier overwrites the locally-edited workflow with the (already-fixed) template version.

## Test plan

- [x] Render template at HEAD against `tests/fixtures/smoke-answers.yml`; rendered `.github/workflows/copier-update.yml` contains `id-token: write` and bare `Write` for Jobs B/C.
- [x] Local gate green on rendered project.
- [ ] template-ci.yml self-test passes.
- [ ] After release: confirm a downstream `Copier Update` run no longer aborts on OIDC AND now produces all three enrichment sections (verified empirically once a downstream picks up the new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)