### PR TITLE
feat(scaffold): co-locate authentication + authorization (closes #178)

### DIFF
--- a/.env.example.jinja
+++ b/.env.example.jinja
@@ -7,7 +7,7 @@
 # {{ env_prefix }}_HTTP_PATH=/mcp
 # {{ env_prefix }}_BASE_URL=https://mcp.example.com
 
-# --- Auth (pick one flavor) ---
+# --- Authentication (pick one flavor) ---
 # {{ env_prefix }}_BEARER_TOKEN=<secret>
 
 # {{ env_prefix }}_BEARER_TOKENS_FILE=/etc/{{ project_name }}/tokens.toml   # mapped per-token subjects (overrides BEARER_TOKEN)

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -109,33 +109,14 @@ Core environment variables shared across all `fastmcp-pvl-core`-based services:
 
 Domain-specific variables go below under [Domain configuration](#domain-configuration).
 
+## Authentication
+
+Callers authenticate via a bearer token or OIDC (mutually exclusive). See the [Authentication guide](docs/guides/authentication.md) for setup, mapped multi-subject tokens, OIDC, and troubleshooting.
+
 {% if enable_authorization -%}
 ## Authorization (opt-in)
 
-This server supports opt-in per-subject authorization from `fastmcp-pvl-core`.  The default runtime posture is **off** — every authenticated caller can use every tool, resource, and prompt.  Turn it on by pointing `{{ env_prefix }}_ACL_PATH` at a TOML ACL file; the middleware is installed only when the path is set, and individual tools opt in by declaring `meta={"required_scope": "<scope>"}` at registration.  A tool without `required_scope` is unrestricted regardless of caller.  (The wiring ships as commented stubs in `src/{{ python_module }}/config.py` and `src/{{ python_module }}/server.py`.)
-
-### ACL TOML schema
-
-```toml
-[subjects]
-"user:alice@example.com" = ["read", "write"]
-"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
-"service:ci-bot"         = ["read"]
-"local"                  = ["*"]              # stdio mode subject
-```
-
-- **Subject strings are opaque.** The `<kind>:<id>` convention is documentation only; the library treats each subject as a literal string.
-- **`*` is the only library-treated special scope** — it grants every required scope.  Subject-side wildcards (`*` as an ACL key) are rejected at load time.
-- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is encoded into the scope string itself (e.g. `read:project-foo`, `write:vault/personal`).
-
-The subject keyed in the ACL TOML is the same string used as a *value* in the bearer-tokens TOML (`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent.  In single-token mode every caller shares one subject (the library default, currently `"bearer-anon"`, overridable via `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in stdio mode the subject is `"local"`.  See [Mapped bearer tokens](docs/guides/authentication.md#mapped-bearer-tokens-multi-subject).
-
-The ACL file loads **once at startup** and `load_acl` fails fast with `ConfigurationError` on any malformed entry (a typo aborts startup rather than silently denying).  Denied requests are logged at WARNING with the subject; the wire-side error omits the subject by default — pass `AuthorizationMiddleware(..., expose_subject_in_error=True)` to surface it on internal-only servers.
-
-### See also
-
-- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
-- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+Per-subject authorization is **off by default** — every authenticated caller can use every tool. Point `{{ env_prefix }}_ACL_PATH` at a TOML ACL file to gate tools by scope (tools opt in via `meta={"required_scope": "<scope>"}`). See the [Authorization guide](docs/guides/authorization.md).
 
 {% endif -%}
 ## Post-scaffold checklist

--- a/copier.yml
+++ b/copier.yml
@@ -80,7 +80,9 @@ _skip_if_exists:
 # — copier itself doesn't act on them.  README.md was moved out of
 # _skip_if_exists in #57.  The same hybrid pattern applies to
 # docs/*.md.jinja files: docs/deployment/* and docs/guides/authentication.md
-# moved out in #29 (PR #108); the remaining top-level docs/*.md files
+# moved out in #29 (PR #108); docs/guides/authorization.md (the
+# enable_authorization-gated guide, DOMAIN-AUTHZ-SCOPES/EXTRA sentinels)
+# added in #178; the remaining top-level docs/*.md files
 # (index, installation, configuration, tools/index, prompts) moved out in #106.
 # Those docs files use topic-specific DOMAIN-{TOPIC}-{KIND} sentinels
 # rather than the bare DOMAIN-START used in CLAUDE.md / README.md.
@@ -179,4 +181,4 @@ include_mcp_apps_scaffold:
 enable_authorization:
   type: bool
   default: false
-  help: "Scaffold the opt-in per-subject authorization surface: the commented ACL middleware stubs in config.py/server.py, the README 'Authorization' section, the *_ACL_PATH line in .env.example, and the cross-link in the authentication guide. Leave off unless this server needs per-caller scope gating (runtime enablement is still via the *_ACL_PATH env var)."
+  help: "Scaffold the opt-in per-subject authorization surface: the commented ACL middleware stubs in config.py/server.py, the brief README 'Authorization' pointer, the docs/guides/authorization.md guide and its nav entry, the *_ACL_PATH line in .env.example, and the cross-link in the authentication guide. Leave off unless this server needs per-caller scope gating (runtime enablement is still via the *_ACL_PATH env var)."

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -72,7 +72,7 @@ The bearer-token mode above shares one subject across every authenticated caller
 
 Each token resolves to a distinct subject string for downstream attribution. Subject strings are opaque: the `<kind>:<id>` convention (`user:`, `service:`, `token:`) is documentation only. When `BEARER_TOKENS_FILE` is set it overrides `BEARER_TOKEN` (a `WARNING` is logged if both are present). A missing or malformed file aborts startup with `ConfigurationError` rather than silently denying every request.
 {% if enable_authorization %}
-For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/{{ github_org }}/{{ project_name }}/blob/main/README.md#authorization-opt-in) in the project README.
+For the per-tool authorization that consumes these subjects, see the [Authorization guide](authorization.md).
 {% endif %}
 ---
 

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -19,7 +19,7 @@ and `src/{{ python_module }}/server.py` — uncomment them to enable the
 "user:alice@example.com" = ["read", "write"]
 "user:admin@example.com" = ["*"]              # wildcard — any required scope passes
 "service:ci-bot"         = ["read"]
-"local"                  = ["*"]              # stdio mode subject
+"local"                  = ["*"]              # no-auth mode subject (default for stdio)
 ```
 
 - **Subject strings are opaque.** The `<kind>:<id>` convention is
@@ -40,22 +40,27 @@ string used as a *value* in the bearer-tokens TOML
 (`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
 single-token mode every caller shares one subject (the library default,
 currently `"bearer-anon"`, overridable via
-`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in stdio mode the subject is
-`"local"`.
+`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in no-auth mode (the default for
+stdio) the subject is `"local"`.
 
 ## Load semantics and privacy
 
 The ACL file loads **once at startup** and `load_acl` fails fast with
-`ConfigurationError` on any malformed entry (a typo aborts startup rather
-than silently denying). Denied requests are logged at WARNING with the
-subject; the wire-side error omits the subject by default — pass
-`AuthorizationMiddleware(..., expose_subject_in_error=True)` to surface it on
-internal-only servers.
+`ConfigurationError` on a *structural* error (missing or unreadable file,
+malformed TOML, no `[subjects]` table, a `*` subject key, or a non-string
+scope), aborting startup rather than running in a broken state. A *scope-name*
+typo is not structural — `"rite"` instead of `"write"` is valid TOML, loads
+cleanly, and then silently never matches, so the affected calls are denied;
+double-check scope spelling against the table below. Denied requests are
+logged at WARNING with the subject; the wire-side error omits the subject by
+default — pass `AuthorizationMiddleware(..., expose_subject_in_error=True)` to
+surface it on internal-only servers.
 
 ## Gated tools
 
 <!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->
-<!-- Replace with this server's tool→scope mapping. Example: -->
+<!-- Replace with this server's tool→scope mapping. For each gated tool, also set
+     meta={"required_scope": "<scope>"} on its registration in tools.py. Example: -->
 | Tool | Required scope |
 |------|----------------|
 | `delete_entry` | `write` |
@@ -66,3 +71,9 @@ internal-only servers.
 
 - [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
 - [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+
+<!-- DOMAIN-AUTHZ-EXTRA-START -->
+<!-- Project-specific authorization notes go here; kept across copier
+     update. (E.g. "the import tool requires the 'write:admin' scope",
+     "the CI service account uses the 'service:ci-bot' subject".) -->
+<!-- DOMAIN-AUTHZ-EXTRA-END -->

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -1,0 +1,68 @@
+# Authorization
+
+This server supports opt-in **per-subject authorization** from
+`fastmcp-pvl-core`. It is **off by default** — every authenticated caller can
+use every tool, resource, and prompt. Turn it on by pointing
+`{{ env_prefix }}_ACL_PATH` at a TOML ACL file; the middleware is installed
+only when the path is set, and individual tools opt in by declaring
+`meta={"required_scope": "<scope>"}` at registration. A tool without
+`required_scope` is unrestricted regardless of caller.
+
+The wiring ships as commented stubs in `src/{{ python_module }}/config.py`
+and `src/{{ python_module }}/server.py` — uncomment them to enable the
+`acl_path` config field and the `AuthorizationMiddleware` registration.
+
+## ACL TOML schema
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode subject
+```
+
+- **Subject strings are opaque.** The `<kind>:<id>` convention is
+  documentation only; the library treats each subject as a literal string.
+- **`*` is the only library-treated special scope** — it grants every
+  required scope. Subject-side wildcards (`*` as an ACL key) are rejected at
+  load time.
+- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is
+  encoded into the scope string itself (e.g. `read:project-foo`,
+  `write:vault/personal`).
+
+## Subjects and bearer alignment
+
+Subjects are minted by the authentication layer — see the
+[Authentication guide](authentication.md) for how bearer tokens and OIDC map
+callers to subject strings. The subject keyed in the ACL TOML is the same
+string used as a *value* in the bearer-tokens TOML
+(`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
+single-token mode every caller shares one subject (the library default,
+currently `"bearer-anon"`, overridable via
+`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in stdio mode the subject is
+`"local"`.
+
+## Load semantics and privacy
+
+The ACL file loads **once at startup** and `load_acl` fails fast with
+`ConfigurationError` on any malformed entry (a typo aborts startup rather
+than silently denying). Denied requests are logged at WARNING with the
+subject; the wire-side error omits the subject by default — pass
+`AuthorizationMiddleware(..., expose_subject_in_error=True)` to surface it on
+internal-only servers.
+
+## Gated tools
+
+<!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->
+<!-- Replace with this server's tool→scope mapping. Example: -->
+| Tool | Required scope |
+|------|----------------|
+| `delete_entry` | `write` |
+| `search`       | `read`  |
+<!-- DOMAIN-AUTHZ-SCOPES-END -->
+
+## See also
+
+- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
+- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.

--- a/docs/superpowers/plans/2026-06-19-authn-authz-colocation.md
+++ b/docs/superpowers/plans/2026-06-19-authn-authz-colocation.md
@@ -1,0 +1,334 @@
+# Authn/Authz Co-location Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make authentication and authorization travel together across the template's README, `.env.example`, and docs — promoting authorization into its own gated docs guide adjacent to the authentication guide, with brief README pointers and a seeded domain home for the project's tool→scope mapping.
+
+**Architecture:** Pure copier-template docs/scaffold change. A new `docs/guides/authorization.md.jinja` (created only when `enable_authorization` is true, via a conditional filename) holds the in-depth authz content moved out of the README. The two guides cross-reference at the subject boundary. The README keeps brief side-by-side pointers. No runtime code changes.
+
+**Tech Stack:** copier (Jinja2 templates), mkdocs + mkdocs-material + mkdocstrings + mike + llmstxt plugin, the project's render-and-gate (`ruff`, `mypy`, `pytest`, `mkdocs build --strict`).
+
+## Global Constraints
+
+- This is the **template repo**. Edit `.jinja` files; copier renders them. Copier reads from the git index/HEAD — **commit before rendering**, and render with `--vcs-ref=HEAD`.
+- `enable_authorization` (copier bool, default `false`) gates every authorization surface. Authentication is core and always renders.
+- The authorization guide must be **absent** (not empty) when `enable_authorization` is false — use the conditional-filename idiom so `mkdocs build --strict` never sees an orphan page.
+- README links to guides use **relative repo paths** (`docs/guides/<x>.md`) — they render on GitHub where the README is read, and the authz pointer + authz guide are co-gated so the link never dangles.
+- Cross-link gating asymmetry: **authn→authz link is gated** (target absent when off); **authz→authn link is ungated** (authn guide always present; the link only renders when the authz guide itself exists).
+- Verify **both** branches every task: `enable_authorization: true` (via `tests/fixtures/smoke-answers.yml`, already set) and `=false` (via `--data enable_authorization=false`).
+- Do NOT touch `docs/deployment/oidc.md.jinja` or the authn guide's OIDC section — the explanation-vs-recipe split is intentional and out of scope.
+
+## Render commands (used in every task's verification)
+
+```bash
+# ON branch (smoke-answers sets enable_authorization: true)
+rm -rf /tmp/aa-on && uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/aa-on
+
+# OFF branch
+rm -rf /tmp/aa-off && uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml --data enable_authorization=false . /tmp/aa-off
+```
+
+(Rendered project name is `smoke-mcp`, module `smoke_mcp`, env prefix `SMOKE_MCP`, github_org `pvliesdonk`.)
+
+---
+
+### Task 1: Authorization guide + nav entry + authn cross-link repoint
+
+**Files:**
+- Create: a conditional-filename template — literal name `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja` (see Step 1)
+- Modify: `mkdocs.yml.jinja` (nav, ~line 114)
+- Modify: `docs/guides/authentication.md.jinja` (cross-link, ~line 74)
+
+**Interfaces:**
+- Produces: a rendered `docs/guides/authorization.md` page (when authz on) at mkdocs URL slug `guides/authorization/`, reachable from the Authentication guide and the README. Contains a `DOMAIN-AUTHZ-SCOPES-START/END` sentinel pair for downstream tool→scope tables.
+- Consumes: nothing from other tasks.
+
+- [ ] **Step 1: Create the authorization guide with a conditional filename**
+
+Create a file whose **literal name on disk** is:
+
+```
+docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+```
+
+(When `enable_authorization` is false the rendered filename is empty and copier skips the file entirely.) Its contents:
+
+~~~markdown
+# Authorization
+
+This server supports opt-in **per-subject authorization** from
+`fastmcp-pvl-core`. It is **off by default** — every authenticated caller can
+use every tool, resource, and prompt. Turn it on by pointing
+`{{ env_prefix }}_ACL_PATH` at a TOML ACL file; the middleware is installed
+only when the path is set, and individual tools opt in by declaring
+`meta={"required_scope": "<scope>"}` at registration. A tool without
+`required_scope` is unrestricted regardless of caller.
+
+The wiring ships as commented stubs in `src/{{ python_module }}/config.py`
+and `src/{{ python_module }}/server.py` — uncomment them to enable the
+`acl_path` config field and the `AuthorizationMiddleware` registration.
+
+## ACL TOML schema
+
+```toml
+[subjects]
+"user:alice@example.com" = ["read", "write"]
+"user:admin@example.com" = ["*"]              # wildcard — any required scope passes
+"service:ci-bot"         = ["read"]
+"local"                  = ["*"]              # stdio mode subject
+```
+
+- **Subject strings are opaque.** The `<kind>:<id>` convention is
+  documentation only; the library treats each subject as a literal string.
+- **`*` is the only library-treated special scope** — it grants every
+  required scope. Subject-side wildcards (`*` as an ACL key) are rejected at
+  load time.
+- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is
+  encoded into the scope string itself (e.g. `read:project-foo`,
+  `write:vault/personal`).
+
+## Subjects and bearer alignment
+
+Subjects are minted by the authentication layer — see the
+[Authentication guide](authentication.md) for how bearer tokens and OIDC map
+callers to subject strings. The subject keyed in the ACL TOML is the same
+string used as a *value* in the bearer-tokens TOML
+(`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
+single-token mode every caller shares one subject (the library default,
+currently `"bearer-anon"`, overridable via
+`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in stdio mode the subject is
+`"local"`.
+
+## Load semantics and privacy
+
+The ACL file loads **once at startup** and `load_acl` fails fast with
+`ConfigurationError` on any malformed entry (a typo aborts startup rather
+than silently denying). Denied requests are logged at WARNING with the
+subject; the wire-side error omits the subject by default — pass
+`AuthorizationMiddleware(..., expose_subject_in_error=True)` to surface it on
+internal-only servers.
+
+## Gated tools
+
+<!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->
+<!-- Replace with this server's tool→scope mapping. Example: -->
+| Tool | Required scope |
+|------|----------------|
+| `delete_entry` | `write` |
+| `search`       | `read`  |
+<!-- DOMAIN-AUTHZ-SCOPES-END -->
+
+## See also
+
+- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
+- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+~~~
+
+- [ ] **Step 2: Add the gated nav entry**
+
+In `mkdocs.yml.jinja`, find (inside the `PROJECT-NAV-START`/`END` block):
+
+```yaml
+      - Authentication: guides/authentication.md
+  - MCP Interface:
+```
+
+Replace with (note: `{% if %}`/`{% endif %}` abut the surrounding lines so both branches render clean YAML — on → both entries, off → only Authentication, no blank line):
+
+```yaml
+      - Authentication: guides/authentication.md
+{% if enable_authorization %}      - Authorization: guides/authorization.md
+{% endif %}  - MCP Interface:
+```
+
+- [ ] **Step 3: Repoint the authentication guide's cross-link to the new guide**
+
+In `docs/guides/authentication.md.jinja`, the cross-link currently reads (inside its existing `{% if enable_authorization %}` block):
+
+```
+For the per-tool authorization that consumes these subjects, see [Authorization (opt-in)](https://github.com/{{ github_org }}/{{ project_name }}/blob/main/README.md#authorization-opt-in) in the project README.
+```
+
+Replace that one line with:
+
+```
+For the per-tool authorization that consumes these subjects, see the [Authorization guide](authorization.md).
+```
+
+(Leave the surrounding `{% if enable_authorization %}` / `{% endif %}` gate untouched — the link stays gated so it never points at an absent page.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja" mkdocs.yml.jinja docs/guides/authentication.md.jinja
+git commit -m "feat(scaffold): add gated Authorization guide adjacent to Authentication"
+```
+
+- [ ] **Step 5: Render both branches and verify presence/absence**
+
+Run the ON and OFF render commands (top of plan). Then:
+
+```bash
+echo "ON: guide present?";  ls /tmp/aa-on/docs/guides/authorization.md && echo OK
+echo "ON: nav has Authorization?"; grep -c "Authorization: guides/authorization.md" /tmp/aa-on/mkdocs.yml
+echo "ON: authn->authz link repointed?"; grep -c "\[Authorization guide\](authorization.md)" /tmp/aa-on/docs/guides/authentication.md
+echo "ON: authz->authn back-link?"; grep -c "\[Authentication guide\](authentication.md)" /tmp/aa-on/docs/guides/authorization.md
+echo "ON: sentinel present?"; grep -c "DOMAIN-AUTHZ-SCOPES-START" /tmp/aa-on/docs/guides/authorization.md
+
+echo "OFF: guide absent?"; test ! -e /tmp/aa-off/docs/guides/authorization.md && echo "absent OK"
+echo "OFF: nav has no Authorization entry?"; grep -c "Authorization: guides/authorization.md" /tmp/aa-off/mkdocs.yml || echo "0 OK"
+echo "OFF: authn guide has no authz link?"; grep -c "authorization.md" /tmp/aa-off/docs/guides/authentication.md || echo "0 OK"
+```
+
+Expected: ON → all `1`/OK; OFF → guide absent, `0` nav/link matches.
+
+- [ ] **Step 6: mkdocs --strict on both branches**
+
+```bash
+for d in /tmp/aa-on /tmp/aa-off; do
+  (cd "$d" && uv sync --no-default-groups --group docs --frozen >/dev/null 2>&1 && uv run mkdocs build --strict 2>&1 | tail -2)
+done
+```
+
+Expected: both "Documentation built" with no `WARNING`/`ERROR` (no orphan-page warning on OFF, no broken-link warning on ON).
+
+---
+
+### Task 2: README brief pointers + `.env.example` header rename
+
+**Files:**
+- Modify: `README.md.jinja` (replace the `## Authorization (opt-in)` section block, ~lines 112–140; add `## Authentication` before it)
+- Modify: `.env.example.jinja` (line 10 header)
+
+**Interfaces:**
+- Consumes: the `docs/guides/authentication.md` and `docs/guides/authorization.md` pages from Task 1 (the README pointers link to them).
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Replace the README authorization section with brief side-by-side pointers**
+
+In `README.md.jinja`, the current block is:
+
+```
+{% if enable_authorization -%}
+## Authorization (opt-in)
+... (full ACL schema, subjects, load/privacy, see-also) ...
+{% endif -%}
+## Post-scaffold checklist
+```
+
+Replace the entire `{% if enable_authorization -%}` … `{% endif -%}` block (the Authorization section, from the `{% if enable_authorization -%}` line through the `{% endif -%}` line, inclusive) with:
+
+```
+## Authentication
+
+Callers authenticate via a bearer token or OIDC (mutually exclusive). See the [Authentication guide](docs/guides/authentication.md) for setup, mapped multi-subject tokens, OIDC, and troubleshooting.
+
+{% if enable_authorization -%}
+## Authorization (opt-in)
+
+Per-subject authorization is **off by default** — every authenticated caller can use every tool. Point `{{ env_prefix }}_ACL_PATH` at a TOML ACL file to gate tools by scope (tools opt in via `meta={"required_scope": "<scope>"}`). See the [Authorization guide](docs/guides/authorization.md).
+
+{% endif -%}
+```
+
+(The `## Post-scaffold checklist` heading that followed the old block stays exactly where it was, immediately after the `{% endif -%}`.)
+
+- [ ] **Step 2: Rename the `.env.example` auth header for naming symmetry**
+
+In `.env.example.jinja`, change line 10 from:
+
+```
+# --- Auth (pick one flavor) ---
+```
+
+to:
+
+```
+# --- Authentication (pick one flavor) ---
+```
+
+(Leave the `{% if enable_authorization %}# --- Authorization (optional opt-in) ---` block below it unchanged — the two headers now read "Authentication" / "Authorization".)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md.jinja .env.example.jinja
+git commit -m "feat(scaffold): brief README authn+authz pointers; .env header symmetry"
+```
+
+- [ ] **Step 4: Render both branches and verify**
+
+Re-run the ON and OFF render commands, then:
+
+```bash
+echo "ON: README has Authentication section?"; grep -c "^## Authentication$" /tmp/aa-on/README.md
+echo "ON: README has Authorization section?"; grep -c "^## Authorization (opt-in)$" /tmp/aa-on/README.md
+echo "ON: README authz links to guide (not anchor)?"; grep -c "docs/guides/authorization.md" /tmp/aa-on/README.md
+echo "ON: README no longer carries the full ACL TOML schema heading?"; grep -c "^### ACL TOML schema$" /tmp/aa-on/README.md || echo "0 OK"
+
+echo "OFF: README has Authentication only?"; grep -c "^## Authentication$" /tmp/aa-off/README.md
+echo "OFF: README has NO Authorization section?"; grep -c "^## Authorization (opt-in)$" /tmp/aa-off/README.md || echo "0 OK"
+
+echo "BOTH: .env header renamed?"; grep -c "Authentication (pick one flavor)" /tmp/aa-on/.env.example /tmp/aa-off/.env.example
+```
+
+Expected: ON → Authentication `1`, Authorization `1`, guide link `1`, no `### ACL TOML schema` (`0`); OFF → Authentication `1`, Authorization `0`; both `.env` headers renamed (`1` each).
+
+---
+
+### Task 3: Full both-branch gate + spec status
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md` (status line)
+
+- [ ] **Step 1: Run the full render-and-gate on both branches**
+
+Re-render ON and OFF, then for each run the project's gate:
+
+```bash
+for d in /tmp/aa-on /tmp/aa-off; do
+  echo "===== $d ====="
+  (cd "$d" \
+    && uv sync --all-extras --all-groups >/dev/null 2>&1 \
+    && uv run ruff check . \
+    && uv run ruff format --check . \
+    && uv run mypy src/ tests/ 2>&1 | tail -1 \
+    && uv run pytest -x -q 2>&1 | tail -1 \
+    && uv run mkdocs build --strict 2>&1 | tail -1)
+done
+```
+
+Expected: both branches — ruff "All checks passed!", format "already formatted", mypy "Success", pytest passing, mkdocs "Documentation built". (`pytest`'s browser/config-wizard tests skip without a built site/Chromium — that is pre-existing and unrelated.)
+
+- [ ] **Step 2: Mark the spec implemented**
+
+In `docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md`, change the `**Status:**` line from `Design — approved, pending spec review` to `Implemented`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md
+git commit -m "docs(spec): mark authn/authz co-location implemented"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two adjacent guides → Task 1 (new authz guide + nav). ✓
+- Authz content moved out of README → Task 1 (guide content) + Task 2 (README pointer replaces it). ✓
+- authn→authz repoint (gated) → Task 1 Step 3. ✓
+- authz→authn back-link (ungated) → Task 1 Step 1 ("Subjects and bearer alignment"). ✓
+- README brief side-by-side pointers → Task 2 Step 1. ✓
+- `.env` naming symmetry → Task 2 Step 2. ✓
+- Conditional filename (no orphan page) → Task 1 Step 1 + Step 6 verify. ✓
+- `DOMAIN-AUTHZ-SCOPES` seeded sentinel → Task 1 Step 1. ✓
+- Gating across all surfaces → Tasks 1–2 + Task 3 OFF-branch gate. ✓
+- OIDC out of scope → no task touches it. ✓
+
+**Placeholder scan:** No TBD/TODO; every file's full content is inline; the seeded ACL/scope examples are intentional template content, not placeholders.
+
+**Type/name consistency:** Slugs and paths are consistent — guide file `authorization.md`, nav `guides/authorization.md`, README link `docs/guides/authorization.md`, intra-docs links `authorization.md`/`authentication.md`, sentinel `DOMAIN-AUTHZ-SCOPES-START/END`.

--- a/docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md
+++ b/docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md
@@ -1,7 +1,7 @@
 # Co-locate authentication + authorization across the template
 
 **Date:** 2026-06-19
-**Status:** Design — approved, pending spec review
+**Status:** Implemented
 **Repo:** fastmcp-server-template (the template itself)
 **Related:** PR #177 (added `enable_authorization` gating), issue #176
 

--- a/docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md
+++ b/docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md
@@ -1,0 +1,186 @@
+# Co-locate authentication + authorization across the template
+
+**Date:** 2026-06-19
+**Status:** Design — approved, pending spec review
+**Repo:** fastmcp-server-template (the template itself)
+**Related:** PR #177 (added `enable_authorization` gating), issue #176
+
+## Problem
+
+Authentication (who the caller is) and authorization (what the caller may
+do) are tightly related — authz consumes the subject that authn mints — but
+the template documents them in structurally inconsistent places:
+
+- **Authentication** lives only in docs: `docs/guides/authentication.md`
+  (bearer, mapped multi-subject, OIDC explanation, troubleshooting). It is
+  absent from the README.
+- **Authorization** lives mostly in the README (`## Authorization (opt-in)`,
+  gated by `enable_authorization`) plus the `config.py`/`server.py` stubs and
+  the `.env.example` ACL block. It has **no docs page** — only a cross-link
+  *from* the authn guide *to* the README section.
+
+The result: the core feature (authn) is a deep docs guide, the optional
+feature (authz) is documented in the README, and they are stitched together
+by a README-pointing cross-link. A reader cannot find the two auth concerns
+next to each other anywhere.
+
+Authn/authz are template-owned and have little domain dependence, so this is
+a template-structure issue, not a per-project one. The one domain-dependent
+part is *which of a project's tools require which scope* — that needs a
+seeded, customizable home.
+
+## Goal
+
+Make authn and authz travel together on every surface — README, `.env`, and
+docs — with authz template-owned and gated by `enable_authorization`, and the
+depth living in two adjacent, cross-linked guides. Give the downstream a
+seeded place to document its own tool→scope mapping.
+
+## Non-goals (explicitly out of scope)
+
+- **OIDC de-duplication.** The authn guide's OIDC *explanation* and
+  `docs/deployment/oidc.md`'s *deployment recipe* serve different audiences
+  (in-depth reference vs. "what it takes to run in a normal environment").
+  They are intentionally distinct and stay as-is.
+- Any change to the authn content itself beyond repointing one cross-link.
+- Any change to the runtime auth/authz code (`fastmcp-pvl-core`) — this is a
+  template docs/scaffold restructuring only.
+
+## Design
+
+### Surface 1 — Docs: two adjacent guides
+
+- `docs/guides/authentication.md.jinja` stays the in-depth authn reference.
+  Its one change: the existing cross-link (currently
+  `→ README.md#authorization-opt-in`, gated by `enable_authorization`) is
+  **repointed** to the new authorization guide, staying gated.
+- **NEW** `docs/guides/authorization.md.jinja` — the in-depth authz content
+  **moved out of the README**: ACL TOML schema, subjects & scopes,
+  subject↔bearer alignment, load semantics, privacy default, and the
+  `fastmcp-pvl-core` "see also" links. It also contains:
+  - A back cross-link to the authentication guide at the subject boundary
+    ("subjects are minted by the auth layer — see the Authentication guide").
+    Always safe to render (the authz guide only exists when authz is on; the
+    authn guide is always present), so this link is **not** gated.
+  - A `DOMAIN-AUTHZ-SCOPES` sentinel block giving the downstream room to
+    document which of *its* tools require which scope, seeded with a
+    commented example table the project replaces (kept across copier update
+    via the same 3-way-merge mechanism as `DOMAIN-AUTH-EXTRA`):
+
+    ```markdown
+    <!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->
+    <!-- Replace with your tool→scope mapping. Example: -->
+    | Tool | Required scope |
+    |------|----------------|
+    | `delete_entry` | `write` |
+    | `search`       | `read`  |
+    <!-- DOMAIN-AUTHZ-SCOPES-END -->
+    ```
+
+#### Conditional file creation
+
+The authorization guide must be **absent** when `enable_authorization` is
+false, not merely empty — an orphaned page (present on disk, missing from
+nav) fails `mkdocs build --strict` ("page exists but not in nav"). Use
+copier's conditional-filename idiom:
+
+```
+docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+```
+
+When the flag is false the rendered filename is empty and copier skips the
+file. The nav entry is gated to match (below).
+
+#### Nav
+
+`mkdocs.yml.jinja` gains an Authorization entry immediately after
+Authentication, wrapped in `{% if enable_authorization %}`:
+
+```yaml
+      - Authentication: guides/authentication.md
+{% if enable_authorization %}      - Authorization: guides/authorization.md
+{% endif %}
+```
+
+(The `llms.txt` section globs `guides/*.md`, so the new page is picked up
+automatically when present and absent when not — no separate change there.)
+
+### Surface 2 — README: brief side-by-side pointers
+
+Immediately after `## Configuration`, two short adjacent sections replace the
+current fuller `## Authorization (opt-in)` section:
+
+- `## Authentication` (always rendered) — 2–3 lines: bearer token or OIDC,
+  pick one; link to the Authentication guide.
+- `## Authorization (opt-in)` (gated by `enable_authorization`) — 2–3 lines:
+  off by default, point `*_ACL_PATH` at an ACL file to gate tools by scope;
+  link to the Authorization guide.
+
+All ACL schema / subject-alignment / load / privacy detail currently in the
+README moves into the authorization guide. The README authz block keeps its
+`{% if enable_authorization %}` gate.
+
+### Surface 3 — `.env.example`: naming symmetry
+
+The authn (`# --- Auth (pick one flavor) ---`) and gated authz
+(`# --- Authorization (optional opt-in) ---`) blocks are already adjacent
+(lines 10–24). Only change: rename the authn header to
+`# --- Authentication (pick one flavor) ---` for naming symmetry with the
+docs/README. The authz block stays gated.
+
+### Gating summary
+
+`enable_authorization` continues to gate every authz surface, now including
+the new guide:
+
+| Surface | Gated? | Mechanism |
+|---|---|---|
+| README `## Authorization` pointer | yes | `{% if %}` block |
+| README `## Authentication` pointer | no (authn is core) | always rendered |
+| `.env.example` ACL block | yes | `{% if %}` block (existing) |
+| `config.py`/`server.py` stubs | yes | `{% if %}` block (existing) |
+| `guides/authorization.md` | yes | conditional filename |
+| nav Authorization entry | yes | `{% if %}` in `mkdocs.yml.jinja` |
+| authn→authz cross-link | yes | `{% if %}` (existing, repointed) |
+| authz→authn back-link | no (target always present) | always rendered |
+
+## Cross-reference integrity
+
+The two guides cross-reference at the subject boundary. The gating asymmetry
+(authn always present, authz present only when enabled) means:
+
+- authn→authz link is gated (no dead link when authz off).
+- authz→authn link is ungated (target always present; the link only renders
+  at all when the authz guide itself is present).
+
+This is the same dead-anchor class fixed in PR #177; the design preserves it
+by construction.
+
+## Testing / verification
+
+Render and gate **both** branches (`enable_authorization` true and false)
+from HEAD with smoke-answers:
+
+- **ON:** `guides/authorization.md` present and in nav; authn→authz and
+  authz→authn links resolve; README has both pointer sections; `.env` has
+  both blocks. `mkdocs build --strict` passes; full render gate
+  (ruff/format/mypy/pytest) passes.
+- **OFF:** `guides/authorization.md` **absent** (no file, no nav entry, no
+  orphan-page warning); README has only `## Authentication`; `.env` has only
+  the authn block; no dead authn→authz link. `mkdocs build --strict` passes.
+
+`smoke-answers.yml` already sets `enable_authorization: true`, so CI exercises
+the ON branch; the OFF branch is verified locally (the established
+convention).
+
+## Downstream migration
+
+Consumers on the current template will, on `copier update`:
+
+- Gain `guides/authorization.md` (if they have `enable_authorization: true`).
+- See the README authz detail collapse to a pointer; the moved content now
+  lives in the guide.
+- Need to populate the `DOMAIN-AUTHZ-SCOPES` table with their real tool→scope
+  mapping (seeded example otherwise renders).
+
+No code changes are required downstream; this is docs/scaffold only.

--- a/mkdocs.yml.jinja
+++ b/mkdocs.yml.jinja
@@ -113,7 +113,8 @@ nav:
       - Configuration Generator: configuration-generator.md
   - Guides:
       - Authentication: guides/authentication.md
-  - MCP Interface:
+{% if enable_authorization %}      - Authorization: guides/authorization.md
+{% endif %}  - MCP Interface:
       - Tools: tools/index.md
       - Prompts: prompts.md
   - Deployment:


### PR DESCRIPTION
## Summary

Authentication and authorization now travel together across every template surface, with authz promoted into its own gated docs guide adjacent to the authentication guide.

Closes #178.

## Changes

- **New `docs/guides/authorization.md`** (gated via the conditional-filename idiom `{% if enable_authorization %}authorization.md{% endif %}.jinja`, so it's *absent* — not orphaned — when `enable_authorization` is off). Holds the in-depth authz content moved out of the README: ACL TOML schema, subjects & bearer alignment, load/privacy semantics, a `DOMAIN-AUTHZ-SCOPES` sentinel (seeded tool→scope table) and a `DOMAIN-AUTHZ-EXTRA` notes sentinel.
- **Two adjacent guides, cross-linked at the subject boundary:** authn→authz link (gated) repointed from the README anchor to the new guide; authz→authn back-link (ungated, target always present).
- **README** reduced to brief side-by-side pointers — `## Authentication` (always) + `## Authorization (opt-in)` (gated), each linking to its guide.
- **`mkdocs.yml.jinja`** gains a gated nav entry after Authentication.
- **`.env.example.jinja`** authn header renamed for naming symmetry.
- `copier.yml` `enable_authorization` help updated to enumerate the new guide surface.

Design spec: `docs/superpowers/specs/2026-06-19-authn-authz-colocation-design.md`. Out of scope (intentional): the authn-guide OIDC *explanation* vs `deployment/oidc.md` *deployment recipe* split.

## Testing

Built subagent-driven (3 tasks, each spec+quality reviewed) plus a whole-branch review. Verified by rendering **both** branches from HEAD:

- **ON** (`enable_authorization: true`, via smoke-answers): guide present + in nav, cross-links resolve, README has both pointers.
- **OFF**: guide absent (no file, no nav entry, no orphan page), README has only `## Authentication`, no dead links.
- Full gate green on **both** branches: `ruff` / `ruff format --check` / `mypy` / `pytest` (22 passed, 14 pre-existing browser skips) / `mkdocs build --strict`.

Whole-branch review fixes folded in: corrected the guide's `load_acl` failure semantics (a scope-*name* typo is valid TOML that silently never matches — verified against `fastmcp-pvl-core` `_authorization.py`; `ConfigurationError` is structural-only), `"local"` is the no-auth-mode subject (not stdio-by-transport, per `_subject.py`), and added the `DOMAIN-AUTHZ-EXTRA` sentinel to match the per-guide convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
