### PR TITLE
fix(vale): Milestone C — cache clobber, exclusion-scope lockstep, ai-tells URL ownership

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -234,23 +234,25 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache Vale style packages
-        # Vale style packs are ~30 MB total and re-downloaded on every run
-        # without caching. Cache key invalidates when .vale.ini changes
-        # (Packages line edited, ai-tells URL bumped, etc.) OR when any
-        # vocab file under .vale/styles/config/ changes (added/removed
-        # accepted terms). Without the config/** hash, cache restore would
-        # silently clobber a newly-added vocab term on disk with the stale
-        # snapshot, making Vale flag the new term as unknown in CI even
-        # though the file is checked in. The `v1-` prefix is a manual
-        # escape hatch: bump it to force re-sync if Vale ever changes
-        # pack format backward-incompatibly.
+        # Cache only the downloaded pack directories — NOT .vale/styles/config/.
+        # The config/ subtree (accept.txt vocabulary) is tracked by git and must
+        # stay authoritative from checkout. Caching the whole .vale/styles tree
+        # would let restore-keys overwrite a newly-added vocab term with the
+        # stale snapshot on the exact PR that adds the term.
+        # Pack list mirrors the Packages = line in .vale.ini; if you add or
+        # remove a pack, update both. Bump the v1- prefix to evict all cached
+        # packs if Vale changes pack format backward-incompatibly.
         uses: actions/cache@v4
         with:
-          path: .vale/styles
-          key: vale-styles-v1-{% raw %}${{ hashFiles('.vale.ini', '.vale/styles/config/**') }}{% endraw %}
-          # Fallback to any prior `vale-styles-v1-*` cache as a warm start
-          # when the exact key misses. `vale sync` will then only fetch the
-          # packs that actually changed instead of re-downloading all four.
+          path: |
+            .vale/styles/Google
+            .vale/styles/proselint
+            .vale/styles/write-good
+            .vale/styles/ai-tells
+          key: vale-styles-v1-{% raw %}${{ hashFiles('.vale.ini') }}{% endraw %}
+          # Warm-start fallback: restores the most recent pack snapshot when
+          # .vale.ini changes (e.g. URL bump). vale sync then only re-fetches
+          # the changed pack rather than re-downloading all four.
           restore-keys: vale-styles-v1-
 
       - name: Run Vale

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -183,10 +183,12 @@ jobs:
           # values if a downstream adds a second Vale invocation.
           CI_EXCL=$(awk '/^  vale:/{f=1} f && /vale_flags:/{print; exit}' .github/workflows/ci.yml \
             | grep -oE '!docs/[^"'"'"' ]*' || true)
-          # grep -A10 bounds the search to the vale hook block — prevents a
-          # false-OK if the vale hook's exclude is removed and unbounded awk
-          # would silently capture a later hook's exclude instead.
-          PC_EXCL=$(grep -A10 '^[[:space:]]*- id: vale' .pre-commit-config.yaml \
+          # grep -A15 bounds the search to the vale hook block. The `$`
+          # anchor avoids matching `- id: vale-sync`. Window of 15 safely
+          # covers the 11-line gap between `- id: vale` and `exclude:` in the
+          # rendered pre-commit config; prevents capturing a later hook's
+          # exclude if the vale hook's own exclude is removed.
+          PC_EXCL=$(grep -A15 '^[[:space:]]*- id: vale$' .pre-commit-config.yaml \
             | grep -m1 'exclude:' \
             | grep -oE 'docs/[^[:space:]]*' || true)
           [ -n "$CI_EXCL" ] || { echo "::error::vale exclusion glob not found in ci.yml vale_flags"; exit 1; }

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -182,11 +182,15 @@ jobs:
           # version check above) to avoid false matches on other vale_flags
           # values if a downstream adds a second Vale invocation.
           CI_EXCL=$(awk '/^  vale:/{f=1} f && /vale_flags:/{print; exit}' .github/workflows/ci.yml \
-            | grep -oE '!docs/[^"'"'"' ]*')
-          PC_EXCL=$(awk '/vale-cli\/vale[[:space:]]*$/{f=1; next} f && /exclude:/{print; exit}' .pre-commit-config.yaml \
-            | grep -oE 'docs/[^[:space:]]*')
+            | grep -oE '!docs/[^"'"'"' ]*' || true)
+          # grep -A10 bounds the search to the vale hook block — prevents a
+          # false-OK if the vale hook's exclude is removed and unbounded awk
+          # would silently capture a later hook's exclude instead.
+          PC_EXCL=$(grep -A10 '^[[:space:]]*- id: vale' .pre-commit-config.yaml \
+            | grep -m1 'exclude:' \
+            | grep -oE 'docs/[^[:space:]]*' || true)
           [ -n "$CI_EXCL" ] || { echo "::error::vale exclusion glob not found in ci.yml vale_flags"; exit 1; }
-          [ -n "$PC_EXCL" ] || { echo "::error::vale exclude not found in .pre-commit-config.yaml"; exit 1; }
+          [ -n "$PC_EXCL" ] || { echo "::error::vale exclude not found in .pre-commit-config.yaml vale hook"; exit 1; }
           # Normalize: strip leading ! / ^ and trailing /** / before comparing.
           CI_NORM=$(echo "${CI_EXCL#!}" | sed 's|/\*\*$||;s|/$||')
           PC_NORM=$(echo "${PC_EXCL#^}" | sed 's|/\*\*$||;s|/$||')

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -171,6 +171,28 @@ jobs:
           [ "$CI_VER" = "$PC_VER" ] \
             || { echo "::error::vale version drift — ci.yml=$CI_VER pre-commit=$PC_VER (bump in lockstep)"; exit 1; }
 
