### PR TITLE
fix(workflow): restore github-actions[bot] identity on copier-update commits

### DIFF
--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -280,7 +280,7 @@ jobs:
           claude_code_oauth_token: {{ '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}' }}
           prompt: {{ '${{ steps.prepare-prompt-a.outputs.prompt }}' }}
           claude_args: |
-            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
+            --allowed-tools "Read,Edit,Write,Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git config user.name:*),Bash(git config user.email:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git -C /tmp/template:*)"
 
       - name: Pre-render Job B prompt
         id: prepare-prompt-b

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -373,6 +373,11 @@ jobs:
           REF: {{ '${{ steps.meta.outputs.ref }}' }}
         run: |
           set -euo pipefail
+          # claude-code-action overwrites local git config (user.name/email) to
+          # claude[bot] during the agent step; reset here so this commit is
+          # attributed to github-actions[bot], not the agent identity.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           branch="copier/update"
           # `git add -A` runs BEFORE `git checkout -B` because copier's
           # `--conflict=inline` mode leaves conflict-marker files in the

--- a/scripts/copier_update_prompts/job_a.md.jinja
+++ b/scripts/copier_update_prompts/job_a.md.jinja
@@ -69,7 +69,12 @@ git add <files-you-modified>
 # the PR branch under the auto-resolve commit.
 git diff --cached --name-only
 
-git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+# Reset git identity so both author and committer are github-actions[bot].
+# claude-code-action overwrites user.name/email to claude[bot]; --author alone
+# would fix the author field but leave the committer as claude[bot].
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git commit -m "auto-resolve N trivial conflicts (claude-code)"
 ```
 
 Capture the commit SHA via `git rev-parse HEAD`.

--- a/scripts/copier_update_prompts/job_a.md.jinja
+++ b/scripts/copier_update_prompts/job_a.md.jinja
@@ -118,7 +118,8 @@ deviation from the shapes above will cause the section to render as
 
 - Tool access: file read/write on the working tree, file read on `/tmp/template`,
   `git -C /tmp/template <subcommand>`, `git status`, `git diff`, `git add <path>`,
-  `git commit -m '<msg>'`. NO `git push`, NO branch operations, NO network calls.
+  `git config user.name`, `git config user.email`, `git commit -m '<msg>'`,
+  `git rev-parse`. NO `git push`, NO branch operations, NO network calls.
 - Do not modify files outside the conflict files listed above.
 - Sentinel-block awareness: lines inside `<!-- DOMAIN-*-START -->` ... `<!-- DOMAIN-*-END -->`,
   `<!-- PROJECT-*-START -->` ... `<!-- PROJECT-*-END -->`, `# CONFIG-*-START` ...

--- a/scripts/copier_update_prompts/job_a.md.jinja
+++ b/scripts/copier_update_prompts/job_a.md.jinja
@@ -69,7 +69,7 @@ git add <files-you-modified>
 # the PR branch under the auto-resolve commit.
 git diff --cached --name-only
 
-git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="claude-code <claude-code@anthropic.com>"
+git commit -m "auto-resolve N trivial conflicts (claude-code)" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 ```
 
 Capture the commit SHA via `git rev-parse HEAD`.


### PR DESCRIPTION
## Summary

Closes #163.

Three-commit fix for commits on `copier/update` being attributed to `claude[bot]` / `claude-code@anthropic.com` instead of `github-actions[bot]`:

- **`chore(copier)` commit** — `claude-code-action@v1` overwrites local git config (`user.name`/`user.email`) to `claude[bot]` during the agent step. The "Commit and push" step ran after the agent and inherited that identity. Fix: reset git config to `github-actions[bot]` at the top of the "Commit and push" step.

- **Job A auto-resolve commit** — two-part fix:
  1. The old prompt used `--author="claude-code <claude-code@anthropic.com>"`. `--author` only overrides the author field; the committer still came from git config (`claude[bot]`). Fix: replace `--author` with `git config user.name/email` before the commit, so both author and committer are set correctly.
  2. `Bash(git config user.name:*)` and `Bash(git config user.email:*)` were absent from the Job A `--allowed-tools` list. Without them, the tool filter would silently deny the `git config` calls, leaving the identity as `claude[bot]` anyway. Fix: add both patterns to `--allowed-tools`.

## Test plan

- [ ] Trigger a `copier-update` run on a downstream repo with conflicts (to exercise Job A's commit path)
- [ ] Verify both commits on `copier/update` show author and committer as `github-actions[bot]`
- [ ] Trigger a run without conflicts — verify the single `chore(copier)` commit is also attributed to `github-actions[bot]`

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._