### PR TITLE
feat(template): port in-browser configuration generator

### DIFF
--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -44,6 +44,15 @@ jobs:
       - name: Build documentation
         run: uv run mkdocs build --strict
 
+      - name: Install browser test deps
+        run: uv sync --no-default-groups --all-extras --group docs --group browser --frozen
+
+      - name: Install Chromium
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run config-wizard smoke test
+        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
     #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)

--- a/docs/configuration-generator.md.jinja
+++ b/docs/configuration-generator.md.jinja
@@ -5,6 +5,7 @@ deployment. Everything runs in your browser; nothing you type is sent anywhere.
 Secret fields (tokens, keys) are never included in the shareable link; replace
 the `<YOUR_...>` placeholders if you leave them blank.
 
+<!-- The relative path relies on MkDocs' default use_directory_urls: true -->
 <div id="cfg-wizard" data-spec-url="../javascripts/config-wizard/wizard-spec.json">
   Loading the configuration generator…
 </div>

--- a/docs/configuration-generator.md.jinja
+++ b/docs/configuration-generator.md.jinja
@@ -1,0 +1,10 @@
+# Configuration Generator
+
+Answer a few questions and copy a ready-to-use configuration for your exact
+deployment. Everything runs in your browser; nothing you type is sent anywhere.
+Secret fields (tokens, keys) are never included in the shareable link; replace
+the `<YOUR_...>` placeholders if you leave them blank.
+
+<div id="cfg-wizard" data-spec-url="../javascripts/config-wizard/wizard-spec.json">
+  Loading the configuration generator…
+</div>

