### PR TITLE
fix(config-wizard): deep meta validation + dockerVolume/dockerPath var constraint (closes #172, #173)

### DIFF
--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -50,8 +50,12 @@ jobs:
       - name: Install Chromium
         run: uv run playwright install --with-deps chromium
 
-      - name: Run config-wizard smoke test
-        run: uv run pytest tests/test_config_wizard_smoke.py -v -m browser
+      - name: Run config-wizard browser tests
+        # Both the template-owned smoke suite and the project-owned domain suite
+        # (test_config_wizard_domain.py). -m browser selects the browser-marked
+        # tests in each; the seeded domain placeholder is skipped until a
+        # consumer replaces it with real assertions.
+        run: uv run pytest tests/test_config_wizard_smoke.py tests/test_config_wizard_domain.py -v -m browser
 
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:

--- a/docs/javascripts/config-wizard/generators.js
+++ b/docs/javascripts/config-wizard/generators.js
@@ -50,6 +50,28 @@ const systemdLine = (k, v) => {
   return `Environment="${k}=${escaped}"`;
 };
 
+// Validate a loaded wizard spec before any generator runs. The generators
+// iterate spec.questions and dereference spec.meta.{projectName,dockerImage,
+// envPrefix} with no per-field guard at the use site, so an incomplete spec
+// (hand-edited, or served mid-migration) must fail loudly here rather than
+// reach the generators and emit
+// undefined-laden artifacts the user copy-pastes. The JSON Schema enforces the
+// same shape, but only in the Python test lane — never at runtime, which is what
+// this guards. Throws Error with a specific message on the first violation.
+export function validateSpec(spec) {
+  if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
+    throw new Error("wizard-spec.json is malformed (missing questions array)");
+  }
+  if (!spec.meta || typeof spec.meta !== "object") {
+    throw new Error("wizard-spec.json is malformed (missing meta block)");
+  }
+  for (const k of ["projectName", "dockerImage", "envPrefix"]) {
+    if (typeof spec.meta[k] !== "string" || spec.meta[k] === "") {
+      throw new Error(`wizard-spec.json is malformed (meta.${k} missing or empty)`);
+    }
+  }
+}
+
 // Build {VAR: value} from the spec + answers. Empty non-secret answers are
 // dropped; a visible secret left empty becomes a placeholder so the artifact is
 // still complete and signals "replace me".

--- a/docs/javascripts/config-wizard/wizard-spec-schema.json
+++ b/docs/javascripts/config-wizard/wizard-spec-schema.json
@@ -68,6 +68,15 @@
         {
           "if": { "required": ["type"], "properties": { "type": { "const": "select" } } },
           "then": { "required": ["options"] }
+        },
+        {
+          "$comment": "A dockerVolume/dockerPath question binds its var to the container path (generators.js dockerEnvMap). Without var that binding never happens — reject rather than accept a question that silently emits a dead bind mount (dockerVolume) or a no-op (dockerPath).",
+          "if": { "required": ["dockerVolume"] },
+          "then": { "required": ["var"] }
+        },
+        {
+          "if": { "required": ["dockerPath"] },
+          "then": { "required": ["var"] }
         }
       ],
       "not": { "required": ["dockerVolume", "dockerPath"] }

--- a/docs/javascripts/config-wizard/wizard.js
+++ b/docs/javascripts/config-wizard/wizard.js
@@ -1,5 +1,5 @@
 import {
-  buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
+  validateSpec, buildEnvMap, isVisible, generateDotenv, generateClaudeJson,
   generateDockerRun, generateCompose, generateSystemd,
 } from "./generators.js";
 
@@ -26,8 +26,12 @@ function writeUrlState(spec) {
   const qs = params.toString();
   try {
     history.replaceState(null, "", qs ? `#${qs}` : location.pathname + location.search);
-  } catch {
-    // history.replaceState throws in sandboxed iframes — safe to ignore.
+  } catch (e) {
+    // Benign in a sandboxed iframe (SecurityError, no allow-same-origin). But
+    // replaceState also throws SecurityError when its ~100-calls/10 s throttle
+    // is breached — a real signal the 300 ms debounce is insufficient — so log
+    // the cause at debug level rather than swallow it blind.
+    console.debug("config-wizard: history.replaceState failed", e);
   }
 }
 
