### PR TITLE
feat(deps): bump fastmcp-pvl-core to >=3.2.0,<4 and expose build_kv_store

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -103,7 +103,7 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 |---|---|---|
 | `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
-| `{{ env_prefix }}_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
+| `{{ env_prefix }}_KV_STORE_URL` | `file:///data/state` | Persistent-state backend URL for pvl-core subsystems — `file:///path` (survives restarts), `memory://` (dev/ephemeral). |
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -16,7 +16,7 @@ classifiers = [
     "License :: Other/Proprietary License",  # starter: TODO update when you pick a license (see LICENSE)
 ]
 dependencies = [
-    "fastmcp-pvl-core>=2.1.0,<3",
+    "fastmcp-pvl-core>=3.2.0,<4",
     "typer>=0.12",
     # PROJECT-DEPS-START — add domain dependencies below; kept across copier update
     # PROJECT-DEPS-END

--- a/server.json.jinja
+++ b/server.json.jinja
@@ -105,9 +105,9 @@
           ]
         },
         {
-          "name": "{{ env_prefix }}_EVENT_STORE_URL",
-          "description": "Event store backend for HTTP session persistence (file:///path or memory://)",
-          "default": "file:///data/state/events"
+          "name": "{{ env_prefix }}_KV_STORE_URL",
+          "description": "Persistent-state backend URL for pvl-core subsystems. Schemes: file:///path (survives restarts), memory:// (dev/ephemeral).",
+          "default": "file:///data/state"
         },
         {
           "name": "{{ env_prefix }}_SERVER_NAME",

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -18,6 +18,7 @@ from fastmcp_pvl_core import (
     build_auth,
     build_event_store,  # noqa: F401  — re-exported for downstream projects' convenience
     build_instructions,
+    build_kv_store,  # noqa: F401  — re-exported for downstream projects' convenience
     configure_logging_from_env,
     register_server_info_tool,
     resolve_auth_mode,


### PR DESCRIPTION
## Summary

- **`pyproject.toml.jinja`**: bump `fastmcp-pvl-core` pin from `>=2.1.0,<3` to `>=3.2.0,<4`
- **`server.py.jinja`**: add `build_kv_store` re-export alongside `build_event_store` (alphabetically ordered)
- **`server.json.jinja`**: rename `{env_prefix}_EVENT_STORE_URL` → `{env_prefix}_KV_STORE_URL`; update description (no forward references); default `file:///data/state` (pvl-core 3.x default, no subsystem suffix)
- **`README.md.jinja`**: align configuration table row with new env-var name and default

`build_event_store` is retained as a re-export — pvl-core 3.x keeps it as a legacy shim that reads `KV_STORE_URL` first, `EVENT_STORE_URL` as fallback with a deprecation warning. `cli.py.jinja` requires no change.

Closes #137

## Test plan

- [x] `copier copy --vcs-ref=HEAD` renders cleanly
- [x] `uv sync --all-extras --all-groups` resolves with pvl-core 3.2.0
- [x] `ruff check . && ruff format --check .` — no issues
- [x] `mypy src/ tests/` — no issues
- [x] `pytest -x -q` — 9 passed (0 failures)
- [x] Preflight circus (5 core lenses + code-reviewer + pr-test-analyzer) — 0 findings ≥ 80 confidence
- [x] Empirically verified `build_event_store` still exported in pvl-core 3.2.0 (legacy shim confirmed)
- [x] Empirically verified `build_kv_store` exported in pvl-core 3.2.0
- [x] Verified `KV_STORE_URL` is read by `ServerConfig.from_env()` in pvl-core 3.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._