### PR TITLE
fix(ci): CVE-2026-42561 ignore, test timeout, interpreter cache, stale #49 ref

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -20,6 +20,12 @@ jobs:
         with:
           version: "latest"
 
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
+
       - name: Set up Python
         run: uv python install 3.12
 
@@ -43,6 +49,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
 
       - name: Set up Python
         run: uv python install 3.12
@@ -205,6 +217,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -54,6 +54,10 @@ jobs:
   test:
     name: Test (Python {% raw %}${{ matrix.python-version }}{% endraw %})
     runs-on: ubuntu-latest
+    # Prevent a stalled `uv python install` from blocking the PR for hours.
+    # 20 min covers the full test matrix with headroom; cold interpreter
+    # downloads from python-build-standalone are the most likely stall source.
+    timeout-minutes: 20
     continue-on-error: {% raw %}${{ matrix.experimental || false }}{% endraw %}
     permissions:
       contents: read
@@ -77,6 +81,16 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v4
+        with:
+          # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
+          # separate from the uv package cache and not covered by setup-uv's
+          # enable-cache. Caching by version + OS avoids re-downloading the
+          # python-build-standalone tarball on every run.
+          path: ~/.local/share/uv/python
+          key: uv-python-{% raw %}${{ matrix.python-version }}-${{ runner.os }}{% endraw %}
 
       - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
         run: uv python install {% raw %}${{ matrix.python-version }}{% endraw %}
@@ -202,7 +216,13 @@ jobs:
         run: uv export --all-extras --no-default-groups --frozen --no-emit-project --no-hashes -o {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
 
       - name: Run pip-audit
-        run: uvx pip-audit --strict --progress-spinner off -r {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
+        run: |
+          uvx pip-audit --strict --progress-spinner off \
+            --ignore-vuln CVE-2026-42561 \
+            -r {% raw %}${{ runner.temp }}{% endraw %}/requirements.txt
+          # CVE-2026-42561: python-multipart <0.0.27, pulled in transitively by
+          # fastmcp/starlette. Ignored until the upstream pin chain propagates
+          # the fix to 0.0.27. Remove once `uv lock` resolves >=0.0.27.
 
   secrets:
     name: Secret Detection

--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -11,6 +11,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -34,6 +35,7 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -193,6 +195,7 @@ jobs:
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -406,7 +406,7 @@ jobs:
             echo "DIFF_STAT_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build #49 body content
+      - name: Build PR body content
         id: build-body
         if: steps.changes.outputs.changed == 'true'
         env:
@@ -483,10 +483,10 @@ jobs:
 
       - name: Compose PR body via aggregator
         id: compose
-        # Reads the existing #49-shaped body data + three /tmp/agent-job-*.json
+        # Reads the existing PR body data + three /tmp/agent-job-*.json
         # files (any may be missing/errored) and writes the composed PR body.
         # Failure-tolerant: if aggregator crashes, PR still opens with the
-        # existing #49 body (no agent sections).
+        # existing body (no agent sections).
         if: steps.changes.outputs.changed == 'true'
         continue-on-error: true
         env:
@@ -529,8 +529,8 @@ jobs:
           branch="copier/update"
           title="chore(copier): update to ${REF}"
 
-          # Prefer the aggregator's composed body; fall back to the plain
-          # #49 body if the aggregator step failed (continue-on-error: true).
+          # Prefer the aggregator's composed body; fall back to the plain body
+          # if the aggregator step failed (continue-on-error: true).
           if [ -f /tmp/aggregator/composed-body.md ]; then
             body_file=/tmp/aggregator/composed-body.md
           else


### PR DESCRIPTION
## Summary

- **#125** — Add `--ignore-vuln CVE-2026-42561` to pip-audit (python-multipart <0.0.27, transitively pulled by fastmcp/starlette; stop-gap until upstream pin chain propagates the fix)
- **#126** — Rename step `Build #49 body content` → `Build PR body content` in `copier-update.yml.jinja`; scrub remaining `#49` comment references that render as live GitHub hyperlinks in downstream repos
- **#149** — Add `timeout-minutes: 20` to the `test` job so a stalled `uv python install` fails fast instead of hanging for up to 6 hours; add `actions/cache` for `~/.local/share/uv/python` (UV_PYTHON_INSTALL_DIR, not covered by setup-uv's `enable-cache`) keyed by Python version + OS

Closes #125, #126, #149

## Test plan

- [ ] CI passes on all Python versions (template-ci gate)
- [ ] pip-audit job no longer fails on CVE-2026-42561
- [ ] Interpreter cache step populates on first run, restores on subsequent runs
- [ ] Rendered `copier-update.yml` step names contain no bare `#N` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._