### PR TITLE
ci(claude-review): skip on fork PRs to avoid auth-failing checks

### DIFF
--- a/.github/workflows/claude-code-review.yml.jinja
+++ b/.github/workflows/claude-code-review.yml.jinja
@@ -12,6 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Skip PRs from forks: GitHub does not expose repository secrets
+    # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
+    # context, regardless of maintainer approval. Running anyway produces
+    # a hard-failing check on every external contribution. Maintainers who
+    # want a bot review on a fork PR can push the contributor's branch to
+    # this repo under a topic name and the workflow will run.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml.jinja
+++ b/.github/workflows/claude.yml.jinja
@@ -12,11 +12,17 @@ on:
 
 jobs:
   claude:
+    # Trigger only on @claude mentions, AND on the two PR-context events
+    # (`pull_request_review*`) only when the PR head is in this repo. Those
+    # events run in PR context for fork PRs, where GitHub withholds repository
+    # secrets (incl. CLAUDE_CODE_OAUTH_TOKEN) and the action would auth-fail.
+    # `issues` and `issue_comment` always run in base-repo context, so secrets
+    # are available — no fork check needed there.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- `claude-code-review.yml.jinja`: job-level `if:` guard requires `head.repo == base repo`.
- `claude.yml.jinja`: fork check added to the two PR-context events (`pull_request_review`, `pull_request_review_comment`). `issues` / `issue_comment` always run in base-repo context, so they don't need the check.
- Inline comments explain the rationale.

GitHub doesn't expose repository secrets (incl. `CLAUDE_CODE_OAUTH_TOKEN`) to workflows running in fork-PR context, regardless of maintainer approval. The previous setup produced a hard-failing `claude-review` check on every external PR (e.g. https://github.com/pvliesdonk/markdown-vault-mcp/pull/505).

Closes #138

## Test plan

- [x] `template-ci` smoke render + gate passes locally (ruff, ruff format, yaml parse on rendered workflows).
- [x] Rendered `claude-code-review.yml` and `claude.yml` contain the expected `if:` guards with no `{% raw %}` leakage.
- [x] Preflight-circus (5 lenses + supplementary code-reviewer) clean on `BASE..HEAD`.
- [ ] Downstream picks up the change via copier-update; verify a fork PR on a downstream no longer produces a failing `claude-review` check after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)