### PR TITLE
fix: convert DOMAIN-*-EXTRA sentinels to pure HTML-comment blocks

### DIFF
--- a/docs/deployment/docker.md.jinja
+++ b/docs/deployment/docker.md.jinja
@@ -81,12 +81,7 @@ When the helper is invoked but `debugpy` isn't installed (say, someone sets `DEB
 
 
 <!-- DOMAIN-DOCKER-EXTRA-START -->
-<!-- Project-specific notes for Docker deployment; kept across copier update. -->
-
-## Project-specific notes
-
-<!-- Add domain-specific caveats here (e.g. "the /data/uploads volume must
-     be writable by UID Y", "container needs cap_add: SYS_PTRACE for
-     debugging tools"). Use sub-headings to organize if needed. -->
-
+<!-- Project-specific notes for Docker deployment go here; kept across copier
+     update. (E.g. "the /data/uploads volume must be writable by UID Y",
+     "container needs cap_add: SYS_PTRACE for debugging tools".) -->
 <!-- DOMAIN-DOCKER-EXTRA-END -->

--- a/docs/deployment/oidc.md.jinja
+++ b/docs/deployment/oidc.md.jinja
@@ -203,12 +203,7 @@ labels:
 
 
 <!-- DOMAIN-OIDC-EXTRA-START -->
-<!-- Project-specific notes for OIDC deployment; kept across copier update. -->
-
-## Project-specific notes
-
-<!-- Add domain-specific caveats here (e.g. "Keycloak requires X claim",
-     "Authelia token-cache quirk for /admin paths", "this server's audience
-     claim must include 'mcp'"). Use sub-headings to organize if needed. -->
-
+<!-- Project-specific notes for OIDC deployment go here; kept across copier
+     update. (E.g. "Keycloak requires X claim", "Authelia token-cache quirk
+     for /admin paths", "this server's audience claim must include 'mcp'".) -->
 <!-- DOMAIN-OIDC-EXTRA-END -->

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -232,13 +232,8 @@ When these are resolved, OIDC sessions should persist indefinitely via automatic
 
 
 <!-- DOMAIN-AUTH-EXTRA-START -->
-<!-- Project-specific notes for authentication; kept across copier update. -->
-
-## Project-specific notes
-
-<!-- Add domain-specific caveats here (e.g. "paperless-mcp tokens expire
-     every 60 min", "this server requires the 'admin' scope for write tools",
-     "bearer-token middleware skips /health for liveness probes"). Use
-     sub-headings to organize if needed. -->
-
+<!-- Project-specific notes for authentication go here; kept across copier
+     update. (E.g. "paperless-mcp tokens expire every 60 min", "this server
+     requires the 'admin' scope for write tools", "bearer-token middleware
+     skips /health for liveness probes".) -->
 <!-- DOMAIN-AUTH-EXTRA-END -->

--- a/docs/installation.md.jinja
+++ b/docs/installation.md.jinja
@@ -21,10 +21,7 @@ uv sync --all-extras --all-groups
 ```
 
 <!-- DOMAIN-INSTALL-EXTRA-START -->
-
-## Project-specific notes
-
-_Add domain-specific install notes here, such as system dependencies, optional
-extras, or custom configuration steps._
-
+<!-- Project-specific notes for installation go here; kept across copier
+     update. (E.g. system dependencies, optional extras, custom configuration
+     steps.) -->
 <!-- DOMAIN-INSTALL-EXTRA-END -->


### PR DESCRIPTION
## Summary

Closes #130

Converts four `DOMAIN-*-EXTRA` sentinel blocks from a mixed visible-heading + hidden-placeholder pattern to pure HTML-comment blocks, matching the sibling `DOMAIN-*` sentinel convention used elsewhere in the template.

**Problem (issue #130):** The old pattern shipped a `## Project-specific notes` Markdown heading inside the sentinel block. In every generated project that had not yet customised the block, this heading rendered as a visible orphan section in the published docs site — content-less but present. Downstream consumers either lived with the orphan or patched it locally (scholar-mcp fixed `DOMAIN-INSTALL-EXTRA` locally in its own v1.4.0 → v1.5.0 update).

**Fix:** Replace the visible heading + instructional HTML comment with a single compact HTML-comment block:

```html
<!-- Project-specific notes for <topic> go here; kept across copier
     update. (E.g. "example A", "example B".) -->
```

Applied uniformly to all four `DOMAIN-*-EXTRA` blocks:
- `docs/guides/authentication.md.jinja` — `DOMAIN-AUTH-EXTRA`
- `docs/deployment/docker.md.jinja` — `DOMAIN-DOCKER-EXTRA`
- `docs/deployment/oidc.md.jinja` — `DOMAIN-OIDC-EXTRA`
- `docs/installation.md.jinja` — `DOMAIN-INSTALL-EXTRA`

The `DOMAIN-INSTALL-EXTRA` block also gains the missing "kept across copier update" note that the other three already carried.

## Scope boundary

The `EVENT_STORE_URL` → `KV_STORE_URL` rename (issue #137) is **not** in this PR. `KV_STORE_URL` is a pvl-core 3.x API; advertising it in `server.json.jinja` while the pin is still `>=2.1.0,<3` would cause silently-ignored configuration for operators of generated projects. That rename ships with the `>=3.2.0,<4` pin-bump PR.

## Verification

```bash
# Render and run the full gate
rm -rf /tmp/smoke && uv run --no-project --with copier \
  copier copy --trust --defaults --vcs-ref=HEAD \
  --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
cd /tmp/smoke
uv sync --all-extras --all-groups
uv run ruff check . && uv run ruff format --check .
uv run mypy src/ tests/ && uv run pytest -x -q
uv run mkdocs build --strict

# Confirm orphan headings are gone from generated auth guide
! grep -q '## Project-specific notes' docs/guides/authentication.md
! grep -q '## Project-specific notes' docs/deployment/docker.md
! grep -q '## Project-specific notes' docs/deployment/oidc.md
! grep -q '## Project-specific notes' docs/installation.md

# Confirm sentinel markers are intact (copier 3-way-merge protection)
grep -q 'DOMAIN-AUTH-EXTRA-START' docs/guides/authentication.md
grep -q 'DOMAIN-DOCKER-EXTRA-START' docs/deployment/docker.md
grep -q 'DOMAIN-OIDC-EXTRA-START' docs/deployment/oidc.md
grep -q 'DOMAIN-INSTALL-EXTRA-START' docs/installation.md
```

All checks verified green locally (ruff, mypy, pytest 9/9, mkdocs --strict, grep assertions above).

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._