### PR TITLE
feat(scaffold): migrate authorization to pvl-core v4 native AuthChecks

### DIFF
--- a/.env.example.jinja
+++ b/.env.example.jinja
@@ -20,7 +20,13 @@
 # {{ env_prefix }}_OIDC_JWT_SIGNING_KEY=<hex-string>
 {% if enable_authorization %}
 # --- Authorization (optional opt-in) ---
+# Bearer / any mode: subject->scope ACL (TOML).
 # {{ env_prefix }}_ACL_PATH=/etc/{{ project_name }}/acl.toml
+# OIDC: claim->scope. Name the claim to read (e.g. "groups"); identity
+# mapping when IdP group names already match your scope names.
+# {{ env_prefix }}_AUTHZ_CLAIM=groups
+# Optional inline-JSON translation map when group names differ from scopes:
+# {{ env_prefix }}_AUTHZ_GRANTS={"app-writers": ["read", "write"], "app-admins": ["*"]}
 {% endif %}
 # --- Remote debugger (development only — image must be built with --build-arg DEBUG=true) ---
 # {{ env_prefix }}_DEBUG_PORT=5678

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -116,7 +116,7 @@ Callers authenticate via a bearer token or OIDC (mutually exclusive). See the [A
 {% if enable_authorization -%}
 ## Authorization (opt-in)
 
-Authorization is **off by default** — every authenticated caller can use every tool. Tools opt in via `meta={"required_scope": "<scope>"}`, then gate by either a subject→scope ACL (`{{ env_prefix }}_ACL_PATH`, the only per-token option for bearer) or an OIDC claim→scope map (`{{ env_prefix }}_AUTHZ_CLAIM`). See the [Authorization guide](docs/guides/authorization.md).
+Authorization gates individual tools by scope and is **off by default** — every authenticated caller can use everything. Decide a caller's scopes from a subject ACL file (`{{ env_prefix }}_ACL_PATH`, for bearer) or an OIDC identity claim (`{{ env_prefix }}_AUTHZ_CLAIM`). See the [Authorization guide](docs/guides/authorization.md).
 
 {% endif -%}
 ## Post-scaffold checklist

--- a/README.md.jinja
+++ b/README.md.jinja
@@ -116,7 +116,7 @@ Callers authenticate via a bearer token or OIDC (mutually exclusive). See the [A
 {% if enable_authorization -%}
 ## Authorization (opt-in)
 
-Per-subject authorization is **off by default** — every authenticated caller can use every tool. Point `{{ env_prefix }}_ACL_PATH` at a TOML ACL file to gate tools by scope (tools opt in via `meta={"required_scope": "<scope>"}`). See the [Authorization guide](docs/guides/authorization.md).
+Authorization is **off by default** — every authenticated caller can use every tool. Tools opt in via `meta={"required_scope": "<scope>"}`, then gate by either a subject→scope ACL (`{{ env_prefix }}_ACL_PATH`, the only per-token option for bearer) or an OIDC claim→scope map (`{{ env_prefix }}_AUTHZ_CLAIM`). See the [Authorization guide](docs/guides/authorization.md).
 
 {% endif -%}
 ## Post-scaffold checklist

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -82,10 +82,10 @@ Full OAuth 2.1 authentication using an external identity provider. Supports user
 
 ### How it works
 
-The server uses FastMCP's built-in `OIDCProxy`. No external auth sidecar needed:
+The server proxies OIDC itself — no external auth sidecar to deploy:
 
 ```
-Client → mcp-server (OIDCProxy) → OIDC Provider
+Client → mcp-server → OIDC Provider
 ```
 
 1. Client connects to the server

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -1,25 +1,61 @@
 # Authorization
 
-This server supports opt-in **per-subject authorization** from
-`fastmcp-pvl-core`. It is **off by default** — every authenticated caller can
-use every tool, resource, and prompt. Turn it on by pointing
-`{{ env_prefix }}_ACL_PATH` at a TOML ACL file; the middleware is installed
-only when the path is set, and individual tools opt in by declaring
-`meta={"required_scope": "<scope>"}` at registration. A tool without
-`required_scope` is unrestricted regardless of caller.
+This server supports opt-in **authorization** from `fastmcp-pvl-core`,
+layered on FastMCP's native `AuthMiddleware`. It is **off by default** —
+every authenticated caller can use every tool, resource, and prompt. A
+component opts in by declaring `meta={"required_scope": "<scope>"}` at
+registration; one without `required_scope` is unrestricted regardless of
+caller.
+
+pvl-core ships the two checks the framework has no built-in for, plus an
+OR-combinator:
+
+- **`make_acl_check(load_acl(path))`** — a static **subject→scope** ACL,
+  keyed by the caller's `sub` claim (OIDC) or `client_id` (bearer). This
+  is the **only** per-caller authz available in **bearer** modes (bearer
+  tokens carry no OIDC claims).
+- **`make_claims_check(claim, grants=None)`** — **claim→scope** for
+  **OIDC** modes. It reads an OIDC *claim* (e.g. `groups`, `roles`) —
+  the IdP's assertion about the user — not OAuth *scopes*.
+- **`any_check(a, b)`** — OR the two for `multi` mode (bearer break-glass
+  *and* OIDC users on one server).
+
+Scope- and tag-only patterns can also use FastMCP's own `require_scopes`
+/ `restrict_tag` directly.
 
 The wiring ships as commented stubs in `src/{{ python_module }}/config.py`
-and `src/{{ python_module }}/server.py` — uncomment them to enable the
-`acl_path` config field and the `AuthorizationMiddleware` registration.
+and `src/{{ python_module }}/server.py` — uncomment the check that
+matches your auth mode and install it with
+`AuthMiddleware(auth=<check>)`.
 
-## ACL TOML schema
+## Claim vs. scope (OIDC)
+
+Claim-based authz reads OIDC **claims** (`groups`, `roles`) — the user's
+IdP-issued permissions — **not** OAuth **scopes** (which describe the
+client/token grant and are usually fixed, e.g. `openid profile email`).
+Configure which claim to read with `{{ env_prefix }}_AUTHZ_CLAIM`.
+
+**Identity mapping (zero-config):** when your IdP's group names already
+match your scope strings, no translation is needed — a caller is granted
+exactly the values in their claim. Only when the vocabularies differ do
+you supply an inline-JSON **translation map**:
+
+```jsonc
+// {{ env_prefix }}_AUTHZ_GRANTS
+{"app-writers": ["read", "write"], "app-admins": ["*"]}
+```
+
+A literal `"*"` from a raw claim value never escalates — the `"*"`
+wildcard is honoured only when an operator places it in a `grants` scope
+list.
+
+## ACL TOML schema (subject→scope)
 
 ```toml
 [subjects]
 "user:alice@example.com" = ["read", "write"]
 "user:admin@example.com" = ["*"]              # wildcard — any required scope passes
 "service:ci-bot"         = ["read"]
-"local"                  = ["*"]              # no-auth mode subject (default for stdio)
 ```
 
 - **Subject strings are opaque.** The `<kind>:<id>` convention is
@@ -40,21 +76,29 @@ string used as a *value* in the bearer-tokens TOML
 (`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
 single-token mode every caller shares one subject (the library default,
 currently `"bearer-anon"`, overridable via
-`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`); in no-auth mode (the default for
-stdio) the subject is `"local"`.
+`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).
 
-## Load semantics and privacy
+## Load semantics and mode coverage
 
-The ACL file loads **once at startup** and `load_acl` fails fast with
-`ConfigurationError` on a *structural* error (missing or unreadable file,
-malformed TOML, no `[subjects]` table, a `*` subject key, or a non-string
-scope), aborting startup rather than running in a broken state. A *scope-name*
-typo is not structural — `"rite"` instead of `"write"` is valid TOML, loads
-cleanly, and then silently never matches, so the affected calls are denied;
-double-check scope spelling against the table below. Denied requests are
-logged at WARNING with the subject; the wire-side error omits the subject by
-default — pass `AuthorizationMiddleware(..., expose_subject_in_error=True)` to
-surface it on internal-only servers.
+Config loads **once at startup**: `load_acl` (TOML) and `parse_claim_grants`
+(inline JSON) both **fail fast** with `ConfigurationError` on a *structural*
+error (unreadable/malformed input, wrong shape, a `*` key), aborting startup
+rather than running broken. A *scope-name* typo is not structural —
+`"rite"` for `"write"` loads cleanly and then silently never matches, so the
+affected calls are denied; double-check spelling against the table below.
+
+A few mode facts worth knowing:
+
+- **Bearer** tokens carry no OIDC claims, so only the **subject-ACL** check
+  gates them per-caller.
+- Authorization is **meaningful only under an `AuthProvider`.** `stdio`
+  bypasses checks entirely; on HTTP `AuthMiddleware` still runs without a
+  provider, but every request then carries no token — so a component with
+  `required_scope` is **denied**. Install these checks alongside real
+  authentication.
+- Deny handling is delegated to FastMCP's `AuthMiddleware` (it raises an
+  authorization error on an unauthorized call and filters `list_*`
+  responses); pvl-core no longer ships its own deny envelope.
 
 ## Gated tools
 
@@ -69,8 +113,8 @@ surface it on internal-only servers.
 
 ## See also
 
-- [fastmcp-pvl-core README — Authorization](https://github.com/pvliesdonk/fastmcp-pvl-core#authorization-opt-in--authorizationmiddleware) — full design, the `check_authorization` per-call helper, and per-token subject mapping.
-- [Authorization submodule spec](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/specs/authorization-submodule.md) — design rationale and deviations table.
+- [fastmcp-pvl-core README](https://github.com/pvliesdonk/fastmcp-pvl-core#readme) — the "Authorization" section covers the native `AuthCheck` factories, the claim-vs-scope distinction, and per-mode coverage in full.
+- [Authz native-rebuild design](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/superpowers/specs/2026-06-19-authz-native-rebuild-design.md) — design rationale for the move to native checks.
 
 <!-- DOMAIN-AUTHZ-EXTRA-START -->
 <!-- Project-specific authorization notes go here; kept across copier

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -41,9 +41,7 @@ mapping each claim value to the scopes it grants:
 {"app-writers": ["read", "write"], "app-admins": ["*"]}
 ```
 
-`"*"` grants every scope. It is honoured **only** here, in this
-operator-supplied map — a literal `"*"` arriving in a caller's claim is
-never treated as the wildcard.
+In this map, `"*"` grants every scope.
 
 ## The ACL file (subject → scope)
 

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -1,55 +1,53 @@
 # Authorization
 
-This server supports opt-in **authorization** from `fastmcp-pvl-core`,
-layered on FastMCP's native `AuthMiddleware`. It is **off by default** —
-every authenticated caller can use every tool, resource, and prompt. A
-component opts in by declaring `meta={"required_scope": "<scope>"}` at
-registration; one without `required_scope` is unrestricted regardless of
+This server supports opt-in **authorization** — gating individual tools,
+resources, and prompts by *scope*. It is **off by default**: every
+authenticated caller can use everything. A component is gated only once
+it declares a required scope; one without is unrestricted regardless of
 caller.
 
-pvl-core ships the two checks the framework has no built-in for, plus an
-OR-combinator:
+There are two ways to decide which scopes a caller holds — pick the one
+that matches how callers authenticate (see the
+[Authentication guide](authentication.md)):
 
-- **`make_acl_check(load_acl(path))`** — a static **subject→scope** ACL,
-  keyed by the caller's `sub` claim (OIDC) or `client_id` (bearer). This
-  is the **only** per-caller authz available in **bearer** modes (bearer
-  tokens carry no OIDC claims).
-- **`make_claims_check(claim, grants=None)`** — **claim→scope** for
-  **OIDC** modes. It reads an OIDC *claim* (e.g. `groups`, `roles`) —
-  the IdP's assertion about the user — not OAuth *scopes*.
-- **`any_check(a, b)`** — OR the two for `multi` mode (bearer break-glass
-  *and* OIDC users on one server).
+- **Bearer tokens → a subject ACL file.** A TOML file maps each caller's
+  subject to the scopes it holds. Point `{{ env_prefix }}_ACL_PATH` at
+  it. This is the only option for bearer callers.
+- **OIDC → an identity claim.** The server reads a claim the identity
+  provider issues about the user (group or role membership) and treats
+  its values as the caller's scopes. Set `{{ env_prefix }}_AUTHZ_CLAIM`
+  to that claim's name (e.g. `groups`).
 
-Scope- and tag-only patterns can also use FastMCP's own `require_scopes`
-/ `restrict_tag` directly.
+To turn either on: set the relevant `{{ env_prefix }}_*` variable(s)
+and uncomment the matching block in `src/{{ python_module }}/server.py`
+(plus the config field it reads in `config.py`). Both may run together —
+e.g. an OIDC deployment that keeps a bearer break-glass account.
 
-The wiring ships as commented stubs in `src/{{ python_module }}/config.py`
-and `src/{{ python_module }}/server.py` — uncomment the check that
-matches your auth mode and install it with
-`AuthMiddleware(auth=<check>)`.
+## Gating by an OIDC claim
 
-## Claim vs. scope (OIDC)
+Authorization reads OIDC **claims** — what the identity provider asserts
+about the *user* (their groups/roles) — not the OAuth scopes the client
+negotiated. Set `{{ env_prefix }}_AUTHZ_CLAIM` to the claim that carries
+the user's group/role list.
 
-Claim-based authz reads OIDC **claims** (`groups`, `roles`) — the user's
-IdP-issued permissions — **not** OAuth **scopes** (which describe the
-client/token grant and are usually fixed, e.g. `openid profile email`).
-Configure which claim to read with `{{ env_prefix }}_AUTHZ_CLAIM`.
+**No mapping is needed when the names already match.** If your IdP's
+group names are the same strings as your tool scopes, a caller is
+granted exactly the values in their claim — there is nothing else to
+configure. Only when the two vocabularies differ do you supply a
+translation map in `{{ env_prefix }}_AUTHZ_GRANTS`, as inline JSON
+mapping each claim value to the scopes it grants:
 
-**Identity mapping (zero-config):** when your IdP's group names already
-match your scope strings, no translation is needed — a caller is granted
-exactly the values in their claim. Only when the vocabularies differ do
-you supply an inline-JSON **translation map**:
-
-```jsonc
-// {{ env_prefix }}_AUTHZ_GRANTS
+```json
 {"app-writers": ["read", "write"], "app-admins": ["*"]}
 ```
 
-A literal `"*"` from a raw claim value never escalates — the `"*"`
-wildcard is honoured only when an operator places it in a `grants` scope
-list.
+`"*"` grants every scope. It is honoured **only** here, in this
+operator-supplied map — a literal `"*"` arriving in a caller's claim is
+never treated as the wildcard.
 
-## ACL TOML schema (subject→scope)
+## The ACL file (subject → scope)
+
+Point `{{ env_prefix }}_ACL_PATH` at a TOML file shaped like:
 
 ```toml
 [subjects]
@@ -59,46 +57,40 @@ list.
 ```
 
 - **Subject strings are opaque.** The `<kind>:<id>` convention is
-  documentation only; the library treats each subject as a literal string.
-- **`*` is the only library-treated special scope** — it grants every
-  required scope. Subject-side wildcards (`*` as an ACL key) are rejected at
-  load time.
-- **Scope vocabulary is domain-defined.** Per-project or per-folder gating is
+  documentation only; each subject is matched as a literal string.
+- **`*` is the only special scope** — it grants every required scope.
+  Subject-side wildcards (`*` as a subject key) are rejected at startup.
+- **Scope vocabulary is yours.** Per-project or per-folder gating is
   encoded into the scope string itself (e.g. `read:project-foo`,
   `write:vault/personal`).
 
-## Subjects and bearer alignment
+### Aligning subjects with bearer tokens
 
-Subjects are minted by the authentication layer — see the
-[Authentication guide](authentication.md) for how bearer tokens and OIDC map
-callers to subject strings. The subject keyed in the ACL TOML is the same
-string used as a *value* in the bearer-tokens TOML
+Subjects come from the authentication layer — see the
+[Authentication guide](authentication.md) for how bearer tokens and OIDC
+map callers to subject strings. The subject keyed in this ACL is the
+same string used as a *value* in the bearer-tokens TOML
 (`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
-single-token mode every caller shares one subject (the library default,
-currently `"bearer-anon"`, overridable via
+single-token mode every caller shares one subject (the default
+`"bearer-anon"`, overridable via
 `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).
 
-## Load semantics and mode coverage
+## Operating notes
 
-Config loads **once at startup**: `load_acl` (TOML) and `parse_claim_grants`
-(inline JSON) both **fail fast** with `ConfigurationError` on a *structural*
-error (unreadable/malformed input, wrong shape, a `*` key), aborting startup
-rather than running broken. A *scope-name* typo is not structural —
-`"rite"` for `"write"` loads cleanly and then silently never matches, so the
-affected calls are denied; double-check spelling against the table below.
-
-A few mode facts worth knowing:
-
-- **Bearer** tokens carry no OIDC claims, so only the **subject-ACL** check
-  gates them per-caller.
-- Authorization is **meaningful only under an `AuthProvider`.** `stdio`
-  bypasses checks entirely; on HTTP `AuthMiddleware` still runs without a
-  provider, but every request then carries no token — so a component with
-  `required_scope` is **denied**. Install these checks alongside real
-  authentication.
-- Deny handling is delegated to FastMCP's `AuthMiddleware` (it raises an
-  authorization error on an unauthorized call and filters `list_*`
-  responses); pvl-core no longer ships its own deny envelope.
+- **Loaded once at startup.** Restart the server to pick up edits to the
+  ACL file or the grants map.
+- **Fails fast on a structural error.** An unreadable or malformed file,
+  the wrong shape, or a `*` subject key aborts startup rather than
+  running half-configured. A scope-*name* typo is **not** structural —
+  `"rite"` for `"write"` is valid and loads cleanly, then silently never
+  matches, so those calls are denied. Double-check scope spelling
+  against the table below.
+- **Meaningful only with authentication.** Over stdio, authorization is
+  bypassed entirely. On HTTP with no authentication configured there is
+  no caller to scope, so every gated component is denied. Run
+  authorization only alongside real authentication.
+- A denied call is rejected, and gated components a caller can't use are
+  hidden from `tools` / `resources` / `prompts` listings.
 
 ## Gated tools
 
@@ -113,8 +105,8 @@ A few mode facts worth knowing:
 
 ## See also
 
-- [fastmcp-pvl-core README](https://github.com/pvliesdonk/fastmcp-pvl-core#readme) — the "Authorization" section covers the native `AuthCheck` factories, the claim-vs-scope distinction, and per-mode coverage in full.
-- [Authz native-rebuild design](https://github.com/pvliesdonk/fastmcp-pvl-core/blob/main/docs/superpowers/specs/2026-06-19-authz-native-rebuild-design.md) — design rationale for the move to native checks.
+- [Authentication guide](authentication.md) — how callers obtain the
+  subject and claims this guide gates on.
 
 <!-- DOMAIN-AUTHZ-EXTRA-START -->
 <!-- Project-specific authorization notes go here; kept across copier

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -16,7 +16,7 @@ classifiers = [
     "License :: Other/Proprietary License",  # starter: TODO update when you pick a license (see LICENSE)
 ]
 dependencies = [
-    "fastmcp-pvl-core>=3.2.0,<4",
+    "fastmcp-pvl-core>=4.0.0,<5",
     "typer>=0.12",
 {% if include_mcp_apps_scaffold %}
     # fastmcp>=3.2.4 required for fastmcp.apps and fastmcp.server.providers.addressing.

--- a/src/{{python_module}}/config.py.jinja
+++ b/src/{{python_module}}/config.py.jinja
@@ -32,10 +32,15 @@ class ProjectConfig:
     # vault_path: Path = Path("/data/vault")
     {%- if enable_authorization %}
     #
-    # (example: enable optional authorization — see fastmcp-pvl-core's
-    #  README "Authorization" section for the full opt-in story.  Absence
-    #  of the path means no authorization middleware is installed.)
+    # (example: opt-in authorization — see fastmcp-pvl-core's README
+    #  "Authorization" section.  Subject->scope ACL gating (bearer + any
+    #  mode) uses ``acl_path``; OIDC claim->scope gating uses
+    #  ``authz_claim`` plus an optional inline-JSON ``authz_grants`` map.
+    #  A component is unrestricted unless it sets
+    #  ``meta={"required_scope": "<scope>"}``.)
     # acl_path: Path | None = None
+    # authz_claim: str | None = None
+    # authz_grants: str | None = None
     {%- endif %}
     # CONFIG-FIELDS-END
 
@@ -49,9 +54,12 @@ class ProjectConfig:
             # vault_path=Path(env(_ENV_PREFIX, "VAULT_PATH", "/data/vault")),
             {%- if enable_authorization %}
             #
-            # (example: load ``acl_path`` from ``{{ env_prefix }}_ACL_PATH``;
-            #  unset env var means no authorization middleware.)
+            # (example: load the authz config from ``{{ env_prefix }}_*``;
+            #  wire whichever the deployment uses in server.py — ACL for
+            #  bearer, claim for OIDC, or both via any_check.)
             # acl_path=Path(_p) if (_p := env(_ENV_PREFIX, "ACL_PATH")) else None,
+            # authz_claim=env(_ENV_PREFIX, "AUTHZ_CLAIM"),
+            # authz_grants=env(_ENV_PREFIX, "AUTHZ_GRANTS"),
             {%- endif %}
             # CONFIG-FROM-ENV-END
         )

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -89,21 +89,28 @@ def make_server(
 
     wire_middleware_stack(mcp)
 {% if enable_authorization %}
-    # Optional: enable opt-in per-subject authorization on tools / resources /
-    # prompts.  See fastmcp-pvl-core's README "Authorization" section for the
-    # design.  Tools, resources, and prompts opt in by setting
-    # ``meta={"required_scope": "<scope>"}``; absence of the key means
-    # unrestricted.  The middleware is only installed when ``acl_path`` is set.
+    # Optional: opt-in authorization on tools / resources / prompts via
+    # FastMCP's native ``AuthMiddleware``.  See fastmcp-pvl-core's README
+    # "Authorization" section.  Components opt in by setting
+    # ``meta={"required_scope": "<scope>"}``; without it they are
+    # unrestricted.  Pick the check(s) that match your auth mode:
     #
+    # from fastmcp.server.middleware import AuthMiddleware
     # from fastmcp_pvl_core import (
-    #     AuthorizationMiddleware,
-    #     load_acl,
-    #     make_acl_authorizer,
+    #     any_check, load_acl, make_acl_check, make_claims_check, parse_claim_grants,
     # )
     #
+    # # bearer (subject -> scope ACL — the only per-token authz for bearer):
     # if config.acl_path is not None:
-    #     authorizer = make_acl_authorizer(load_acl(config.acl_path))
-    #     mcp.add_middleware(AuthorizationMiddleware(authorizer=authorizer))
+    #     mcp.add_middleware(AuthMiddleware(auth=make_acl_check(load_acl(config.acl_path))))
+    #
+    # # OIDC (claim -> scope); identity map when IdP groups == scope names:
+    # if config.authz_claim is not None:
+    #     grants = parse_claim_grants(config.authz_grants) if config.authz_grants else None
+    #     mcp.add_middleware(AuthMiddleware(auth=make_claims_check(config.authz_claim, grants)))
+    #
+    # # multi (bearer break-glass + OIDC): OR the two —
+    # #   AuthMiddleware(auth=any_check(make_acl_check(...), make_claims_check(...)))
 {% endif %}
     register_tools(mcp)
     register_resources(mcp)

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -90,27 +90,31 @@ def make_server(
     wire_middleware_stack(mcp)
 {% if enable_authorization %}
     # Optional: opt-in authorization on tools / resources / prompts via
-    # FastMCP's native ``AuthMiddleware``.  See fastmcp-pvl-core's README
-    # "Authorization" section.  Components opt in by setting
+    # FastMCP's native ``AuthMiddleware``.  Components opt in by setting
     # ``meta={"required_scope": "<scope>"}``; without it they are
-    # unrestricted.  Pick the check(s) that match your auth mode:
+    # unrestricted.  See fastmcp-pvl-core's README "Authorization" section.
+    #
+    # Install exactly ONE ``AuthMiddleware``.  Build ONE check below — for
+    # bearer + OIDC together, OR them with ``any_check`` (a single
+    # middleware); do NOT add two.
     #
     # from fastmcp.server.middleware import AuthMiddleware
     # from fastmcp_pvl_core import (
     #     any_check, load_acl, make_acl_check, make_claims_check, parse_claim_grants,
     # )
     #
-    # # bearer (subject -> scope ACL — the only per-token authz for bearer):
-    # if config.acl_path is not None:
-    #     mcp.add_middleware(AuthMiddleware(auth=make_acl_check(load_acl(config.acl_path))))
-    #
-    # # OIDC (claim -> scope); identity map when IdP groups == scope names:
-    # if config.authz_claim is not None:
-    #     grants = parse_claim_grants(config.authz_grants) if config.authz_grants else None
-    #     mcp.add_middleware(AuthMiddleware(auth=make_claims_check(config.authz_claim, grants)))
-    #
-    # # multi (bearer break-glass + OIDC): OR the two —
-    # #   AuthMiddleware(auth=any_check(make_acl_check(...), make_claims_check(...)))
+    # grants = parse_claim_grants(config.authz_grants) if config.authz_grants else None
+    # # Choose one and assign it to ``check``:
+    # #   bearer (subject -> scope ACL; the only per-token authz for bearer):
+    # #     check = make_acl_check(load_acl(config.acl_path))
+    # #   OIDC (claim -> scope; identity map when IdP groups == scope names):
+    # #     check = make_claims_check(config.authz_claim, grants)
+    # #   both (bearer break-glass + OIDC, evaluated as OR):
+    # #     check = any_check(
+    # #         make_acl_check(load_acl(config.acl_path)),
+    # #         make_claims_check(config.authz_claim, grants),
+    # #     )
+    # mcp.add_middleware(AuthMiddleware(auth=check))
 {% endif %}
     register_tools(mcp)
     register_resources(mcp)


### PR DESCRIPTION
Closes #180.

## What & why

`fastmcp-pvl-core` **v4.0.0** (released) replaced the bespoke `AuthorizationMiddleware` / `Authorizer` / ACL with FastMCP-native `AuthCheck` factories — removing `AuthorizationMiddleware`, `make_acl_authorizer`, `check_authorization`, `AuthzDenied`, `expose_subject_in_error`, and `docs/specs/authorization-submodule.md`. This template's `enable_authorization` scaffold wired all of those and pinned pvl-core `<4`, so it must migrate before adopting v4.

## Changes (all gated by `enable_authorization`)

- **`pyproject.toml.jinja`** — pin `fastmcp-pvl-core>=4.0.0,<5` (**breaking** for the rendered project's dependency).
- **`server.py.jinja`** — native `AuthMiddleware(auth=…)` wiring with `make_acl_check` (bearer/any), `make_claims_check` (OIDC), and `any_check` (multi), replacing the removed `AuthorizationMiddleware(authorizer=make_acl_authorizer(load_acl(…)))`.
- **`config.py.jinja`** — `authz_claim` / `authz_grants` stubs alongside `acl_path`.
- **`.env.example.jinja`** — `*_AUTHZ_CLAIM` / `*_AUTHZ_GRANTS` alongside `*_ACL_PATH`.
- **`docs/guides/authorization.md.jinja`** — rewritten for the native model: the **scope-vs-claim** distinction, the **identity convention** (IdP groups == scope names ⇒ no map), the inline-JSON `grants` table, and **per-mode coverage** (subject-ACL is the only per-token authz for bearer; claims are OIDC-only; `any_check` for multi; "meaningful only under an `AuthProvider`"). Removed `check_authorization`, `expose_subject_in_error`, the `"local"`-subject ACL row, and the pvl-core deny-logging claim. **Fixed the two dead links** (deleted submodule spec → the native design doc; the `#authorization-opt-in--authorizationmiddleware` README anchor → the README).
- **`README.md.jinja`** — claim *or* ACL gating.

## Validation

`copier copy --vcs-ref HEAD` rendered with `enable_authorization` **true** and **false**:
- **true**: guide present + in nav, all `{{ env_prefix }}` / `{{ python_module }}` substituted (`SMOKE_MCP_AUTHZ_CLAIM`, `smoke_mcp`), native wiring rendered, **zero** old symbols or unrendered `{{ }}`.
- **false**: `authorization.md` absent, no README authz block, no `*_AUTHZ_*` env lines.
- `fastmcp-pvl-core==4.0.0` confirmed to export `make_acl_check` / `make_claims_check` / `any_check` / `parse_claim_grants` / `load_acl`.
- `rg` over the template (excluding CHANGELOG/superpowers history) finds no surviving removed-symbol reference.

CHANGELOG left for the maintainer's release flow (entries here are collected per-release with assigned PR numbers).

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._