@@ -151,10 +155,18 @@ function render() {
     copy.className = "cfg-copy";
     copy.textContent = "Copy";
     copy.addEventListener("click", () => {
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(text).catch(() => {});
-      } else {
-        // Fallback for non-secure contexts: select the block so Ctrl/Cmd-C works.
+      // Flash a transient affordance on the button, then restore its label.
+      const flash = (msg) => {
+        copy.textContent = msg;
+        setTimeout(() => {
+          copy.textContent = "Copy";
+        }, 1500);
+      };
+      // Select the block so the user can finish with Ctrl/Cmd-C themselves.
+      // Used both when the Clipboard API is absent (non-secure context) and when
+      // writeText rejects (permission/focus) — without it the empty catch left
+      // the user believing a failed copy had succeeded.
+      const selectFallback = () => {
         const range = document.createRange();
         range.selectNodeContents(pre);
         const sel = window.getSelection();
@@ -162,6 +174,12 @@ function render() {
           sel.removeAllRanges();
           sel.addRange(range);
         }
+        flash("Press Ctrl-C");
+      };
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(() => flash("Copied!"), selectFallback);
+      } else {
+        selectFallback();
       }
     });
     head.appendChild(copy);
@@ -218,15 +236,10 @@ async function init() {
     const resp = await fetch(specUrl);
     if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
     const spec = await resp.json();
-    if (!spec || typeof spec !== "object" || !Array.isArray(spec.questions)) {
-      throw new Error("wizard-spec.json is malformed (missing questions array)");
-    }
-    if (!spec.meta || typeof spec.meta !== "object") {
-      // The generators read project identity from spec.meta; a spec missing it
-      // (e.g. mid-migration) must fail loudly here rather than throw an
-      // uncaught TypeError deep inside render().
-      throw new Error("wizard-spec.json is malformed (missing meta block)");
-    }
+    // The generators read project identity from spec.meta and dereference its
+    // required fields unconditionally; validateSpec fails loudly here rather
+    // than let render() emit undefined-laden output (see generators.js).
+    validateSpec(spec);
     SPEC = spec;
   } catch (e) {
     ROOT.textContent = `Failed to load the configuration generator: ${e.message}`;

--- a/tests/test_config_wizard_domain.py.jinja
+++ b/tests/test_config_wizard_domain.py.jinja
@@ -8,12 +8,17 @@ emits the expected env var, or that a guard message appears. The generic
 framework tests live in ``test_config_wizard_smoke.py`` (template-owned) and
 must not be edited here.
 
-See ``test_config_wizard_smoke.py`` for the page/browser fixtures to import.
+Import the page/browser fixtures from ``test_config_wizard_smoke.py`` (e.g.
+``from tests.test_config_wizard_smoke import page, site_url, browser``). This
+module is marked ``browser`` so the tests you add run in the docs CI lane, which
+invokes ``pytest ... -m browser``.
 """
 
 from __future__ import annotations
 
 import pytest
+
+pytestmark = pytest.mark.browser
 
 
 def test_domain_placeholder() -> None:

--- a/tests/test_config_wizard_smoke.py.jinja
+++ b/tests/test_config_wizard_smoke.py.jinja
@@ -10,8 +10,9 @@ Two kinds of tests live here, both template-owned and spec-agnostic:
   every spec shares (the ``deployment`` question exists; output carries the
   project identity from ``meta``).
 * Generator unit tests import ``generators.js`` directly and feed it synthetic
-  specs, so they exercise ``dockerVolume`` / ``dockerPath`` behaviour without
-  depending on this project's questions.
+  specs, so they exercise generator behaviour (``dockerVolume`` / ``dockerPath``
+  mapping, ``validateSpec`` rejection of malformed specs) without depending on
+  this project's questions.
 
 Domain-specific assertions belong in ``test_config_wizard_domain.py``.
 """
@@ -113,6 +114,75 @@ def _eval_generators(page: Page, body: str) -> typing.Any:
         + ")(g); }"
     )
     return page.evaluate(script)
