### PR TITLE
feat(ci): surface MCPB_VERSION as env var and add bundle smoke-test

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -287,12 +287,14 @@ jobs:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
+    env:
+      MCPB_VERSION: "2.1.2"
     steps:
       - uses: actions/checkout@v6
         with:
           ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
       - name: Install mcpb CLI
-        run: npm install -g @anthropic-ai/mcpb@2.1.2
+        run: npm install -g @anthropic-ai/mcpb@$MCPB_VERSION
       - name: Render templates
         env:
           VERSION: {% raw %}${{ needs.release.outputs.version }}{% endraw %}
@@ -311,6 +313,28 @@ jobs:
           mcpb validate build/mcpb/manifest.json
           mkdir -p dist
           mcpb pack build/mcpb "dist/{{ project_name }}-${VERSION}.mcpb"
+      - name: Smoke-test bundle artifact
+        env:
+          VERSION: {% raw %}${{ needs.release.outputs.version }}{% endraw %}
+        run: |
+          bundle="dist/{{ project_name }}-${VERSION}.mcpb"
+          test -f "$bundle" || { echo "::error::bundle missing: $bundle"; exit 1; }
+
+          work=$(mktemp -d)
+          unzip -q "$bundle" -d "$work"
+
+          test -f "$work/manifest.json"  || { echo "::error::manifest.json missing from bundle"; exit 1; }
+          test -f "$work/pyproject.toml" || { echo "::error::pyproject.toml missing from bundle"; exit 1; }
+          test -f "$work/src/server.py"  || { echo "::error::src/server.py missing from bundle"; exit 1; }
+
+          bundled_version=$(jq -r .version "$work/manifest.json")
+          test "$bundled_version" = "$VERSION" \
+            || { echo "::error::manifest version $bundled_version != release $VERSION"; exit 1; }
+
+          jq -e '.server.mcp_config.env' "$work/manifest.json" > /dev/null \
+            || { echo "::error::manifest missing server.mcp_config.env"; exit 1; }
+          jq -e '.user_config' "$work/manifest.json" > /dev/null \
+            || { echo "::error::manifest missing user_config"; exit 1; }
       - uses: actions/upload-artifact@v7
         with:
           name: mcpb-bundle

--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -321,6 +321,7 @@ jobs:
           test -f "$bundle" || { echo "::error::bundle missing: $bundle"; exit 1; }
 
           work=$(mktemp -d)
+          trap 'rm -rf "$work"' EXIT
           unzip -q "$bundle" -d "$work"
 
           test -f "$work/manifest.json"  || { echo "::error::manifest.json missing from bundle"; exit 1; }


### PR DESCRIPTION
## Summary

- `MCPB_VERSION: "2.1.2"` added as a job-level env var in `build-mcpb` — CLI pin is now a one-line bump instead of a buried inline string
- Post-pack smoke step verifies the produced `.mcpb` bundle: file exists, `manifest.json` / `pyproject.toml` / `src/server.py` present, manifest version matches the release tag, `server.mcp_config.env` and `user_config` sections present
- `jq` is pre-installed on `ubuntu-latest`; no extra setup needed

Closes #128

## Test plan

- [x] Smoke gate passes (`ruff`, `mypy`, `pytest` — 9 passed)
- [x] Preflight circus (5 core lenses + code-reviewer) — 0 findings ≥ 80 confidence
- [x] Verified `jq -e` exit-code semantics correct for object truthiness check
- [x] Verified `src/server.py` path matches `packaging/mcpb/manifest.json.in.jinja` `entry_point`
- [x] Verified `$MCPB_VERSION` shell expansion is correct (job-level env, no `{% raw %}` guard needed)

Note: the smoke-test step only runs during real releases (`if: needs.release.outputs.released == 'true'`), so it is not exercised by `template-ci.yml`'s gate — this is inherent to release-only workflow steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._