### PR TITLE
fix(aggregator): surface silent failures at operator boundary

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -171,6 +171,7 @@ jobs:
         continue-on-error: true
         env:
           PREVIOUS_COMMIT: {{ '${{ steps.meta.outputs.previous_commit }}' }}
+          NEW_REF: {{ '${{ steps.meta.outputs.new_ref }}' }}
           TEMPLATE_REPO: {{ '${{ steps.meta.outputs.template_repo }}' }}
         run: |
           set -euo pipefail
@@ -182,10 +183,14 @@ jobs:
           git clone --filter=blob:none \
             "https://github.com/${TEMPLATE_REPO}.git" \
             /tmp/template
-          # Verify both refs are reachable
+          # Verify both refs are reachable before declaring the clone usable.
           git -C /tmp/template fetch --tags
           if [ -n "${PREVIOUS_COMMIT}" ]; then
             git -C /tmp/template rev-parse "${PREVIOUS_COMMIT}^{commit}" >/dev/null
+          fi
+          if [ -n "${NEW_REF}" ]; then
+            git -C /tmp/template rev-parse "${NEW_REF}^{commit}" >/dev/null \
+              || { echo "::error::NEW_REF not reachable in template clone: ${NEW_REF}"; exit 1; }
           fi
           echo "template_clone_ok=true" >> "$GITHUB_OUTPUT"
 

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -46,12 +47,21 @@ class AggregatorInputs:
 
 
 def _read_job_json(path: Path | None) -> dict | None:
-    """Read and JSON-parse an agent output file. Returns None if missing or unreadable."""
+    """Read and JSON-parse an agent output file. Returns None if missing or unreadable.
+
+    Absent paths (None or not-exists) return None silently — expected when an
+    agent was gated off. Parse or read failures emit a ::warning:: annotation so
+    operators have a breadcrumb without aborting the aggregator run.
+    """
     if path is None or not path.exists():
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError as e:
+        print(f"::warning::agent output at {path} is not valid JSON: {e}", file=sys.stderr)
+        return None
+    except OSError as e:
+        print(f"::warning::could not read agent output at {path}: {e}", file=sys.stderr)
         return None
 
 