+
+
+def test_validate_spec_accepts_complete_spec(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' },
+            secretKeys: [],
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }],
+            guards: [] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is None
+
+
+def test_validate_spec_rejects_missing_questions(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: 'img:latest', envPrefix: 'DEMO' } };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing questions array" in err
+
+
+def test_validate_spec_rejects_missing_meta(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "missing meta block" in err
+
+
+def test_validate_spec_rejects_empty_meta(page: Page) -> None:
+    # meta is an object but lacks the fields the generators dereference: the
+    # exact gap the old `typeof meta === 'object'` guard let through.
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1, meta: {},
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.projectName missing or empty" in err
+
+
+def test_validate_spec_rejects_empty_meta_field(page: Page) -> None:
+    err = _eval_generators(
+        page,
+        """(g) => {
+          const spec = { version: 1,
+            meta: { projectName: 'demo', dockerImage: '', envPrefix: 'DEMO' },
+            questions: [{ id: 'deployment', label: 'W', type: 'select' }] };
+          try { g.validateSpec(spec); return null; } catch (e) { return e.message; }
+        }""",
+    )
+    assert err is not None
+    assert "meta.dockerImage missing or empty" in err
 
 
 def test_docker_volume_adds_mount_and_fixes_container_path(page: Page) -> None:

--- a/tests/test_config_wizard_spec_schema.py.jinja
+++ b/tests/test_config_wizard_spec_schema.py.jinja
@@ -141,6 +141,29 @@ def test_schema_accepts_dockervolume_alone(schema: dict[str, Any]) -> None:
     jsonschema.validate(spec, schema)
 
 
+def test_schema_rejects_dockervolume_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {"id": "data_dir", "label": "Data", "type": "text", "dockerVolume": "/data/app"}
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_schema_rejects_dockerpath_without_var(schema: dict[str, Any]) -> None:
+    bad = _minimal_valid_spec()
+    bad["questions"].append(
+        {
+            "id": "index_path",
+            "label": "Index",
+            "type": "text",
+            "dockerPath": "/data/state/index.db",
+        }
+    )
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
 def test_schema_accepts_dockerpath_alone(schema: dict[str, Any]) -> None:
     spec = _minimal_valid_spec()
     spec["questions"].append(


### PR DESCRIPTION
## Summary

Hardening for the v2.3.0 config-wizard, fixing two issues found while adopting it downstream (scholar-mcp, markdown-vault-mcp#715). All template-owned config-wizard files.

Closes #172. Closes #173.

## #173 — schema: `dockerVolume`/`dockerPath` ⇒ `var`

`wizard-spec-schema.json` now rejects a question carrying `dockerVolume` or `dockerPath` without `var`. Such a question binds nothing: `dockerVolumes()` still emits a `-v host:/container` bind mount, but `dockerEnvMap()` skips the var-less question, so no env var points the app at the mounted path — a silent dead mount (a no-op for `dockerPath`). Two negative schema tests added; the pre-existing accept-alone tests already carry `var`, so the new `allOf` branches can't trivially false-pass.

> Note on the issue's repro: the literal `undefined=...` symptom it describes does **not** occur in current `generators.js` — `dockerEnvMap` guards `!q.var`. The real symptom is the dead mount above. The schema constraint is the right fix either way.

## #172 — `init()` meta guard + copy/URL affordances

- **Finding 1 (primary):** the old `init()` guard only checked `typeof meta === "object"`, so `meta: {}` passed and reached the generators, which dereference `meta.{projectName,dockerImage,envPrefix}` and emit `undefined`-laden artifacts. Extracted a pure, exported `validateSpec()` into `generators.js` (the natural home — it's the consumer of `meta`, and the test harness already imports that module) and call it from `init()`. It now fails loudly with a specific message per missing/empty field. 5 unit tests added.
- **Finding 2:** clipboard copy now flashes `Copied!` on success and falls back to selecting the block with a `Press Ctrl-C` affordance on rejection, replacing the empty `.catch(() => {})` that hid copy failures.
- **Finding 3:** `writeUrlState`'s `replaceState` catch logs at `console.debug` so the throttle-breach `SecurityError` is discoverable, while still tolerating the benign sandboxed-iframe case.
- **Secondary:** `docs.yml` now runs the project-owned `test_config_wizard_domain.py` alongside the smoke suite, and the domain seed is marked `browser` so added tests actually execute in the `-m browser` lane (previously they'd be silently deselected).

## Testing

Rendered the template from HEAD with smoke-answers and ran the full gate on the generated project:

- `ruff check` / `ruff format --check` / `mypy src tests` — clean
- `pytest` main lane — 22 passed (incl. 2 new schema tests)
- `mkdocs build --strict`, then browser lane (`pytest test_config_wizard_smoke.py test_config_wizard_domain.py -m browser`) — 13 passed, 1 skipped (the domain placeholder, now correctly collected+skipped in the browser lane)

Findings 2/3 (clipboard/console.debug) are deliberately not unit-tested — clipboard permissions are flaky in headless Chromium and `console.debug` has no testable contract; the wizard load is smoke-exercised by the framework tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