--- a/docs/javascripts/config-wizard/generators.js.jinja
+++ b/docs/javascripts/config-wizard/generators.js.jinja
@@ -21,7 +21,7 @@ const shellQuote = (v) => {
 // break parsing (or has surrounding whitespace, or is empty).
 const yamlScalar = (v) => {
   const s = String(v);
-  return /[:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+  return /[\n:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
 };
 
 // A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
@@ -78,7 +78,7 @@ function dockerEnvMap(map) {
 const dotenvQuote = (v) => {
   const s = String(v);
   if (!/[#"'\\\s]/.test(s)) return s;
-  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`;
 };
 
 export function generateDotenv(map) {

--- a/docs/javascripts/config-wizard/generators.js.jinja
+++ b/docs/javascripts/config-wizard/generators.js.jinja
@@ -1,0 +1,143 @@
+// Pure config-output generators. No DOM, no spec knowledge beyond the emit map.
+
+const IMAGE = "{{ docker_registry }}/{{ project_name }}:latest";
+
+// Vars whose value is fixed to a container path in Docker/Compose output.
+const CONTAINER_PATHS = {
+  // PROJECT-WIZARD-CONTAINER-PATHS-START — add container paths below; kept across copier update
+  // PROJECT-WIZARD-CONTAINER-PATHS-END
+};
+
+const SECRET_PLACEHOLDER = (key) => `<YOUR_${key.replace(/^{{ env_prefix }}_/, "")}>`;
+
+// Single-quote a value for a POSIX shell `-e KEY=value` argument, but only when
+// it contains characters outside the shell-safe set (keeps clean output tidy).
+const shellQuote = (v) => {
+  const s = String(v);
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${s.replace(/'/g, "'\\''")}'`;
+};
+
+// Quote a YAML scalar only when it contains characters that would otherwise
+// break parsing (or has surrounding whitespace, or is empty).
+const yamlScalar = (v) => {
+  const s = String(v);
+  return /[:#[\]{}&*?|<>=!%@,`"']|^\s|\s$|^$/.test(s) ? JSON.stringify(s) : s;
+};
+
+// A systemd `Environment=` line. systemd does NOT expand `$` in Environment=
+// values (expansion only happens in ExecXYZ= directives), so `$` is left
+// literal. It DOES resolve `%` specifiers (escaped as `%%`) and process
+// C-style `\`/`"` escapes (systemd/systemd#36488), so those are escaped, and
+// the assignment is wrapped in quotes when it contains whitespace, a quote, or
+// a backslash.
+const systemdLine = (k, v) => {
+  const s = String(v).replace(/%/g, "%%");
+  if (!/[\s"\\]/.test(s)) return `Environment=${k}=${s}`;
+  const escaped = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `Environment="${k}=${escaped}"`;
+};
+
+// Build {VAR: value} from the spec + answers. Empty non-secret answers are
+// dropped; a visible secret left empty becomes a placeholder so the artifact is
+// still complete and signals "replace me".
+export function buildEnvMap(spec, answers) {
+  const secrets = new Set(spec.secretKeys);
+  const map = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    if (q.options) {
+      const chosen = q.options.find((o) => o.value === answers[q.id]);
+      if (chosen && chosen.emit) Object.assign(map, chosen.emit);
+    }
+    if (q.var) {
+      const raw = answers[q.id];
+      if (raw !== undefined && raw !== "") map[q.var] = raw;
+      else if (secrets.has(q.var)) map[q.var] = SECRET_PLACEHOLDER(q.var);
+    }
+  }
+  return map;
+}
+
+export function isVisible(q, answers) {
+  if (!q.showIf) return true;
+  return Object.entries(q.showIf).every(([k, allowed]) => allowed.includes(answers[k]));
+}
+
+function dockerEnvMap(map) {
+  const out = { ...map };
+  for (const [k, v] of Object.entries(CONTAINER_PATHS)) {
+    if (k in out) out[k] = v;
+  }
+  out.FASTMCP_HOME = "/data/state/fastmcp";
+  return out;
+}
+
+// Quote a .env value when it contains characters that common dotenv parsers
+// treat specially (notably `#`, which starts an inline comment in an unquoted
+// value and would silently truncate the value on load).
+const dotenvQuote = (v) => {
+  const s = String(v);
+  if (!/[#"'\\\s]/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+};
+
+export function generateDotenv(map) {
+  return Object.entries(map).map(([k, v]) => `${k}=${dotenvQuote(v)}`).join("\n") + "\n";
+}
+
+export function generateClaudeJson(map) {
+  return JSON.stringify(
+    { mcpServers: { "{{ project_name }}": { command: "{{ project_name }}", args: ["serve"], env: map } } },
+    null, 2,
+  );
+}
+
+export function generateDockerRun(map) {
+  const env = dockerEnvMap(map);
+  const lines = [
+    "docker run -d --name {{ project_name }}",
+    "  -p 8000:8000",
+    "  -v state-data:/data/state",
+  ];
+  for (const [k, v] of Object.entries(env)) lines.push(`  -e ${k}=${shellQuote(v)}`);
+  lines.push(`  ${IMAGE}`);
+  return lines.join(" \\\n");
+}
+
+export function generateCompose(map) {
+  const env = dockerEnvMap(map);
+  const envLines = Object.entries(env).map(([k, v]) => `      ${k}: ${yamlScalar(v)}`).join("\n");
+  return [
+    "services:",
+    "  {{ project_name }}:",
+    `    image: ${IMAGE}`,
+    "    ports:",
+    '      - "8000:8000"',
+    "    volumes:",
+    "      - state-data:/data/state",
+    "    environment:",
+    envLines,
+    "volumes:",
+    "  state-data:",
+  ].join("\n");
+}
+
+export function generateSystemd(map) {
+  const envLines = Object.entries(map).map(([k, v]) => systemdLine(k, v)).join("\n");
+  return [
+    "[Unit]",
+    "Description={{ project_name }}",
+    "After=network.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    "# Create this user first: sudo useradd --system --no-create-home {{ project_name }}",
+    "User={{ project_name }}",
+    "ExecStart=/opt/{{ project_name }}/venv/bin/{{ project_name }} serve --transport http",
+    envLines,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+}

--- a/docs/javascripts/config-wizard/wizard-spec.json.jinja
+++ b/docs/javascripts/config-wizard/wizard-spec.json.jinja
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "secretKeys": [
+    "{{ env_prefix }}_BEARER_TOKEN"
+  ],
+  "questions": [
+    {
+      "id": "deployment",
+      "label": "Where will the server run?",
+      "help": "Local stdio for Claude Desktop/Code, or an HTTP server for Docker/systemd.",
+      "type": "select",
+      "options": [
+        { "value": "local", "label": "Local (Claude Desktop / Claude Code, stdio)" },
+        { "value": "server", "label": "Server (HTTP — Docker / Compose / systemd)" }
+      ]
+    },
+    {
+      "id": "bearer_token",
+      "label": "Bearer token",
+      "help": "Any non-empty string enables bearer auth. Browser-only.",
+      "type": "text",
+      "var": "{{ env_prefix }}_BEARER_TOKEN",
+      "showIf": { "deployment": ["server"] }
+    },
+    {
+      "id": "log_level",
+      "label": "Log level",
+      "type": "text",
+      "var": "FASTMCP_LOG_LEVEL",
+      "advancedGroup": "Logging"
+    },
+    {
+      "id": "rich_logging",
+      "label": "Rich logging",
+      "type": "bool",
+      "var": "FASTMCP_ENABLE_RICH_LOGGING",
+      "advancedGroup": "Logging"
+    }
+  ],
+  "guards": []
+}

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,0 +1,214 @@
+import {
+  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  generateDockerRun, generateCompose, generateSystemd,
+} from "./generators.js";
+
+const MOUNT_ID = "cfg-wizard";
+const answers = {};
+
+function readUrlState(spec) {
+  const hash = new URLSearchParams(location.hash.slice(1));
+  const secrets = new Set(spec.secretKeys);
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue; // never hydrate secrets from URL
+    const v = hash.get(q.id);
+    if (v !== null) answers[q.id] = v;
+  }
+}
+
+function writeUrlState(spec) {
+  const secrets = new Set(spec.secretKeys);
+  const params = new URLSearchParams();
+  for (const q of spec.questions) {
+    if (secrets.has(q.var)) continue;
+    if (answers[q.id] !== undefined && answers[q.id] !== "") params.set(q.id, answers[q.id]);
+  }
+  const qs = params.toString();
+  history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
+}
+
+function field(q, secrets) {
+  const wrap = document.createElement("label");
+  wrap.className = "cfg-field";
+  wrap.dataset.qid = q.id;
+  const title = document.createElement("span");
+  title.className = "cfg-label";
+  title.textContent = q.label;
+  wrap.appendChild(title);
+  if (q.help) {
+    const help = document.createElement("small");
+    help.className = "cfg-help";
+    help.textContent = q.help;
+    wrap.appendChild(help);
+  }
+  let input;
+  if (q.type === "select") {
+    input = document.createElement("select");
+    for (const opt of q.options) {
+      const o = document.createElement("option");
+      o.value = opt.value;
+      o.textContent = opt.label;
+      input.appendChild(o);
+    }
+  } else if (q.type === "bool") {
+    input = document.createElement("select");
+    for (const v of ["", "true", "false"]) {
+      const o = document.createElement("option");
+      o.value = v;
+      o.textContent = v || "(default)";
+      input.appendChild(o);
+    }
+  } else {
+    input = document.createElement("input");
+    input.type = q.type === "number" ? "number" : "text";
+  }
+  if (secrets.has(q.var)) wrap.classList.add("cfg-secret");
+  if (answers[q.id] !== undefined) input.value = answers[q.id];
+  // One listener per control: selects/bools settle on "change"; text/number
+  // fields update live on "input". Avoids the double render + double
+  // history.replaceState that "input"+"change" both firing on <select> causes.
+  const evt = q.type === "select" || q.type === "bool" ? "change" : "input";
+  input.addEventListener(evt, () => {
+    answers[q.id] = input.value;
+    render();
+  });
+  wrap.appendChild(input);
+  return wrap;
+}
+
+let SPEC = null;
+let ROOT = null;
+
+function render() {
+  const spec = SPEC;
+  const secrets = new Set(spec.secretKeys);
+  // Capture focus + caret so a full re-render (replaceChildren) doesn't drop
+  // the user mid-keystroke in a text field.
+  const active = document.activeElement;
+  const activeQid =
+    active && active.closest ? active.closest(".cfg-field")?.dataset.qid : null;
+  let selStart = null;
+  let selEnd = null;
+  try {
+    selStart = active.selectionStart;
+    selEnd = active.selectionEnd;
+  } catch {
+    // selects / number inputs do not expose a text selection
+  }
+  const core = document.createElement("div");
+  core.className = "cfg-core";
+  const advanced = {};
+  for (const q of spec.questions) {
+    if (!isVisible(q, answers)) continue;
+    const el = field(q, secrets);
+    if (q.advancedGroup) {
+      (advanced[q.advancedGroup] ??= []).push(el);
+    } else {
+      core.appendChild(el);
+    }
+  }
+  const drawer = document.createElement("details");
+  drawer.className = "cfg-advanced";
+  const sum = document.createElement("summary");
+  sum.textContent = "Advanced tuning";
+  drawer.appendChild(sum);
+  for (const [group, els] of Object.entries(advanced)) {
+    const h = document.createElement("h4");
+    h.textContent = group;
+    drawer.appendChild(h);
+    els.forEach((e) => drawer.appendChild(e));
+  }
+
+  const map = buildEnvMap(spec, answers);
+  const local = answers.deployment !== "server";
+  const tabs = local
+    ? [["Claude config", generateClaudeJson(map)], [".env", generateDotenv(map)]]
+    : [
+        ["docker run", generateDockerRun(map)],
+        ["compose", generateCompose(map)],
+        ["systemd", generateSystemd(map)],
+        [".env", generateDotenv(map)],
+      ];
+  const out = document.createElement("div");
+  out.className = "cfg-output";
+  for (const [name, text] of tabs) {
+    const block = document.createElement("div");
+    block.className = "cfg-tab";
+    const head = document.createElement("div");
+    head.className = "cfg-tab-head";
+    head.textContent = name;
+    const pre = document.createElement("pre");
+    pre.className = "cfg-pre";
+    pre.textContent = text;
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "cfg-copy";
+    copy.textContent = "Copy";
+    copy.addEventListener("click", () => {
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).catch(() => {});
+      } else {
+        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+        const range = document.createRange();
+        range.selectNodeContents(pre);
+        const sel = getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    });
+    head.appendChild(copy);
+    block.appendChild(head);
+    block.appendChild(pre);
+    out.appendChild(block);
+  }
+
+  const warnings = document.createElement("div");
+  warnings.className = "cfg-warnings";
+  for (const g of spec.guards) {
+    if (Object.entries(g.when).every(([k, vals]) => vals.includes(answers[k]))) {
+      const w = document.createElement("div");
+      w.className = `cfg-${g.level}`;
+      w.textContent = g.message;
+      warnings.appendChild(w);
+    }
+  }
+
+  ROOT.replaceChildren(core, drawer, warnings, out);
+  writeUrlState(spec);
+
+  // Restore focus + caret to the field the user was editing.
+  if (activeQid) {
+    const restored = ROOT.querySelector(
+      `.cfg-field[data-qid="${activeQid}"] input, .cfg-field[data-qid="${activeQid}"] select`,
+    );
+    if (restored) {
+      restored.focus();
+      if (selStart !== null && restored.tagName === "INPUT" && restored.type !== "number") {
+        try {
+          restored.setSelectionRange(selStart, selEnd);
+        } catch {
+          // input type does not support text selection
+        }
+      }
+    }
+  }
+}
+
+async function init() {
+  ROOT = document.getElementById(MOUNT_ID);
+  if (!ROOT) return;
+  const specUrl = ROOT.dataset.specUrl;
+  try {
+    const resp = await fetch(specUrl);
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+    SPEC = await resp.json();
+  } catch (e) {
+    ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;
+    return;
+  }
+  readUrlState(SPEC);
+  render();
+}
+
+if (document.readyState !== "loading") init();
+else document.addEventListener("DOMContentLoaded", init);

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -151,9 +151,11 @@ function render() {
         // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
         const range = document.createRange();
         range.selectNodeContents(pre);
-        const sel = getSelection();
-        sel.removeAllRanges();
-        sel.addRange(range);
+        const sel = window.getSelection();
+        if (sel) {
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
       }
     });
     head.appendChild(copy);
@@ -207,6 +209,11 @@ async function init() {
     return;
   }
   readUrlState(SPEC);
+  for (const q of SPEC.questions) {
+    if (answers[q.id] === undefined && q.type === "select" && q.options?.length) {
+      answers[q.id] = q.options[0].value;
+    }
+  }
   render();
 }
 

--- a/docs/stylesheets/config-wizard.css
+++ b/docs/stylesheets/config-wizard.css
@@ -1,0 +1,19 @@
+#cfg-wizard { display: flex; flex-direction: column; gap: 1rem; }
+.cfg-core { display: grid; gap: 0.75rem; }
+.cfg-field { display: flex; flex-direction: column; gap: 0.25rem; }
+.cfg-label { font-weight: 600; }
+.cfg-help { color: var(--md-default-fg-color--light); }
+.cfg-field input, .cfg-field select {
+  padding: 0.4rem 0.5rem; border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px; background: var(--md-default-bg-color); color: var(--md-default-fg-color);
+}
+.cfg-secret input { border-color: var(--md-accent-fg-color); }
+.cfg-advanced { border: 1px solid var(--md-default-fg-color--lightest); border-radius: 6px; padding: 0.5rem 1rem; }
+.cfg-advanced h4 { margin: 0.75rem 0 0.25rem; }
+.cfg-output { display: grid; gap: 1rem; }
+.cfg-tab-head { display: flex; justify-content: space-between; align-items: center; font-weight: 600; }
+.cfg-copy { cursor: pointer; padding: 0.2rem 0.6rem; border-radius: 4px; border: 1px solid var(--md-default-fg-color--lighter); background: var(--md-default-bg-color); }
+.cfg-pre { background: var(--md-code-bg-color); padding: 0.75rem; border-radius: 6px; overflow-x: auto; white-space: pre; }
+.cfg-warn { color: #b26a00; }
+[data-md-color-scheme="slate"] .cfg-warn { color: #e0a83a; }
+.cfg-info { color: var(--md-default-fg-color--light); }

--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -40,8 +40,8 @@ extra:
     default: latest
 
 extra_javascript:
-  - javascripts/config-wizard/generators.js
-  - javascripts/config-wizard/wizard.js
+  - path: javascripts/config-wizard/wizard.js
+    type: module
 
 extra_css:
   - stylesheets/config-wizard.css

--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -39,6 +39,13 @@ extra:
     provider: mike
     default: latest
 
+extra_javascript:
+  - javascripts/config-wizard/generators.js
+  - javascripts/config-wizard/wizard.js
+
+extra_css:
+  - stylesheets/config-wizard.css
+
 plugins:
   - search
   # Generates llms.txt + llms-full.txt for the README badge.
@@ -55,6 +62,7 @@ plugins:
           - index.md
           - installation.md
           - configuration.md
+          - configuration-generator.md
         Guides:
           - guides/*.md
         MCP Interface:
@@ -102,6 +110,7 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Configuration: configuration.md
+      - Configuration Generator: configuration-generator.md
   - Guides:
       - Authentication: guides/authentication.md
   - MCP Interface:

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -56,6 +56,10 @@ docs = [
     "mkdocs-llmstxt>=0.5",
 ]
 
+browser = [
+    "pytest-playwright>=0.5",
+]
+
 [project.scripts]
 {{ project_name }} = "{{ python_module }}.cli:main"
 
@@ -114,6 +118,9 @@ indent-style = "space"
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-ra"]
 asyncio_mode = "auto"
+markers = [
+    "browser: end-to-end test that drives a headless browser (requires the 'browser' dependency group + 'playwright install chromium')",
+]
 
 [tool.coverage.run]
 source = ["src/{{ python_module }}"]

--- a/tests/test_config_wizard_smoke.py.jinja
+++ b/tests/test_config_wizard_smoke.py.jinja
@@ -11,11 +11,15 @@ import functools
 import http.server
 import socketserver
 import threading
+import typing
 from pathlib import Path
 
 import pytest
 
 pytest.importorskip("playwright.sync_api")
+
+if typing.TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page
 
 SITE = Path(__file__).resolve().parent.parent / "site"
 
@@ -23,7 +27,7 @@ pytestmark = pytest.mark.browser
 
 
 @pytest.fixture(scope="module")
-def site_url():
+def site_url() -> typing.Iterator[str]:
     if not (SITE / "configuration-generator" / "index.html").exists():
         pytest.skip("site/ not built -- run `uv run mkdocs build` first")
     handler = functools.partial(
@@ -40,7 +44,7 @@ def site_url():
 
 
 @pytest.fixture(scope="module")
-def browser(site_url):  # noqa: ARG001 — depended on only for fixture ordering
+def browser(site_url: str) -> typing.Iterator[Browser]:  # noqa: ARG001 — depended on only for fixture ordering
     # Depend on site_url so its "site not built" skip runs BEFORE we try to
     # launch Chromium. In the main CI test lane (no built site, no installed
     # browser) this makes the smoke tests skip cleanly instead of erroring.
@@ -53,7 +57,7 @@ def browser(site_url):  # noqa: ARG001 — depended on only for fixture ordering
 
 
 @pytest.fixture
-def page(browser, site_url):
+def page(browser: Browser, site_url: str) -> typing.Iterator[Page]:
     # Fresh page per test: the wizard keeps answer state in a module-level JS
     # object, so each test must start from a clean load to stay order-independent.
     pg = browser.new_page()
@@ -63,13 +67,13 @@ def page(browser, site_url):
     pg.close()
 
 
-def test_local_path_emits_claude_json(page):
+def test_local_path_emits_claude_json(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "local")
     text = page.inner_text(".cfg-output")
     assert "{{ project_name }}" in text
 
 
-def test_server_docker_path_emits_image(page):
+def test_server_docker_path_emits_image(page: Page) -> None:
     page.select_option('[data-qid="deployment"] select', "server")
     page.fill('[data-qid="bearer_token"] input', "secret-token")
     text = page.inner_text("#cfg-wizard")

--- a/tests/test_config_wizard_smoke.py.jinja
+++ b/tests/test_config_wizard_smoke.py.jinja
@@ -1,0 +1,77 @@
+"""Browser smoke test for the built config-wizard page.
+
+Marked ``browser``; requires the ``browser`` dependency group and
+``playwright install chromium``. Runs against the built ``site/`` directory, so
+``mkdocs build`` must have run first.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import threading
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+SITE = Path(__file__).resolve().parent.parent / "site"
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture(scope="module")
+def site_url():
+    if not (SITE / "configuration-generator" / "index.html").exists():
+        pytest.skip("site/ not built -- run `uv run mkdocs build` first")
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(SITE)
+    )
+    with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            httpd.shutdown()
+
+
+@pytest.fixture(scope="module")
+def browser(site_url):  # noqa: ARG001 — depended on only for fixture ordering
+    # Depend on site_url so its "site not built" skip runs BEFORE we try to
+    # launch Chromium. In the main CI test lane (no built site, no installed
+    # browser) this makes the smoke tests skip cleanly instead of erroring.
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+@pytest.fixture
+def page(browser, site_url):
+    # Fresh page per test: the wizard keeps answer state in a module-level JS
+    # object, so each test must start from a clean load to stay order-independent.
+    pg = browser.new_page()
+    pg.goto(f"{site_url}/configuration-generator/")
+    pg.wait_for_selector("#cfg-wizard select")
+    yield pg
+    pg.close()
+
+
+def test_local_path_emits_claude_json(page):
+    page.select_option('[data-qid="deployment"] select', "local")
+    text = page.inner_text(".cfg-output")
+    assert "{{ project_name }}" in text
+
+
+def test_server_docker_path_emits_image(page):
+    page.select_option('[data-qid="deployment"] select', "server")
+    page.fill('[data-qid="bearer_token"] input', "secret-token")
+    text = page.inner_text("#cfg-wizard")
+    assert "{{ docker_registry }}/{{ project_name }}:latest" in text
+    assert "{{ env_prefix }}_BEARER_TOKEN" in text


### PR DESCRIPTION
This PR ports the in-browser configuration generator from the markdown-vault-mcp project.

Included:
- `generators.js.jinja` templated for the target package properties.
- `wizard.js` and `config-wizard.css`.
- `wizard-spec.json.jinja` with baseline fields for server topologies, credentials, and logging.
- Embeds the wizard using `configuration-generator.md.jinja` and maps it via `mkdocs.yml.jinja`.
- Bootstraps smoke tests using Playwright (`test_config_wizard_smoke.py.jinja`) added to a new `browser` dependency group inside `pyproject.toml.jinja` and configured to run in `.github/workflows/docs.yml.jinja`.