### PR TITLE
feat(docs): add Vale prose linter for downstream docs/**

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -218,3 +218,72 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+
+  vale:
+    name: Docs Prose (Vale)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # vale-cli/vale-action posts findings as PR annotations via reviewdog.
+      # The default reporter (`github-pr-annotations`) uses the GitHub Checks
+      # API — `checks: write` is sufficient. If a downstream switches the
+      # reporter to `github-pr-review` (inline PR review comments), they
+      # need to add `pull-requests: write` here too.
+      checks: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Vale style packages
+        # Vale style packs are ~30 MB total and re-downloaded on every run
+        # without caching. Cache key invalidates when .vale.ini changes
+        # (Packages line edited, ai-tells URL bumped, etc.) OR when any
+        # vocab file under .vale/styles/config/ changes (added/removed
+        # accepted terms). Without the config/** hash, cache restore would
+        # silently clobber a newly-added vocab term on disk with the stale
+        # snapshot, making Vale flag the new term as unknown in CI even
+        # though the file is checked in. The `v1-` prefix is a manual
+        # escape hatch: bump it to force re-sync if Vale ever changes
+        # pack format backward-incompatibly.
+        uses: actions/cache@v4
+        with:
+          path: .vale/styles
+          key: vale-styles-v1-{% raw %}${{ hashFiles('.vale.ini', '.vale/styles/config/**') }}{% endraw %}
+          # Fallback to any prior `vale-styles-v1-*` cache as a warm start
+          # when the exact key misses. `vale sync` will then only fetch the
+          # packs that actually changed instead of re-downloading all four.
+          restore-keys: vale-styles-v1-
+
+      - name: Run Vale
+        # SHA pin matches the gitleaks-action pattern earlier in this file.
+        # The current release is named "v2.1.2" in the GitHub UI but the
+        # underlying git tag is `2.1.2` (no `v` prefix) — pinning to the
+        # SHA sidesteps that mismatch and provides supply-chain hygiene.
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a  # v2.1.2
+        with:
+          # Pin Vale CLI version explicitly. Bump in lockstep with the
+          # pre-commit hook `rev:` in .pre-commit-config.yaml — template-ci
+          # asserts the two stay synchronized.
+          version: "3.14.2"
+          files: docs
+          # Working specs follow internal conventions, not user-facing prose
+          # style — exclude from linting. NO inner single quotes around the
+          # glob value: vale-action splits `vale_flags` on whitespace and
+          # passes argv elements directly (no shell), so literal quotes here
+          # would be passed through to Vale, the glob would match no files,
+          # and CI would silently exit 0. Verified empirically.
+          vale_flags: "--glob=!docs/superpowers/**"
+          # Failure gating is controlled by MinAlertLevel = error in
+          # .vale.ini (governs both what Vale prints AND its exit code)
+          # combined with fail_on_error below — only error-severity
+          # findings fail CI; warnings and suggestions surface as advisory
+          # annotations. (The action also accepts a `level:` input, but at
+          # the pinned SHA that input is declared but never read — the
+          # reviewdog level is derived from Vale's exit code and
+          # fail_on_error. Setting it here would be a no-op.)
+          fail_on_error: true
+          # filter_mode defaults to `added` — only findings on lines this PR
+          # adds or modifies fail the build. Pre-existing prose debt isn't a
+          # blocker for new contributions; downstream's own untouched docs
+          # don't gate PRs that don't touch them. To enforce repo-wide
+          # cleanliness, set this to `nofilter`.
+          filter_mode: added

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -134,6 +134,43 @@ jobs:
           grep -qF 'any(.[]; .name == $name)' .github/workflows/release.yml \
             || { echo "::error::release.yml missing upsert branch — still silently no-ops on missing entry"; exit 1; }
 
+      - name: vale config structural check
+        working-directory: /tmp/smoke
+        run: |
+          # Cheap sanity check on the rendered .vale.ini — catches
+          # template breakage (empty file, missing Packages directive)
+          # without paying the cost of a full vale sync+lint round.
+          [ -f .vale.ini ] || { echo "::error::.vale.ini missing — render regressed"; exit 1; }
+          grep -qE '^StylesPath\s*=' .vale.ini \
+            || { echo "::error::.vale.ini missing StylesPath directive"; exit 1; }
+          grep -qE '^Packages\s*=' .vale.ini \
+            || { echo "::error::.vale.ini missing Packages directive"; exit 1; }
+          grep -qE '^\[\*\.md\]$' .vale.ini \
+            || { echo "::error::.vale.ini missing [*.md] section"; exit 1; }
+          grep -qE '^BasedOnStyles\s*=' .vale.ini \
+            || { echo "::error::.vale.ini missing BasedOnStyles directive"; exit 1; }
+
+      - name: vale version pin lockstep
+        working-directory: /tmp/smoke
+        run: |
+          # CI's vale-cli/vale-action `version:` and pre-commit's vale hook
+          # `rev:` must stay in lockstep — drift means local pre-commit and
+          # CI exercise different Vale binaries, so a finding visible to one
+          # becomes silent to the other. Same discipline as the nfpm
+          # lockstep enforced in PR #66.
+          #
+          # CI_VER extraction is scoped to the `vale:` job to avoid
+          # accidentally matching a `version: "X.Y.Z"` if some other job
+          # (e.g. setup-uv) ever moves off `version: "latest"` to a pinned
+          # semver — that would silently extract the wrong pin and let real
+          # drift slip through.
+          CI_VER=$(awk '/^  vale:/{f=1} f && /^[[:space:]]+version:/{print; exit}' .github/workflows/ci.yml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          PC_VER=$(awk '/^[[:space:]]*-[[:space:]]*repo:.*vale-cli\/vale[[:space:]]*$/{f=1; next} f && /rev:/{print; exit}' .pre-commit-config.yaml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          [ -n "$CI_VER" ] || { echo "::error::vale version pin not found in rendered ci.yml"; exit 1; }
+          [ -n "$PC_VER" ] || { echo "::error::vale rev not found in rendered .pre-commit-config.yaml"; exit 1; }
+          [ "$CI_VER" = "$PC_VER" ] \
+            || { echo "::error::vale version drift — ci.yml=$CI_VER pre-commit=$PC_VER (bump in lockstep)"; exit 1; }
+
   # Runs the two downstream workflow shapes that generated projects invoke
   # on their own CI — `mkdocs build --strict` (docs.yml) and `nfpm package`
   # (release.yml).  Dedicated non-matrix job so the downstream-gate is

--- a/.gitignore.jinja
+++ b/.gitignore.jinja
@@ -29,6 +29,12 @@ htmlcov/
 # MkDocs build output
 site/
 
+# Vale-synced style packages (downloaded by `vale sync`). Custom config
+# (vocabularies, ini overrides) under .vale/styles/config/ stays
+# versioned — sync never touches that subtree.
+.vale/styles/*
+!.vale/styles/config/
+
 # Local environment
 .env
 .env.local

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -37,3 +37,62 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+
+  # Vale prose lint for docs/**. Requires Vale on PATH (`brew install vale`,
+  # `apt install vale`, or download from https://vale.sh/docs/install).
+  # First commit touching docs/ or .vale.ini auto-runs `vale sync` because
+  # the style-pack dirs are missing; subsequent commits are no-ops. Adding a
+  # new package to .vale.ini's `Packages =` line, or bumping a pinned URL
+  # version, does NOT re-sync automatically — the four hard-coded pack-dir
+  # checks below don't see the new package, and bumped-version dirs still
+  # exist on disk. After such .vale.ini edits, run `vale sync` manually
+  # (or `rm -rf .vale/styles/<pack>` to force re-sync via the hook).
+  - repo: local
+    hooks:
+      - id: vale-sync
+        name: vale sync (download style packages if missing)
+        # Loud-fail if Vale isn't on PATH OR if `vale sync` fails (network,
+        # bad URL, etc.). Both error modes silently exited 0 in earlier
+        # iterations: bash's brace-group returns the exit status of its
+        # LAST command, which was `break` (always 0), masking sync failures
+        # and "vale: command not found". `command -v vale` plus `exit 1` on
+        # sync failure plug both holes — without them the next hook (`vale`)
+        # would run against un-synced packs, where Vale prints E201 config
+        # errors and itself exits 0, the exact silent-pass this hook exists
+        # to prevent.
+        language: system
+        entry: |
+          bash -c '
+            command -v vale >/dev/null 2>&1 || {
+              echo "vale not on PATH — install: https://vale.sh/docs/install" >&2
+              exit 1
+            }
+            for p in Google proselint write-good ai-tells; do
+              if [ ! -d ".vale/styles/$p" ]; then
+                vale sync || exit 1
+                break
+              fi
+            done
+          '
+        pass_filenames: false
+        files: ^(docs/|\.vale\.ini$)
+        # Align trigger scope with the `vale` lint hook below — no point
+        # checking sync state on commits that only touch the excluded
+        # working-specs subtree.
+        exclude: ^docs/superpowers/
+
+  - repo: https://github.com/vale-cli/vale
+    rev: v3.14.2
+    hooks:
+      - id: vale
+        # MUST run after `vale-sync` above. Pre-commit runs hooks in
+        # declaration order; if vale precedes vale-sync on a fresh clone
+        # the packs aren't populated, Vale prints E201 config errors and
+        # exits 0 — silent pass.
+        # Upstream hook has `types: [text]`; this `files:` scopes to docs/.
+        # Together: any text file under docs/ except the working-specs
+        # subtree. Matches the CI step's `vale ... --glob='!docs/superpowers/**' docs/`
+        # scope exactly (both lint markdown + asciidoc + rst + plain
+        # text — every format Vale supports — under docs/).
+        files: ^docs/
+        exclude: ^docs/superpowers/

--- a/.vale.ini.jinja
+++ b/.vale.ini.jinja
@@ -1,0 +1,41 @@
+# Vale prose linter — https://vale.sh
+#
+# Lints `docs/**` for prose issues. Working specs under `docs/superpowers/**`
+# are excluded by the pre-commit hook (`exclude:` pattern) and the CI step
+# (`--glob='!docs/superpowers/**'`); Vale itself has no notion of "skip this
+# subtree", so the exclusion lives at the invocation site.
+#
+# `MinAlertLevel = error` governs both what Vale prints AND its exit code —
+# warnings and suggestions are advisory (visible in `vale --minAlertLevel=
+# warning` runs) but do not fail CI / pre-commit. Tune individual rules
+# (e.g. disable a noisy one) via per-rule overrides:
+#
+#     [*.md]
+#     Google.Spelling = NO
+#
+# See https://vale.sh/docs/keys/format for the full key reference and
+# https://vale.sh/docs/topics/styles for rule-tuning syntax.
+#
+# To add project-specific accepted vocabulary (terms that should not be
+# flagged as unknown words), create
+# `.vale/styles/config/vocabularies/Base/accept.txt`, list one term per
+# line, then add `Vocab = Base` below `MinAlertLevel`. The config/
+# subtree is preserved across `vale sync`; see .gitignore for the
+# include/exclude rules.
+
+StylesPath = .vale/styles
+MinAlertLevel = error
+
+# `Vale` is a built-in style, always available without listing here.
+# `Google`, `proselint`, `write-good` are upstream packages fetched by
+# `vale sync` from Vale's package registry — listed by name without an
+# `@version` suffix means they resolve to the latest registry release on
+# each sync. Intentional: keeps style rules current. To pin for
+# reproducibility, append a version (e.g. `Google@1.0.0`).
+# `ai-tells` (https://github.com/tbhb/vale-ai-tells) catches common
+# LLM-prose tells; pinned to a release URL since it is not in Vale's
+# package index.
+Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
+
+[*.md]
+BasedOnStyles = Vale, Google, proselint, write-good, ai-tells

--- a/copier.yml
+++ b/copier.yml
@@ -50,6 +50,10 @@ _skip_if_exists:
   # yamllint, project-specific linters, etc.) on top of the shipped defaults;
   # preserve customisation across updates.
   - ".pre-commit-config.yaml"
+  # Vale config — users tune rule overrides, add Vocab, pin Packages
+  # versions per their docs corpus.  Initial render seeds the file; later
+  # template updates leave their tuning intact.
+  - ".vale.ini"
 # Note: CLAUDE.md and README.md are deliberately NOT in _skip_if_exists.
 # Both are hybrid files: domain-owned sections are bracketed by
 # <!-- DOMAIN-START --> / <!-- DOMAIN-END --> markers, and the rest is


### PR DESCRIPTION
## Summary

- `.vale.ini.jinja` — config with Google + proselint + write-good + ai-tells + built-in Vale. `MinAlertLevel = error` (warnings/suggestions advisory). In `_skip_if_exists` so downstream can tune rules / add Vocab without losing changes on copier-update.
- `.pre-commit-config.yaml.jinja` — local `vale-sync` hook (loud-fails if `vale` isn't on PATH OR if `vale sync` fails) + upstream `vale-cli/vale@v3.14.2` lint hook. Both scope to `docs/` excluding `docs/superpowers/`.
- `.github/workflows/ci.yml.jinja` — new `vale` job using `vale-cli/vale-action@85f9f7f...` (SHA-pinned for supply-chain hygiene; the underlying tag is `2.1.2` not `v2.1.2`). Reviewdog-driven inline PR annotations; `filter_mode: added` so only NEW prose findings fail CI.
- `.gitignore.jinja` — ignore `.vale/styles/*` but re-include `.vale/styles/config/` so custom Vocab stays versioned.
- `.github/workflows/template-ci.yml` — structural sanity check on rendered `.vale.ini` + **vale version pin lockstep** check that asserts ci.yml's `version:` and pre-commit's `rev:` agree (PR #66 nfpm-lockstep pattern).
- `copier.yml` — `.vale.ini` added to `_skip_if_exists`.

Closes #139.

## ⚠️ Release dependency

This PR introduces a CI gate that runs against rendered downstream docs. **The rendered template docs themselves produce ~166 Vale errors today**, tracked in #141. **#141 MUST land before any release that includes this PR** — otherwise every downstream's first Vale CI run will fail out of the box.

## Design notes

**Why `vale-cli/vale-action` over curl-install.** Earlier revision installed Vale via `curl | tar -xz` and ran lint by hand. Switched to the official action: handles install + sync, posts findings as inline PR annotations via reviewdog, gives us `filter_mode: added` (only NEW findings fail — pre-existing prose debt isn't a blocker).

**`vale_flags` quoting trap.** The action splits `vale_flags` on whitespace and passes argv elements directly (no shell). Inner single quotes around the glob value would be passed through to Vale literally, the glob would match no files, and CI would silently exit 0 — `fail_on_error: true` cannot fire. Inline comment warns about this. Verified empirically.

**Dead `level:` input.** The pinned action declares `level` but never reads it — the reviewdog level is derived from Vale's exit code and `fail_on_error`. Failure gating is controlled by `MinAlertLevel = error` in `.vale.ini` + `fail_on_error: true`. Inline comment notes this so a future maintainer doesn't add `level:` thinking it does something.

**Hardcoded pack-name list in `vale-sync` hook.** The hook checks for `.vale/styles/{Google,proselint,write-good,ai-tells}` and runs `vale sync` if any is missing. Adding a new package or bumping a pinned URL requires manual `vale sync` (parsing the `Packages =` line is fragile; always-syncing costs ~2.4s/commit). Documented in the comment block above the hook.

**CI ↔ pre-commit scope alignment.** Both lint `docs/**` excluding `docs/superpowers/**`. Pre-commit + CI version pins enforced in lockstep by template-ci.

## Test plan

- [x] `template-ci` smoke render gate passes locally.
- [x] Rendered `.vale.ini` parses; rendered `.pre-commit-config.yaml` YAML parses; vale hooks present.
- [x] `vale-sync` hook loud-fails when Vale binary is missing (PATH=/tmp/nope → exit 1).
- [x] `vale-sync` hook loud-fails when `vale sync` itself fails (bogus URL → exit 1).
- [x] Vale `--glob=!docs/superpowers/**` (unquoted, action's argv shape) lints expected files; quoted form silently lints 0 files.
- [x] template-ci `vale version pin lockstep` check: matching versions pass; mismatched versions fail loudly with diagnostic.
- [x] vale-cli/vale-action SHA verified via `git ls-remote refs/tags/2.1.2`.
- [x] Preflight-circus across rounds 1–6 (full circus); round 7 hit subagent quota after Lens 1 completed clean. The diff delta since the last fully-clean round (round 6 + supplementary) is the two empirically-verified bug fixes recommended by that round's supplementary reviewer; bot review on this push is the safety net.
- [ ] Downstream picks up the change via copier-update; first run will surface findings against the downstream's own docs that need addressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)