### PR TITLE
feat(docs): add Claude Desktop deployment guide (#119)

### DIFF
--- a/.vale/styles/config/vocabularies/Base/accept.txt.jinja
+++ b/.vale/styles/config/vocabularies/Base/accept.txt.jinja
@@ -28,6 +28,7 @@ namespace
 namespaced
 pytest
 ruff
+stdio
 
 # --- Operational / config jargon ---
 config

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -82,6 +82,8 @@ mcpb install {{ project_name }}-<version>.mcpb
 
 Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
 
+For manual Claude Desktop configuration and setup options, see [Claude Desktop deployment](docs/deployment/claude-desktop.md).
+
 ## Quick start
 
 ```bash

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -1,0 +1,99 @@
+# Claude Desktop
+
+{{ human_name }} integrates with [Claude Desktop](https://claude.ai/download) via the stdio transport.
+
+## Setup
+
+### 1. Install
+
+From PyPI:
+
+```bash
+pip install {{ pypi_name }}
+```
+
+Or with uv:
+
+```bash
+uv tool install {{ pypi_name }}
+```
+
+Or download the `.mcpb` bundle from the [GitHub Releases](https://github.com/{{ github_org }}/{{ project_name }}/releases) page and double-click to install — Claude Desktop prompts for required env vars via a GUI wizard, no manual JSON editing needed.
+
+### 2. Configure Claude Desktop
+
+Add the server to your Claude Desktop configuration file:
+
+=== "macOS"
+
+    Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+=== "Windows"
+
+    Edit `%APPDATA%\Claude\claude_desktop_config.json`:
+
+=== "Linux"
+
+    Edit `~/.config/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "{{ project_name }}": {
+      "command": "{{ project_name }}",
+      "args": ["serve"],
+      "env": {
+        "{{ env_prefix }}_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
+
+### 3. Restart Claude Desktop
+
+Restart the application to pick up the new configuration. You should see the {{ human_name }} tools available in Claude's tool list.
+
+## Configuration examples
+
+<!-- DOMAIN-CLAUDE-DESKTOP-START -->
+<!-- Add domain-specific Claude Desktop configuration examples here.
+     Kept across copier update. -->
+<!-- DOMAIN-CLAUDE-DESKTOP-END -->
+
+## Using with uv
+
+If you installed with `uv tool install`, the command is already on your PATH. If you installed in a project with `uv pip install`, point to the uv-managed binary:
+
+```json
+{
+  "mcpServers": {
+    "{{ project_name }}": {
+      "command": "uv",
+      "args": ["run", "{{ project_name }}", "serve"],
+      "env": {
+        "{{ env_prefix }}_READ_ONLY": "true"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Server not appearing in Claude Desktop
+
+1. Check the config file path is correct for your OS
+2. Ensure the JSON is valid (no trailing commas)
+3. Restart Claude Desktop completely (quit and reopen)
+4. Check Claude Desktop logs for error messages
+
+### "Command not found"
+
+Ensure `{{ project_name }}` is on your PATH. If installed in a virtualenv, use the full path to the binary:
+
+```json
+{
+  "command": "/Users/me/.venvs/mcp/bin/{{ project_name }}"
+}
+```

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -72,18 +72,36 @@ If the binary is not on your PATH, use the full path to it instead — see [Comm
 
 ### "Command not found"
 
-Ensure `{{ project_name }}` is on your PATH. If installed in a virtualenv, use the full path to the binary (macOS/Linux example):
+Ensure `{{ project_name }}` is on your PATH. If installed in a virtualenv, use the full path to the binary. Replace only the `"command"` value in your existing config — keep `"args"` and `"env"` as-is.
+
+macOS/Linux:
 
 ```json
 {
-  "command": "/Users/me/.venvs/mcp/bin/{{ project_name }}"
+  "mcpServers": {
+    "{{ project_name }}": {
+      "command": "/Users/me/.venvs/mcp/bin/{{ project_name }}",
+      "args": ["serve"],
+      "env": {
+        "{{ env_prefix }}_READ_ONLY": "true"
+      }
+    }
+  }
 }
 ```
 
-On Windows, the equivalent path uses `Scripts\` instead of `bin/` and includes the `.exe` suffix:
+Windows (`Scripts\` not `bin\`, `.exe` suffix):
 
 ```json
 {
-  "command": "%USERPROFILE%\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe"
+  "mcpServers": {
+    "{{ project_name }}": {
+      "command": "%USERPROFILE%\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe",
+      "args": ["serve"],
+      "env": {
+        "{{ env_prefix }}_READ_ONLY": "true"
+      }
+    }
+  }
 }
 ```

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -44,7 +44,7 @@ Add the server to your Claude Desktop configuration file. The path varies by ope
 
 ### 3. Restart Claude Desktop
 
-Restart the application to pick up the new configuration. You should see the {{ human_name }} tools available in Claude's tool list.
+Restart the application to pick up the new configuration. If the server connects successfully, `{{ human_name }}` tools appear in Claude's tool list. If not, see [Troubleshooting](#troubleshooting) below.
 
 ## Configuration examples
 

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -18,23 +18,15 @@ Or with uv:
 uv tool install {{ pypi_name }}
 ```
 
-Or download the `.mcpb` bundle from the [GitHub Releases](https://github.com/{{ github_org }}/{{ project_name }}/releases) page and double-click to install — Claude Desktop prompts for required env vars via a GUI wizard, no manual JSON editing needed.
+Or download the `.mcpb` bundle from the [GitHub Releases](https://github.com/{{ github_org }}/{{ project_name }}/releases) page and double-click to install; Claude Desktop prompts for required env vars via a GUI wizard, no manual JSON editing needed.
 
 ### 2. Configure Claude Desktop
 
-Add the server to your Claude Desktop configuration file:
+Add the server to your Claude Desktop configuration file. The path varies by operating system:
 
-=== "macOS"
-
-    Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
-
-=== "Windows"
-
-    Edit `%APPDATA%\Claude\claude_desktop_config.json`:
-
-=== "Linux"
-
-    Edit `~/.config/Claude/claude_desktop_config.json`:
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
 
 ```json
 {
@@ -63,21 +55,9 @@ Restart the application to pick up the new configuration. You should see the {{ 
 
 ## Using with uv
 
-If you installed with `uv tool install`, the command is already on your PATH. If you installed in a project with `uv pip install`, point to the uv-managed binary:
+Install with `uv tool install {{ pypi_name }}` to make `{{ project_name }}` available as a global command on your PATH. The configuration in step 2 works as-is.
 
-```json
-{
-  "mcpServers": {
-    "{{ project_name }}": {
-      "command": "uv",
-      "args": ["run", "{{ project_name }}", "serve"],
-      "env": {
-        "{{ env_prefix }}_READ_ONLY": "true"
-      }
-    }
-  }
-}
-```
+If the binary is not on your PATH, use the full path to it instead — see [Command not found](#command-not-found) below.
 
 ## Troubleshooting
 

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -12,7 +12,7 @@ From PyPI:
 pip install {{ pypi_name }}
 ```
 
-Or with uv:
+Or with uv (installs `{{ project_name }}` as a global command on your PATH):
 
 ```bash
 uv tool install {{ pypi_name }}
@@ -55,12 +55,6 @@ Restart the application to pick up the new configuration. If the server connects
      Kept across copier update. -->
 <!-- DOMAIN-CLAUDE-DESKTOP-END -->
 
-## Using with uv
-
-Install with `uv tool install {{ pypi_name }}` to make `{{ project_name }}` available as a global command on your PATH. The configuration in step 2 works as-is.
-
-If the binary is not on your PATH, use the full path to it instead — see [Command not found](#command-not-found) below.
-
 ## Troubleshooting
 
 ### Server not appearing in Claude Desktop
@@ -96,7 +90,7 @@ Windows (`Scripts\` not `bin\`, `.exe` suffix):
 {
   "mcpServers": {
     "{{ project_name }}": {
-      "command": "%USERPROFILE%\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe",
+      "command": "C:\\Users\\me\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe",
       "args": ["serve"],
       "env": {
         "{{ env_prefix }}_READ_ONLY": "true"

--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -22,7 +22,9 @@ Or download the `.mcpb` bundle from the [GitHub Releases](https://github.com/{{ 
 
 ### 2. Configure Claude Desktop
 
-Add the server to your Claude Desktop configuration file. The path varies by operating system:
+If you installed via `.mcpb`, skip this step — Claude Desktop was configured automatically by the wizard.
+
+Otherwise, add the server to your Claude Desktop configuration file. The path varies by operating system:
 
 - **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
@@ -70,10 +72,18 @@ If the binary is not on your PATH, use the full path to it instead — see [Comm
 
 ### "Command not found"
 
-Ensure `{{ project_name }}` is on your PATH. If installed in a virtualenv, use the full path to the binary:
+Ensure `{{ project_name }}` is on your PATH. If installed in a virtualenv, use the full path to the binary (macOS/Linux example):
 
 ```json
 {
   "command": "/Users/me/.venvs/mcp/bin/{{ project_name }}"
+}
+```
+
+On Windows, the equivalent path uses `Scripts\` instead of `bin/` and includes the `.exe` suffix:
+
+```json
+{
+  "command": "%USERPROFILE%\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe"
 }
 ```

--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -105,4 +105,5 @@ nav:
   - Deployment:
       - Docker: deployment/docker.md
       - OIDC Authentication: deployment/oidc.md
+      - Claude Desktop: deployment/claude-desktop.md
   # PROJECT-NAV-END


### PR DESCRIPTION
## Summary

- Adds `docs/deployment/claude-desktop.md.jinja` — Claude Desktop setup guide covering PyPI/uv/mcpb install, OS-specific config paths, JSON config snippet, uv usage, and troubleshooting.
- Wires the new page into `mkdocs.yml.jinja` nav under Deployment.
- Adds a cross-reference link in `README.md.jinja` (`### Claude Desktop (.mcpb bundle)` section).
- Adds `stdio` to `accept.txt.jinja` so Vale doesn't flag the term in deployment docs prose.

Closes #119

## Test plan

- [x] Template renders cleanly via `copier copy --vcs-ref=HEAD --defaults`
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest` all pass on rendered output
- [x] `mkdocs build --strict` clean — new nav entry resolves, no broken links
- [x] Two full pre-push circus rounds (5 core lenses + code-reviewer + comment-analyzer each); all surviving findings addressed:
  - Tab indentation bug (JSON block outside MkDocs tabs) → replaced with flat OS-path bullet list
  - Em-dash in `.mcpb` sentence → replaced with semicolon (Vale AI-tells.EmDashUsage)
  - Incorrect `uv run` Claude Desktop example → replaced with accurate guidance
  - Aspirational "You should see the tools" → conditional with Troubleshooting link

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._