### PR TITLE
ci(release): expose `prerelease` as a force option so a second rc can be cut

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump (leave empty for auto)'
+        description: 'Force version bump (empty = auto; "prerelease" advances the rc revision e.g. rc.1 → rc.2 — keep the pre-release box below checked)'
         type: choice
         default: ''
         options:
           - ''
+          - prerelease
           - patch
           - minor
           - major
@@ -32,6 +33,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Reject contradictory dispatch inputs
+        if: inputs.force == 'prerelease' && inputs.prerelease == false
+        run: |
+          echo "::error::force=prerelease advances the rc revision and requires the pre-release box to stay checked"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Adds `prerelease` to the `force` `workflow_dispatch` choice list in the generated project's `release.yml`, and clarifies the input description.
- The release workflow could cut `X.Y.Z-rc.1` but never `rc.2`. `prerelease: true` maps to PSR's `--as-prerelease`, which does **not** force a release when none would otherwise occur. Advancing the rc revision needs PSR's `--prerelease` *force* flag, surfaced by the action as `force: prerelease` (valid `force` values: `prerelease`/`patch`/`minor`/`major`). The choice list simply never exposed it.
- Adds a guard step rejecting the contradictory `force: prerelease` + unchecked pre-release box combination, failing fast before checkout.

This mirrors the merged upstream fix in `pvliesdonk/fastmcp-pvl-core` PR #110.

## Behaviour

Dispatching the generated project's `Release` workflow with `force: prerelease` (pre-release box checked) runs `semantic-release version --prerelease --as-prerelease --prerelease-token rc`, which advances `rc.1 → rc.2`.

The `if:` expression `inputs.force == 'prerelease' && inputs.prerelease == false` is correct: the `inputs` context preserves `type: boolean` `workflow_dispatch` inputs as genuine booleans (verified against GitHub docs; same form as the merged upstream PR).

Closes #135

## Test plan

- [ ] `template-ci.yml` renders the template and runs the generated project's gate on Python 3.11–3.14.
- [ ] After a consumer picks up the update, dispatch its `Release` workflow with `force: prerelease` against an `rc.1` state and confirm it cuts `rc.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
