### PR TITLE
docs(claude-md): add Logging Standard Scope subsection

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -99,7 +99,7 @@ try to make them conform:
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.
 - FastMCP middleware handles tool invocation, timing, and error logging automatically.
-- All logging goes through FastMCP's `configure_logging()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
+- All first-party logging goes through FastMCP's `configure_logging_from_env()` for uniform output. `FASTMCP_LOG_LEVEL` is the single log level control; the `-v` CLI flag sets it to `DEBUG`. `FASTMCP_ENABLE_RICH_LOGGING=false` switches to plain/JSON output.
 
 ### Log Levels
 | Level | Use for |

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -89,8 +89,9 @@ try to make them conform:
   `fastmcp-pvl-core` itself (see pvliesdonk/fastmcp-pvl-core#90); no
   first-party code needed.
 - **uvicorn access logs and `mcp.server.lowlevel.server` lines**: upstream
-  transport / SDK output. `configure_logging_from_env` demotes them below
-  `INFO` so they are silent at the default level and reappear only at `DEBUG`
+  transport / SDK output. `configure_logging_from_env` raises their effective
+  level to `WARNING`, suppressing their per-request `INFO` output at the
+  default level; they reappear at `DEBUG` via `NOTSET` inheritance
   (pvliesdonk/fastmcp-pvl-core#91). Do not silence or reformat them — they
   are out of scope by design.
 

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -77,6 +77,23 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 
 ## Logging Standard
 
+### Scope
+
+This standard governs **first-party code only** — `src/{{ python_module }}/` and
+`tests/`. Two categories of log output are explicitly **out of scope**; do not
+try to make them conform:
+
+- **FastMCP middleware stack** (`fastmcp-pvl-core` timing / logging /
+  error-handling middleware): emits conforming, bare-event-name-first lines
+  automatically. Tool-call lines carry `tool=<name>`. Governed by
+  `fastmcp-pvl-core` itself (see pvliesdonk/fastmcp-pvl-core#90); no
+  first-party code needed.
+- **uvicorn access logs and `mcp.server.lowlevel.server` lines**: upstream
+  transport / SDK output. `configure_logging_from_env` demotes them below
+  `INFO` so they are silent at the default level and reappear only at `DEBUG`
+  (pvliesdonk/fastmcp-pvl-core#91). Do not silence or reformat them — they
+  are out of scope by design.
+
 ### Framework
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.
 - No `print()` for operational output. No third-party logging libraries.

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -88,12 +88,14 @@ try to make them conform:
   automatically. Tool-call lines carry `tool=<name>`. Governed by
   `fastmcp-pvl-core` itself (see pvliesdonk/fastmcp-pvl-core#90); no
   first-party code needed.
-- **uvicorn access logs and `mcp.server.lowlevel.server` lines**: upstream
+- **`uvicorn.access` and `mcp.server.lowlevel.server` log lines**: upstream
   transport / SDK output. `configure_logging_from_env` raises their effective
-  level to `WARNING`, suppressing their per-request `INFO` output at the
-  default level; they reappear at `DEBUG` via `NOTSET` inheritance
-  (pvliesdonk/fastmcp-pvl-core#91). Do not silence or reformat them — they
-  are out of scope by design.
+  level to `WARNING`, suppressing per-request `INFO` output at the default
+  level; at `DEBUG` they are reset to `NOTSET` so the root logger governs
+  their effective level via propagation (pvliesdonk/fastmcp-pvl-core#91).
+  `uvicorn.error` is intentionally not suppressed — it carries startup and
+  bind failures. Do not silence or reformat any of these — they are out of
+  scope by design.
 
 ### Framework
 - Standard library `logging` throughout. Every module: `logger = logging.getLogger(__name__)`.


### PR DESCRIPTION
## Summary

- Adds a `### Scope` subsection to the `## Logging Standard` section of `CLAUDE.md.jinja`, clarifying that the standard governs first-party code only (`src/<package>/` and `tests/`).
- Names the two explicitly out-of-scope categories: FastMCP middleware stack (emits conforming lines via `fastmcp-pvl-core` — pvliesdonk/fastmcp-pvl-core#90) and upstream transport/SDK loggers (`uvicorn.access`, `mcp.server.lowlevel.server` — suppressed to `WARNING` by `configure_logging_from_env`; pvliesdonk/fastmcp-pvl-core#91). Notes that `uvicorn.error` is intentionally not suppressed.
- Corrects the Framework bullet's function name from the non-existent `configure_logging()` to `configure_logging_from_env()`, and tightens "All logging" to "All first-party logging" to match the carve-out.

Closes #134

## Test plan

- [ ] Smoke render: `CLAUDE.md.jinja` renders without Jinja errors (`{{ python_module }}` resolves correctly).
- [ ] No prose visible in the rendered output that references `configure_logging()` (grep for the old name).
- [ ] template-ci gate passes.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._