@@ -524,6 +534,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    if not args.existing_body.exists():
+        print(f"::error::--existing-body file not found: {args.existing_body}", file=sys.stderr)
+        return 1
     inputs = AggregatorInputs(
         existing_body=args.existing_body.read_text(encoding="utf-8"),
         agent_enabled=(args.agent_enabled == "true"),

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -49,11 +49,12 @@ class AggregatorInputs:
 def _read_job_json(path: Path | None) -> dict | None:
     """Read and JSON-parse an agent output file. Returns None if missing or unreadable.
 
-    Absent paths (None or not-exists) return None silently — expected when an
-    agent was gated off. Parse or read failures emit a ::warning:: annotation so
-    operators have a breadcrumb without aborting the aggregator run.
+    Absent paths (None or not a regular file) return None silently — expected
+    when an agent was gated off. Parse, encoding, or I/O failures emit a
+    ::warning:: annotation so operators have a breadcrumb without aborting the
+    aggregator run.
     """
-    if path is None or not path.exists():
+    if path is None or not path.is_file():
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -542,9 +543,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    if not args.existing_body.exists():
+    if not args.existing_body.is_file():
         print(
-            f"::error::--existing-body file not found: {args.existing_body}",
+            f"::error::--existing-body not found or not a regular file: {args.existing_body}",
             file=sys.stderr,
         )
         return 1

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -47,12 +47,13 @@ class AggregatorInputs:
 
 
 def _read_job_json(path: Path | None) -> dict | None:
-    """Read and JSON-parse an agent output file. Returns None if missing or unreadable.
+    """Read and JSON-parse an agent output file.
 
     Absent paths (None or not a regular file) return None silently — expected
     when an agent was gated off. Parse, encoding, or I/O failures emit a
     ::warning:: annotation so operators have a breadcrumb without aborting the
-    aggregator run.
+    aggregator run. Note: UnicodeDecodeError requires its own except clause
+    because it is a ValueError subclass, not an OSError subclass.
     """
     if path is None or not path.is_file():
         return None

--- a/scripts/copier_update_aggregator.py
+++ b/scripts/copier_update_aggregator.py
@@ -58,7 +58,15 @@ def _read_job_json(path: Path | None) -> dict | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
-        print(f"::warning::agent output at {path} is not valid JSON: {e}", file=sys.stderr)
+        print(
+            f"::warning::agent output at {path} is not valid JSON: {e}", file=sys.stderr
+        )
+        return None
+    except UnicodeDecodeError as e:
+        print(
+            f"::warning::agent output at {path} is not valid UTF-8: {e}",
+            file=sys.stderr,
+        )
         return None
     except OSError as e:
         print(f"::warning::could not read agent output at {path}: {e}", file=sys.stderr)
@@ -535,7 +543,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if not args.existing_body.exists():
-        print(f"::error::--existing-body file not found: {args.existing_body}", file=sys.stderr)
+        print(
+            f"::error::--existing-body file not found: {args.existing_body}",
+            file=sys.stderr,
+        )
         return 1
     inputs = AggregatorInputs(
         existing_body=args.existing_body.read_text(encoding="utf-8"),

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -1261,6 +1261,29 @@ def test_main_missing_existing_body_exits_1_with_error_annotation(
     assert "nonexistent.md" in err
 
 
+def test_main_existing_body_is_directory_exits_1_with_error_annotation(
+    tmp_path, capsys
+) -> None:
+    """main() returns 1 with ::error:: when --existing-body is a directory, not a file."""
+    rc = agg.main(
+        [
+            "--existing-body",
+            str(tmp_path),  # directory, not a file
+            "--agent-enabled",
+            "false",
+            "--conflict-count",
+            "0",
+            "--output-body",
+            str(tmp_path / "out.md"),
+            "--overflow-dir",
+            str(tmp_path / "overflow"),
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "::error::" in err
+
+
 def test_job_c_skip_rollup_drops_null_file(write_job_json) -> None:
     """skip rollup mirrors Job B informational rollup: null file dropped, count adjusts."""
     job_c = write_job_json(

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -1174,7 +1174,7 @@ def test_job_c_only_skip_with_null_file_suppresses_section_header(
     assert "## Agent analysis" not in body
 
 
-# ── Issue #129: silent-failure annotations ────────────────────────────────────
+# ── Silent-failure annotations ────────────────────────────────────────────────
 
 
 def test_read_job_json_no_warning_for_none_path(capsys) -> None:
@@ -1218,17 +1218,34 @@ def test_read_job_json_warns_on_oserror(tmp_path, capsys, monkeypatch) -> None:
     assert str(p) in err
 
 
+def test_read_job_json_warns_on_unicode_error(tmp_path, capsys) -> None:
+    """UnicodeDecodeError emits a ::warning:: annotation to stderr."""
+    p = tmp_path / "job.json"
+    p.write_bytes(b"\xff\xfe not utf-8")  # invalid UTF-8 sequence
+
+    result = agg._read_job_json(p)
+    assert result is None
+    err = capsys.readouterr().err
+    assert "::warning::" in err
+    assert str(p) in err
+
+
 def test_main_missing_existing_body_exits_1_with_error_annotation(
     tmp_path, capsys
 ) -> None:
     """main() returns exit code 1 with a ::error:: annotation when --existing-body is absent."""
     rc = agg.main(
         [
-            "--existing-body", str(tmp_path / "nonexistent.md"),
-            "--agent-enabled", "false",
-            "--conflict-count", "0",
-            "--output-body", str(tmp_path / "out.md"),
-            "--overflow-dir", str(tmp_path / "overflow"),
+            "--existing-body",
+            str(tmp_path / "nonexistent.md"),
+            "--agent-enabled",
+            "false",
+            "--conflict-count",
+            "0",
+            "--output-body",
+            str(tmp_path / "out.md"),
+            "--overflow-dir",
+            str(tmp_path / "overflow"),
         ]
     )
     assert rc == 1

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -1174,6 +1174,69 @@ def test_job_c_only_skip_with_null_file_suppresses_section_header(
     assert "## Agent analysis" not in body
 
 
+# ── Issue #129: silent-failure annotations ────────────────────────────────────
+
+
+def test_read_job_json_no_warning_for_none_path(capsys) -> None:
+    """Path=None is expected-missing; no stderr annotation emitted."""
+    result = agg._read_job_json(None)
+    assert result is None
+    assert capsys.readouterr().err == ""
+
+
+def test_read_job_json_no_warning_for_missing_file(tmp_path, capsys) -> None:
+    """Non-existent path is expected-missing; no stderr annotation emitted."""
+    result = agg._read_job_json(tmp_path / "absent.json")
+    assert result is None
+    assert capsys.readouterr().err == ""
+
+
+def test_read_job_json_warns_on_malformed_json(tmp_path, capsys) -> None:
+    """JSONDecodeError emits a ::warning:: annotation to stderr."""
+    bad = tmp_path / "job.json"
+    bad.write_text("not valid json {", encoding="utf-8")
+    result = agg._read_job_json(bad)
+    assert result is None
+    err = capsys.readouterr().err
+    assert "::warning::" in err
+    assert str(bad) in err
+
+
+def test_read_job_json_warns_on_oserror(tmp_path, capsys, monkeypatch) -> None:
+    """OSError emits a ::warning:: annotation to stderr."""
+    p = tmp_path / "job.json"
+    p.write_text('{"status": "ok"}', encoding="utf-8")
+
+    def raise_oserror(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(type(p), "read_text", raise_oserror)
+    result = agg._read_job_json(p)
+    assert result is None
+    err = capsys.readouterr().err
+    assert "::warning::" in err
+    assert str(p) in err
+
+
+def test_main_missing_existing_body_exits_1_with_error_annotation(
+    tmp_path, capsys
+) -> None:
+    """main() returns exit code 1 with a ::error:: annotation when --existing-body is absent."""
+    rc = agg.main(
+        [
+            "--existing-body", str(tmp_path / "nonexistent.md"),
+            "--agent-enabled", "false",
+            "--conflict-count", "0",
+            "--output-body", str(tmp_path / "out.md"),
+            "--overflow-dir", str(tmp_path / "overflow"),
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "::error::" in err
+    assert "nonexistent.md" in err
+
+
 def test_job_c_skip_rollup_drops_null_file(write_job_json) -> None:
     """skip rollup mirrors Job B informational rollup: null file dropped, count adjusts."""
     job_c = write_job_json(

--- a/scripts/tests/test_copier_update_aggregator.py
+++ b/scripts/tests/test_copier_update_aggregator.py
@@ -1191,6 +1191,13 @@ def test_read_job_json_no_warning_for_missing_file(tmp_path, capsys) -> None:
     assert capsys.readouterr().err == ""
 
 
+def test_read_job_json_no_warning_for_directory_path(tmp_path, capsys) -> None:
+    """Directory path fails is_file() and returns None silently (not an OSError warning)."""
+    result = agg._read_job_json(tmp_path)  # tmp_path is a directory
+    assert result is None
+    assert capsys.readouterr().err == ""
+
+
 def test_read_job_json_warns_on_malformed_json(tmp_path, capsys) -> None:
     """JSONDecodeError emits a ::warning:: annotation to stderr."""
     bad = tmp_path / "job.json"


### PR DESCRIPTION
## Summary

Three fixes for patterns where a real failure produced an opaque traceback or no signal at the operator boundary:

- **`_read_job_json`**: split the combined `except (JSONDecodeError, OSError)` clause — each now emits a `::warning::` annotation to stderr with the file path and error detail. Absent paths (None or not-exists) remain silent (expected when an agent was gated off).
- **`main()`**: check `--existing-body` existence before `read_text`; returns exit code 1 with a `::error::` annotation instead of an uncaught `FileNotFoundError` traceback.
- **`copier-update.yml.jinja` `clone-template` step**: add `NEW_REF` reachability guard (mirroring the existing `PREVIOUS_COMMIT` guard) so an unreachable `workflow_dispatch` ref fails fast with a clear error rather than setting `template_clone_ok=true` and letting agent steps fail with cryptic git errors.

Closes #129

## Test plan

- [ ] `uv run --with pytest pytest scripts/tests/ -q` — all 39 tests pass (5 new tests cover the `_read_job_json` warning paths and the `main()` exit-1 path).
- [ ] template-ci gate passes.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._