+      - name: vale exclusion-scope lockstep
+        working-directory: /tmp/smoke
+        run: |
+          # CI's vale_flags glob and pre-commit's exclude regex must scope to
+          # the same subtree. Drift means CI and pre-commit lint different file
+          # sets — a finding visible to one is silent to the other.
+          #
+          # CI extraction is scoped to the vale: job (same awk anchor as the
+          # version check above) to avoid false matches on other vale_flags
+          # values if a downstream adds a second Vale invocation.
+          CI_EXCL=$(awk '/^  vale:/{f=1} f && /vale_flags:/{print; exit}' .github/workflows/ci.yml \
+            | grep -oE '!docs/[^"'"'"' ]*')
+          PC_EXCL=$(awk '/vale-cli\/vale[[:space:]]*$/{f=1; next} f && /exclude:/{print; exit}' .pre-commit-config.yaml \
+            | grep -oE 'docs/[^[:space:]]*')
+          [ -n "$CI_EXCL" ] || { echo "::error::vale exclusion glob not found in ci.yml vale_flags"; exit 1; }
+          [ -n "$PC_EXCL" ] || { echo "::error::vale exclude not found in .pre-commit-config.yaml"; exit 1; }
+          # Normalize: strip leading ! / ^ and trailing /** / before comparing.
+          CI_NORM=$(echo "${CI_EXCL#!}" | sed 's|/\*\*$||;s|/$||')
+          PC_NORM=$(echo "${PC_EXCL#^}" | sed 's|/\*\*$||;s|/$||')
+          [ "$CI_NORM" = "$PC_NORM" ] \
+            || { echo "::error::vale exclusion scope drift — ci.yml=$CI_EXCL pre-commit=$PC_EXCL"; exit 1; }
+
   # Runs the two downstream workflow shapes that generated projects invoke
   # on their own CI — `mkdocs build --strict` (docs.yml) and `nfpm package`
   # (release.yml).  Dedicated non-matrix job so the downstream-gate is

--- a/.vale.ini.jinja
+++ b/.vale.ini.jinja
@@ -33,8 +33,12 @@ Vocab = Base
 # each sync. Intentional: keeps style rules current. To pin for
 # reproducibility, append a version (e.g. `Google@1.0.0`).
 # `ai-tells` (https://github.com/tbhb/vale-ai-tells) catches common
-# LLM-prose tells; pinned to a release URL since it is not in Vale's
-# package index.
+# LLM-prose tells; pinned to a specific release URL since it is not in
+# Vale's package index. NOTE: this file is `_skip_if_exists` — after the
+# first `copier copy`, copier updates no longer propagate URL changes here.
+# If tbhb/vale-ai-tells renames or removes the pinned release, `vale sync`
+# will fail permanently for this project. Periodically check
+# https://github.com/tbhb/vale-ai-tells/releases and bump the URL manually.
 Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
 
 [*.md]


### PR DESCRIPTION
## Summary

- Fixes the Vale style cache step clobbering git-tracked `accept.txt` vocabulary terms on the PR that adds them (issue #147)
- Adds a `vale exclusion-scope lockstep` check to `template-ci.yml` asserting that CI's `vale_flags` glob and pre-commit's `exclude:` regex scope to the same subtree (issue #143)
- Documents downstream ownership of the pinned `ai-tells` URL in `.vale.ini.jinja`, with a `NOTE:` explaining that `_skip_if_exists` means template updates won't propagate the URL to existing projects (issue #144)

Closes #143, #144, #147

## Changes

**`.github/workflows/ci.yml.jinja`**
- Cache only the four downloaded pack directories (`Google`, `proselint`, `write-good`, `ai-tells`), not the whole `.vale/styles` tree
- Drop `.vale/styles/config/**` from the `hashFiles()` key — `config/` (tracked vocab) is no longer cached, so `restore-keys` fallback can no longer overwrite a newly-added `accept.txt` term with a stale snapshot

**`.github/workflows/template-ci.yml`**
- New `vale exclusion-scope lockstep` step after the existing version-pin check
- Extracts the `!docs/superpowers/**` glob from `ci.yml`'s `vale_flags` and the `^docs/superpowers/` regex from the pre-commit vale hook, normalises both, and asserts they scope to the same subtree
- Extraction uses `grep -A15 '^[[:space:]]*- id: vale$'` (exact anchor + safe window) so the check is bounded to the vale hook block and can't capture a later hook's `exclude:`

**`.vale.ini.jinja`**
- Expanded comment above `Packages =` to warn that this file is `_skip_if_exists` — after the first `copier copy`, copier updates won't propagate URL changes, so a broken `ai-tells` release URL requires a manual bump in each downstream project

## Test plan

- [ ] Verify `template-ci.yml` gate passes on CI (all Python versions)
- [ ] Confirm vale exclusion-scope lockstep step passes in the smoke render
- [ ] Confirm cache step only caches pack dirs, not `config/`
- [ ] Confirm rendered `.vale.ini` contains the new NOTE comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._