### PR TITLE
feat(docs): mike versioned-docs publishing (#148)

### DIFF
--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -69,6 +69,7 @@ jobs:
       # build internally; no artifact is passed from the build job.
       - uses: actions/checkout@v6
         with:
+          # Full history required: mike reads and pushes the gh-pages branch.
           fetch-depth: 0
           ref: main
 
@@ -96,7 +97,7 @@ jobs:
         run: |
           version="${TAG#v}"
           if [ "$PRERELEASE" = "true" ]; then
-            uv run mike deploy --push --update-aliases unstable --title "unstable (${version})"
+            uv run mike deploy --push unstable --title "unstable (${version})"
           else
             minor="$(echo "$version" | cut -d. -f1-2)"
             uv run mike deploy --push --update-aliases --title "$version" "$minor" latest

--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -3,11 +3,6 @@ name: Documentation
 on:
   push:
     branches: [main]
-    # Tag-push is a SMOKE TEST: it runs `build` only (confirms docs still
-    # compile against a release tag) — the `upload-artifact` and `deploy`
-    # steps below are gated on `github.event_name == 'release'`, so actual
-    # GitHub Pages deployment still only happens via the release event.
-    tags: ["v*"]
   pull_request:
     branches: [main]
   release:
@@ -17,26 +12,20 @@ on:
 permissions:
   contents: read
 
-# Include github.event_name so tag-push and release runs don't share a
-# concurrency key — without this, the tag-push run fired by ``git push``
-# and the release run fired by ``release:published`` collide on the same
-# ref+workflow key and `cancel-in-progress: true` cancels whichever
-# arrived first (usually the one carrying the deployment).
 concurrency:
   group: {% raw %}${{ github.workflow }}{% endraw %}-{% raw %}${{ github.ref }}{% endraw %}-{% raw %}${{ github.event_name }}{% endraw %}
   cancel-in-progress: true
 
 jobs:
   build:
+    # Validation only: strict docs build. Never deploys; publishing happens
+    # in `deploy` on release:published.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           # On release events the triggering tag may move after the workflow is
-          # queued (the release workflow pushes a version-bump commit and
-          # updates the tag). Checkout main explicitly on releases to avoid the
-          # "ref does not point to the expected commit" error from
-          # actions/checkout's SHA-verification.
+          # queued (semantic-release pushes a version-bump commit); build main.
           ref: {% raw %}${{ github.event_name == 'release' && 'main' || github.ref }}{% endraw %}
 
       - name: Install uv
@@ -53,23 +42,59 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build --strict
 
-      - name: Upload artifact
-        if: github.event_name == 'release'
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: site/
-
   deploy:
+    # Publish versioned docs with mike, serving from the gh-pages branch:
+    #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)
+    #   rc prerelease  (prerelease=true)  -> single rolling `unstable` version
+    #
+    # One-time setup before the first deploy (per-project, cannot be templated):
+    #   1. Seed gh-pages:
+    #        uv run mike deploy --push --update-aliases unstable --title "unstable (<ver>)"
+    #   2. Repo Settings -> Pages -> Deploy from a branch -> gh-pages / (root).
+    #   Order matters: seed (1) before switching source (2) so the site is never empty.
     if: github.event_name == 'release'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: {% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}
-    runs-on: ubuntu-latest
     needs: build
+    # Serialize all release deploys (no cancellation) so two releases close
+    # together never push to gh-pages concurrently.
+    concurrency:
+      group: {% raw %}${{ github.workflow }}{% endraw %}-deploy
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish versioned docs
+        env:
+          TAG: {% raw %}${{ github.event.release.tag_name }}{% endraw %}
+          # GitHub renders the JSON boolean as the string "true"/"false".
+          PRERELEASE: {% raw %}${{ github.event.release.prerelease }}{% endraw %}
+        run: |
+          version="${TAG#v}"
+          if [ "$PRERELEASE" = "true" ]; then
+            uv run mike deploy --push --update-aliases unstable --title "unstable (${version})"
+          else
+            minor="$(echo "$version" | cut -d. -f1-2)"
+            uv run mike deploy --push --update-aliases --title "$version" "$minor" latest
+            uv run mike set-default --push latest
+          fi

--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read
 
+# Include event_name so push/PR/release runs on the same ref get separate
+# concurrency buckets and don't cancel each other.
 concurrency:
   group: {% raw %}${{ github.workflow }}{% endraw %}-{% raw %}${{ github.ref }}{% endraw %}-{% raw %}${{ github.event_name }}{% endraw %}
   cancel-in-progress: true
@@ -63,6 +65,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      # `needs: build` is a sequencing gate only — mike drives its own
+      # build internally; no artifact is passed from the build job.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -34,6 +34,11 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+extra:
+  version:
+    provider: mike
+    default: latest
+
 plugins:
   - search
   # Generates llms.txt + llms-full.txt for the README badge.

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -45,6 +45,7 @@ dev = [
 ]
 
 docs = [
+    "mike>=2",
     "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=0.28",
     "mkdocs-llmstxt>=0.5",


### PR DESCRIPTION
## Summary

Ports the mike versioned-docs infrastructure from markdown-vault-mcp PR #701 into the template so newly generated and `copier update`-d projects get a version selector with stable + rolling-unstable channels out of the box.

- **`docs.yml.jinja`**: replace the GitHub Pages Actions-artifact flow (`upload-pages-artifact` / `deploy-pages`) with a mike-based `deploy` job on `release:published`. The `build` job becomes validation-only (strict build, no artifact upload). The `deploy` job publishes `<major.minor>` + `latest` alias for stable releases and a rolling `unstable` version for RC prereleases; job-level concurrency (`cancel-in-progress: false`) serializes gh-pages pushes. Drops the `v*` tag trigger (its smoke-test role is covered by `needs: build` on every release). One-time per-project setup steps documented in a comment block.
- **`pyproject.toml.jinja`**: add `mike>=2` to the `docs` dependency group.
- **`mkdocs.yml.jinja`**: add `extra.version` (provider: mike, default: latest) for the Material version-selector dropdown.

Closes #148

## ⚠️ Two one-time operator steps per generated project (cannot be templated)

1. **Seed `gh-pages`** before flipping the Pages source:
   ```bash
   uv run mike deploy --push --update-aliases unstable --title "unstable (<current-version>)"
   ```
2. **Switch Pages source**: Settings → Pages → Deploy from a branch → `gh-pages` / `(root)`.

Order matters: seed first so the site is never empty.

## Test plan

- [x] Template renders cleanly via `copier copy --vcs-ref=HEAD --defaults`
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest` all pass on rendered output
- [x] `mkdocs build --strict` clean on rendered project (mike present in docs group, version dropdown config valid)
- [x] Full pre-push circus (5 core lenses + code-reviewer); all surviving findings addressed (concurrency key comment restored, `needs:build` sequencing intent documented)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._