### PR TITLE
feat(scaffold): document and enable clean detach from the template (closes #182)

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -222,6 +222,7 @@ jobs:
                 .github/workflows/claude.yml \
                 .github/workflows/claude-code-review.yml
           rm -rf .gemini
+          rm -rf scripts/copier_update_aggregator.py scripts/copier_update_prompts
           # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
           sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
           # --- Step 4 (closing): remove the now-obsolete detach guide ---
@@ -246,17 +247,26 @@ jobs:
             && { echo "::error::Contributing fixes upstream section survived the scrub"; exit 1; } || true
           grep -qF 'claude-review, gemini-code-assist' CLAUDE.md \
             && { echo "::error::bot-reviewer paragraph survived the scrub"; exit 1; } || true
-          # neutral guidance must remain:
-          grep -qE '^## Conventions$' CLAUDE.md \
-            || { echo "::error::Conventions section lost — scrub deleted too much"; exit 1; }
-          grep -qE '^## GitHub Review Types$' CLAUDE.md \
-            || { echo "::error::GitHub Review Types section lost — scrub deleted too much"; exit 1; }
+          # neutral guidance must remain — these are the sections FORKING.md
+          # promises survive; assert each so a balanced-but-misplaced marker
+          # pair that swallows an adjacent section is caught:
+          for kept_section in \
+              '^## Conventions$' \
+              '^## Hard PR Acceptance Gates$' \
+              '^## Logging Standard$' \
+              '^## Config & Customization Contract$' \
+              '^## GitHub Review Types$'; do
+            grep -qE "$kept_section" CLAUDE.md \
+              || { echo "::error::neutral section '$kept_section' lost — scrub deleted too much"; exit 1; }
+          done
           # stripped files gone:
           for gone in \
               .github/workflows/copier-update.yml \
               .github/workflows/claude.yml \
               .github/workflows/claude-code-review.yml \
-              .gemini; do
+              .gemini \
+              scripts/copier_update_aggregator.py \
+              scripts/copier_update_prompts; do
             [ ! -e "$gone" ] \
               || { echo "::error::$gone not removed by detach"; exit 1; }
           done

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -225,7 +225,8 @@ jobs:
           rm -f scripts/copier_update_aggregator.py
           rm -rf scripts/copier_update_prompts
           # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
-          sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+          # -i.bak + rm mirrors FORKING.md's portable form (GNU + BSD sed).
+          sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
           # --- Closing ("You are now standalone"): remove the detach guide.
           #     FORKING.md's numbered Step 4 (README cleanup) is intentionally
           #     NOT mirrored here — it mutates README prose this smoke does not

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -208,6 +208,62 @@ jobs:
           [ "$CI_NORM" = "$PC_NORM" ] \
             || { echo "::error::vale exclusion scope drift — ci.yml=$CI_EXCL pre-commit=$PC_EXCL"; exit 1; }
 
+      - name: detach smoke (FORKING.md commands produce a clean standalone state)
+        working-directory: /tmp/smoke
+        run: |
+          # Mirrors the documented detach in the rendered FORKING.md. Runs LAST
+          # because it mutates the tree in place; idempotence + gate already ran
+          # on the pristine render. Asserts issue #182's Verification block.
+
+          # --- Step 1: stop tracking ---
+          rm -f .copier-answers.yml
+          # --- Step 2: prune template-origin CI + fleet review wiring ---
+          rm -f .github/workflows/copier-update.yml \
+                .github/workflows/claude.yml \
+                .github/workflows/claude-code-review.yml
+          rm -rf .gemini
+          # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
+          sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+
+          # --- assert the detached state ---
+          [ ! -f .copier-answers.yml ] \
+            || { echo "::error::.copier-answers.yml still present after detach"; exit 1; }
+          ! grep -rn "copier" .github/ \
+            || { echo "::error::copier reference remains under .github/ after detach"; exit 1; }
+          ! grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md \
+            || { echo "::error::fleet/downstream tracking language remains in CLAUDE.md"; exit 1; }
+          grep -qE '^## Shared Infrastructure$' CLAUDE.md \
+            && { echo "::error::Shared Infrastructure section survived the scrub"; exit 1; } || true
+          grep -qE '^## Contributing fixes upstream$' CLAUDE.md \
+            && { echo "::error::Contributing fixes upstream section survived the scrub"; exit 1; } || true
+          grep -qF 'claude-review, gemini-code-assist' CLAUDE.md \
+            && { echo "::error::bot-reviewer paragraph survived the scrub"; exit 1; } || true
+          # neutral guidance must remain:
+          grep -qE '^## Conventions$' CLAUDE.md \
+            || { echo "::error::Conventions section lost — scrub deleted too much"; exit 1; }
+          grep -qE '^## GitHub Review Types$' CLAUDE.md \
+            || { echo "::error::GitHub Review Types section lost — scrub deleted too much"; exit 1; }
+          # stripped files gone:
+          for gone in \
+              .github/workflows/copier-update.yml \
+              .github/workflows/claude.yml \
+              .github/workflows/claude-code-review.yml \
+              .gemini; do
+            [ ! -e "$gone" ] \
+              || { echo "::error::$gone not removed by detach"; exit 1; }
+          done
+          # kept files present:
+          for kept in \
+              .github/workflows/ci.yml \
+              .github/workflows/codeql.yml \
+              .github/workflows/coverage-status.yml \
+              .github/workflows/docs.yml \
+              .github/workflows/release.yml; do
+            [ -f "$kept" ] \
+              || { echo "::error::$kept was removed but should be kept"; exit 1; }
+          done
+          echo "detach smoke passed"
+
   # Runs the two downstream workflow shapes that generated projects invoke
   # on their own CI — `mkdocs build --strict` (docs.yml) and `nfpm package`
   # (release.yml).  Dedicated non-matrix job so the downstream-gate is

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -224,14 +224,22 @@ jobs:
           rm -rf .gemini
           # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
           sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+          # --- Step 4 (closing): remove the now-obsolete detach guide ---
+          rm -f FORKING.md
 
           # --- assert the detached state ---
           [ ! -f .copier-answers.yml ] \
             || { echo "::error::.copier-answers.yml still present after detach"; exit 1; }
+          [ ! -f FORKING.md ] \
+            || { echo "::error::FORKING.md not removed by detach"; exit 1; }
           ! grep -rn "copier" .github/ \
             || { echo "::error::copier reference remains under .github/ after detach"; exit 1; }
-          ! grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md \
-            || { echo "::error::fleet/downstream tracking language remains in CLAUDE.md"; exit 1; }
+          # The first three tokens are issue #182's literal Verification block;
+          # the last two ("lives upstream", "propagate here via copier update")
+          # are actual prose inside the scrubbed TEMPLATE-TRACKING range, so this
+          # grep bites on a regressed scrub rather than passing vacuously.
+          ! grep -rniE "fleet|downstream conforms|shape lives in pvl-core|lives upstream|propagate here via .?copier update" CLAUDE.md \
+            || { echo "::error::template-tracking language remains in CLAUDE.md after scrub"; exit 1; }
           grep -qE '^## Shared Infrastructure$' CLAUDE.md \
             && { echo "::error::Shared Infrastructure section survived the scrub"; exit 1; } || true
           grep -qE '^## Contributing fixes upstream$' CLAUDE.md \

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -225,7 +225,10 @@ jobs:
           rm -rf scripts/copier_update_aggregator.py scripts/copier_update_prompts
           # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
           sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
-          # --- Step 4 (closing): remove the now-obsolete detach guide ---
+          # --- Closing ("You are now standalone"): remove the detach guide.
+          #     FORKING.md's numbered Step 4 (README cleanup) is intentionally
+          #     NOT mirrored here — it mutates README prose this smoke does not
+          #     assert (a documented spec non-goal).
           rm -f FORKING.md
 
           # --- assert the detached state ---
@@ -247,11 +250,16 @@ jobs:
             && { echo "::error::Contributing fixes upstream section survived the scrub"; exit 1; } || true
           grep -qF 'claude-review, gemini-code-assist' CLAUDE.md \
             && { echo "::error::bot-reviewer paragraph survived the scrub"; exit 1; } || true
-          # neutral guidance must remain. Includes the five sections FORKING.md
-          # promises survive, plus the two sections physically adjacent to the
-          # marker starts (## PR Discipline above pair 1, ## Server Info Tool
-          # above pair 2) — those are exactly what a balanced-but-misplaced
-          # marker pair would swallow first, so they must be asserted too.
+          # Neutral guidance must remain. The scrub is a sed range-delete, so the
+          # only "deleted too much" failure mode (given the pristine-render
+          # marker-count guard already holds 2 balanced pairs) is a misplaced
+          # marker that swallows a section adjacent to one of the FOUR marker
+          # boundaries. Every boundary is bracketed by a must-survive assertion:
+          #   pair 1 START → ## PR Discipline (above)
+          #   pair 1 END   → ## GitHub Review Types (below)
+          #   pair 2 START → ## Server Info Tool (above)
+          #   pair 2 END   → TEMPLATE-OWNED END fence + ## Key Design Decisions (below)
+          # The remaining entries are the other sections FORKING.md promises survive.
           for kept_section in \
               '^## Conventions$' \
               '^## Hard PR Acceptance Gates$' \
@@ -259,10 +267,16 @@ jobs:
               '^## Logging Standard$' \
               '^## Config & Customization Contract$' \
               '^## Server Info Tool' \
-              '^## GitHub Review Types$'; do
+              '^## GitHub Review Types$' \
+              '^## Key Design Decisions$'; do
             grep -qE "$kept_section" CLAUDE.md \
               || { echo "::error::neutral section '$kept_section' lost — scrub deleted too much"; exit 1; }
           done
+          # Structural bottom boundary: pair 2 END is the last TEMPLATE-TRACKING
+          # marker, so a misplaced END would run the range delete to EOF past
+          # this fence. Assert it survives.
+          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->$' CLAUDE.md \
+            || { echo "::error::TEMPLATE-OWNED END fence lost — scrub over-ran past pair 2"; exit 1; }
           # stripped files gone:
           for gone in \
               .github/workflows/copier-update.yml \

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -222,7 +222,8 @@ jobs:
                 .github/workflows/claude.yml \
                 .github/workflows/claude-code-review.yml
           rm -rf .gemini
-          rm -rf scripts/copier_update_aggregator.py scripts/copier_update_prompts
+          rm -f scripts/copier_update_aggregator.py
+          rm -rf scripts/copier_update_prompts
           # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
           sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
           # --- Closing ("You are now standalone"): remove the detach guide.

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -81,6 +81,15 @@ jobs:
           [ "$end" = "3" ] || { echo "::error::expected 3 DOMAIN-END fences, found $end"; exit 1; }
           grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS BELOW' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED opening fence"; exit 1; }
           grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->$' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED closing fence"; exit 1; }
+          # TEMPLATE-TRACKING marker pairs (2): one around the bot-reviewer
+          # paragraph, one around Shared Infrastructure + Contributing fixes
+          # upstream. FORKING.md's detach scrub deletes them as a sed range — a
+          # dropped marker would make the scrub delete the wrong span, so the
+          # count must stay exact.
+          ttstart=$(grep -cE '^<!-- TEMPLATE-TRACKING-START -->$' CLAUDE.md || true)
+          ttend=$(grep -cE '^<!-- TEMPLATE-TRACKING-END -->$' CLAUDE.md || true)
+          [ "$ttstart" = "2" ] || { echo "::error::expected 2 TEMPLATE-TRACKING-START markers, found $ttstart"; exit 1; }
+          [ "$ttend" = "2" ] || { echo "::error::expected 2 TEMPLATE-TRACKING-END markers, found $ttend"; exit 1; }
 
       - name: shared docs render with consumer env_prefix
         working-directory: /tmp/smoke

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -247,14 +247,18 @@ jobs:
             && { echo "::error::Contributing fixes upstream section survived the scrub"; exit 1; } || true
           grep -qF 'claude-review, gemini-code-assist' CLAUDE.md \
             && { echo "::error::bot-reviewer paragraph survived the scrub"; exit 1; } || true
-          # neutral guidance must remain — these are the sections FORKING.md
-          # promises survive; assert each so a balanced-but-misplaced marker
-          # pair that swallows an adjacent section is caught:
+          # neutral guidance must remain. Includes the five sections FORKING.md
+          # promises survive, plus the two sections physically adjacent to the
+          # marker starts (## PR Discipline above pair 1, ## Server Info Tool
+          # above pair 2) — those are exactly what a balanced-but-misplaced
+          # marker pair would swallow first, so they must be asserted too.
           for kept_section in \
               '^## Conventions$' \
               '^## Hard PR Acceptance Gates$' \
+              '^## PR Discipline$' \
               '^## Logging Standard$' \
               '^## Config & Customization Contract$' \
+              '^## Server Info Tool' \
               '^## GitHub Review Types$'; do
             grep -qE "$kept_section" CLAUDE.md \
               || { echo "::error::neutral section '$kept_section' lost — scrub deleted too much"; exit 1; }

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -52,7 +52,9 @@ The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, ya
 
 Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
+<!-- TEMPLATE-TRACKING-START -->
 **Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+<!-- TEMPLATE-TRACKING-END -->
 
 ## GitHub Review Types
 
@@ -148,6 +150,7 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/{{ python_module }}/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+<!-- TEMPLATE-TRACKING-START -->
 ## Shared Infrastructure
 
 Shared infrastructure (auth providers, middleware stack, logging bootstrap, event store factory, CLI scaffolding, release pipeline, Docker entrypoint, nfpm packaging, mcpb bundle) lives upstream in two places:
@@ -164,6 +167,7 @@ Fixes and improvements to shared code land in those repos and propagate here via
 - **Domain-only fix** (anything inside a `DOMAIN-*`, `CONFIG-*`, or `PROJECT-*` sentinel block, `tools.py`, `resources.py`, `prompts.py`, `domain.py`, `tests/`): PR on this repo directly.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+<!-- TEMPLATE-TRACKING-END -->
 
 <!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
 

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -69,9 +69,10 @@ These leftover references are harmless but now misleading:
 
 ## You are now standalone
 
-Commit the result:
+Remove this guide (it no longer applies once detached) and commit the result:
 
 ```bash
+rm FORKING.md
 git add -A
 git commit -m "chore: detach from fastmcp-server-template"
 ```

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -50,7 +50,9 @@ the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
 ## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
 
 ```bash
-sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+# -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
+# which disagree on the in-place flag's syntax.
+sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
 ```
 
 This deletes the template-coupled sections — the bot-reviewer merge-gate

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -17,7 +17,7 @@ Detaching is mechanical. Run the steps below once, then commit.
 ## Step 1 — Stop tracking the template
 
 ```bash
-rm .copier-answers.yml
+rm -f .copier-answers.yml
 ```
 
 This removes the link copier uses to reattach. The weekly cron that ran
@@ -30,7 +30,8 @@ rm -f .github/workflows/copier-update.yml \
       .github/workflows/claude.yml \
       .github/workflows/claude-code-review.yml
 rm -rf .gemini
-rm -rf scripts/copier_update_aggregator.py scripts/copier_update_prompts
+rm -f scripts/copier_update_aggregator.py
+rm -rf scripts/copier_update_prompts
 ```
 
 What this removes and why:
@@ -76,7 +77,7 @@ These leftover references are harmless but now misleading:
 Remove this guide (it no longer applies once detached) and commit the result:
 
 ```bash
-rm FORKING.md
+rm -f FORKING.md
 git add -A
 git commit -m "chore: detach from fastmcp-server-template"
 ```

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -30,6 +30,7 @@ rm -f .github/workflows/copier-update.yml \
       .github/workflows/claude.yml \
       .github/workflows/claude-code-review.yml
 rm -rf .gemini
+rm -rf scripts/copier_update_aggregator.py scripts/copier_update_prompts
 ```
 
 What this removes and why:
@@ -37,6 +38,9 @@ What this removes and why:
 - `copier-update.yml` — template-update automation; meaningless once detached.
 - `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
 - `.gemini/` — gemini-code-assist fleet scope control.
+- `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` —
+  the orchestration that only `copier-update.yml` invoked; dead weight once
+  that workflow is gone.
 
 **Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
 `coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -1,0 +1,80 @@
+# Forking: detaching from the template
+
+This project was generated from the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+copier template and, by default, **tracks** it: the weekly
+`copier-update` workflow opens PRs that pull in template and `fastmcp-pvl-core`
+improvements, and `CLAUDE.md` routes fixes back upstream.
+
+A **fork** is different. If you are taking sole ownership of this server, or
+want an opinionated variant that no longer follows the fleet, you should
+**detach**: stop tracking the template and remove the fleet-wide automation and
+guidance that no longer applies. A fork is not a downstream — after detaching,
+template and `fastmcp-pvl-core` changes are yours to port manually.
+
+Detaching is mechanical. Run the steps below once, then commit.
+
+## Step 1 — Stop tracking the template
+
+```bash
+rm .copier-answers.yml
+```
+
+This removes the link copier uses to reattach. The weekly cron that ran
+`copier update` is deleted in Step 2.
+
+## Step 2 — Prune template-origin CI and fleet review wiring
+
+```bash
+rm -f .github/workflows/copier-update.yml \
+      .github/workflows/claude.yml \
+      .github/workflows/claude-code-review.yml
+rm -rf .gemini
+```
+
+What this removes and why:
+
+- `copier-update.yml` — template-update automation; meaningless once detached.
+- `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `.gemini/` — gemini-code-assist fleet scope control.
+
+**Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
+`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
+the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+
+## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
+
+```bash
+sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+```
+
+This deletes the template-coupled sections — the bot-reviewer merge-gate
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
+while keeping the fork-neutral contributor guidance (Conventions, the PR
+acceptance gates, the Logging Standard, the config contract, GitHub Review
+Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
+there.
+
+## Step 4 — README cleanup (optional)
+
+These leftover references are harmless but now misleading:
+
+- The **Template** badge at the top of `README.md` (the
+  `![Template](https://img.shields.io/badge/dynamic/yaml?...&label=template)`
+  entry) points at the now-deleted `.copier-answers.yml`. Remove it.
+- In the secrets table, the `RELEASE_TOKEN` row lists `copier-update.yml` as a
+  consumer. Drop that workflow from the row.
+- The `### \`uv.lock\` refresh after \`copier update\`` subsection no longer
+  applies. Remove it.
+
+## You are now standalone
+
+Commit the result:
+
+```bash
+git add -A
+git commit -m "chore: detach from fastmcp-server-template"
+```
+
+Future template or `fastmcp-pvl-core` fixes are no longer delivered
+automatically — pull in anything you want by hand.

--- a/docs/superpowers/plans/2026-06-20-template-detach-fork.md
+++ b/docs/superpowers/plans/2026-06-20-template-detach-fork.md
@@ -1,0 +1,472 @@
+# Template Detach / Fork Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a documented, mechanical, CI-verified way for a generated project to detach from this copier template and become an independent fork.
+
+**Architecture:** Three changes to the template's *rendered output* and *self-test*: (1) wrap the template-coupled prose in `CLAUDE.md.jinja` in `TEMPLATE-TRACKING` markers so the scrub is one `sed`; (2) add a rendered root-level `FORKING.md.jinja` documenting the detach; (3) add two `template-ci.yml` assertion steps — a marker-balance guard and an end-to-end detach-smoke step that runs the documented commands and verifies the resulting standalone state.
+
+**Tech Stack:** copier (Jinja2 templates), GitHub Actions (inline bash assertions), Markdown.
+
+## Global Constraints
+
+- **copier reads from the git index, not the working tree.** Every local render in this plan uses `--vcs-ref=HEAD` and therefore requires the relevant edits to be **committed first**. Uncommitted changes are silently ignored. (Source: this repo's `CLAUDE.md`, "Making changes".)
+- **Local render command** (used verbatim throughout):
+  ```bash
+  rm -rf /tmp/smoke
+  uv run --no-project --with copier copier copy --trust --defaults \
+    --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+  ```
+- **Branch:** all commits land on `feat/template-detach-fork` (already created; the design spec is its first commit).
+- **Commit trailer:** every commit message ends with
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **CI assertion idiom** (match the existing steps in `template-ci.yml`): use `count=$(grep -cE '<pat>' FILE || true)` then `[ "$count" = "N" ] || { echo "::error::..."; exit 1; }`. The `|| true` keeps `bash -e` from aborting at the command substitution when grep matches zero lines.
+- **Spec:** `docs/superpowers/specs/2026-06-20-template-detach-fork-design.md`. Issue: #182.
+- **Strip set** (a detached fork removes these): `.github/workflows/copier-update.yml`, `.github/workflows/claude.yml`, `.github/workflows/claude-code-review.yml`, `.gemini/`. **Keep set:** `ci.yml`, `codeql.yml`, `coverage-status.yml`, `docs.yml`, `release.yml`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `CLAUDE.md.jinja` | Modify | Add two `TEMPLATE-TRACKING` marker pairs around the bot-reviewer paragraph and the Shared-Infrastructure / Contributing-fixes-upstream sections. |
+| `.github/workflows/template-ci.yml` | Modify | Add marker-balance assertions (Task 1) and a detach-smoke step (Task 3). |
+| `FORKING.md.jinja` | Create | Rendered root-level detach guide for generated projects. |
+
+No `copier.yml` change is needed: `FORKING.md.jinja` is an ordinary template file (suffix `.jinja`), so copier renders it automatically and re-renders it on `copier update`. It is intentionally **not** in `_skip_if_exists` (the guide should track template improvements until the fork detaches and deletes it).
+
+---
+
+## Task 1: `TEMPLATE-TRACKING` markers + CI marker-balance guard
+
+**Files:**
+- Modify: `CLAUDE.md.jinja` (bot-reviewer paragraph ~line 55; Shared-Infrastructure / Contributing-fixes-upstream sections ~lines 151–166)
+- Modify: `.github/workflows/template-ci.yml` (extend the `CLAUDE.md sentinel structure` step, ~lines 69–83)
+
+**Interfaces:**
+- Produces: two `<!-- TEMPLATE-TRACKING-START -->` / `<!-- TEMPLATE-TRACKING-END -->` marker pairs in the rendered `CLAUDE.md`, deletable as a `sed` range. Task 2 (FORKING.md) and Task 3 (detach-smoke) both rely on these markers existing and being balanced (exactly 2 of each).
+
+- [ ] **Step 1: Establish the red baseline — render current HEAD and confirm the markers are absent**
+
+Run:
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+grep -cE '^<!-- TEMPLATE-TRACKING-START -->$' /tmp/smoke/CLAUDE.md || true
+```
+Expected: prints `0` (markers do not exist yet — this is the failing state the guard will catch).
+
+- [ ] **Step 2: Add marker pair 1 around the bot-reviewer paragraph in `CLAUDE.md.jinja`**
+
+Replace this exact block:
+```markdown
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
+
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+
+## GitHub Review Types
+```
+with:
+```markdown
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
+
+<!-- TEMPLATE-TRACKING-START -->
+**Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair reviewers.** Local review must be complete before the PR opens. If a bot finds anything on first run, the local review was incomplete — that is a discipline failure to investigate, not "address-and-move-on." Run a local code-review pass on the cumulative diff before `gh pr create`; the bots are not a substitute.
+<!-- TEMPLATE-TRACKING-END -->
+
+## GitHub Review Types
+```
+
+- [ ] **Step 3: Add marker pair 2 opening before `## Shared Infrastructure` in `CLAUDE.md.jinja`**
+
+Replace this exact line:
+```markdown
+## Shared Infrastructure
+```
+with:
+```markdown
+<!-- TEMPLATE-TRACKING-START -->
+## Shared Infrastructure
+```
+
+- [ ] **Step 4: Add marker pair 2 closing before the `TEMPLATE-OWNED SECTIONS END` fence**
+
+Replace this exact block:
+```markdown
+If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+```
+with:
+```markdown
+If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
+<!-- TEMPLATE-TRACKING-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+```
+
+- [ ] **Step 5: Add the marker-balance guard to `template-ci.yml`**
+
+In `.github/workflows/template-ci.yml`, find the `CLAUDE.md sentinel structure` step and replace these two lines:
+```yaml
+          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS BELOW' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED opening fence"; exit 1; }
+          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->$' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED closing fence"; exit 1; }
+```
+with:
+```yaml
+          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS BELOW' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED opening fence"; exit 1; }
+          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->$' CLAUDE.md || { echo "::error::missing TEMPLATE-OWNED closing fence"; exit 1; }
+          # TEMPLATE-TRACKING marker pairs (2): one around the bot-reviewer
+          # paragraph, one around Shared Infrastructure + Contributing fixes
+          # upstream. FORKING.md's detach scrub deletes them as a sed range — a
+          # dropped marker would make the scrub delete the wrong span, so the
+          # count must stay exact.
+          ttstart=$(grep -cE '^<!-- TEMPLATE-TRACKING-START -->$' CLAUDE.md || true)
+          ttend=$(grep -cE '^<!-- TEMPLATE-TRACKING-END -->$' CLAUDE.md || true)
+          [ "$ttstart" = "2" ] || { echo "::error::expected 2 TEMPLATE-TRACKING-START markers, found $ttstart"; exit 1; }
+          [ "$ttend" = "2" ] || { echo "::error::expected 2 TEMPLATE-TRACKING-END markers, found $ttend"; exit 1; }
+```
+
+- [ ] **Step 6: Commit (required before re-rendering — copier reads the index)**
+
+```bash
+git add CLAUDE.md.jinja .github/workflows/template-ci.yml
+git commit -m "feat(scaffold): mark template-tracking CLAUDE.md sections for detach (refs #182)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 7: Render and verify the markers are present, balanced, and scrub cleanly (green)**
+
+Run:
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+echo "START=$(grep -cE '^<!-- TEMPLATE-TRACKING-START -->$' /tmp/smoke/CLAUDE.md) END=$(grep -cE '^<!-- TEMPLATE-TRACKING-END -->$' /tmp/smoke/CLAUDE.md)"
+# Simulate the scrub on a copy and confirm the right content is gone / kept:
+cp /tmp/smoke/CLAUDE.md /tmp/claude-scrubbed.md
+sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' /tmp/claude-scrubbed.md
+grep -qE '^## Shared Infrastructure$' /tmp/claude-scrubbed.md && echo "BAD: Shared Infrastructure survived" || echo "OK: Shared Infrastructure removed"
+grep -qE 'claude-review, gemini-code-assist' /tmp/claude-scrubbed.md && echo "BAD: bot paragraph survived" || echo "OK: bot paragraph removed"
+grep -qE '^## GitHub Review Types$' /tmp/claude-scrubbed.md && echo "OK: GitHub Review Types kept" || echo "BAD: GitHub Review Types lost"
+grep -qE '^## Conventions$' /tmp/claude-scrubbed.md && echo "OK: Conventions kept" || echo "BAD: Conventions lost"
+```
+Expected output:
+```
+START=2 END=2
+OK: Shared Infrastructure removed
+OK: bot paragraph removed
+OK: GitHub Review Types kept
+OK: Conventions kept
+```
+If any line says `BAD`, the marker placement is wrong — fix the relevant edit, amend the commit (`git commit --amend --no-edit`), and re-run this step.
+
+---
+
+## Task 2: `FORKING.md.jinja` detach guide
+
+**Files:**
+- Create: `FORKING.md.jinja`
+
+**Interfaces:**
+- Consumes: the `TEMPLATE-TRACKING` markers from Task 1 (the Step 3 `sed` command targets them) and the Global-Constraints strip/keep sets.
+- Produces: a rendered root `FORKING.md` whose documented commands Task 3's detach-smoke step mirrors exactly.
+
+- [ ] **Step 1: Create `FORKING.md.jinja` with this exact content**
+
+```markdown
+# Forking: detaching from the template
+
+This project was generated from the
+[`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template)
+copier template and, by default, **tracks** it: the weekly
+`copier-update` workflow opens PRs that pull in template and `fastmcp-pvl-core`
+improvements, and `CLAUDE.md` routes fixes back upstream.
+
+A **fork** is different. If you are taking sole ownership of this server, or
+want an opinionated variant that no longer follows the fleet, you should
+**detach**: stop tracking the template and remove the fleet-wide automation and
+guidance that no longer applies. A fork is not a downstream — after detaching,
+template and `fastmcp-pvl-core` changes are yours to port manually.
+
+Detaching is mechanical. Run the steps below once, then commit.
+
+## Step 1 — Stop tracking the template
+
+```bash
+rm .copier-answers.yml
+```
+
+This removes the link copier uses to reattach. The weekly cron that ran
+`copier update` is deleted in Step 2.
+
+## Step 2 — Prune template-origin CI and fleet review wiring
+
+```bash
+rm -f .github/workflows/copier-update.yml \
+      .github/workflows/claude.yml \
+      .github/workflows/claude-code-review.yml
+rm -rf .gemini
+```
+
+What this removes and why:
+
+- `copier-update.yml` — template-update automation; meaningless once detached.
+- `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `.gemini/` — gemini-code-assist fleet scope control.
+
+**Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
+`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
+the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+
+## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
+
+```bash
+sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+```
+
+This deletes the template-coupled sections — the bot-reviewer merge-gate
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
+while keeping the fork-neutral contributor guidance (Conventions, the PR
+acceptance gates, the Logging Standard, the config contract, GitHub Review
+Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
+there.
+
+## Step 4 — README cleanup (optional)
+
+These leftover references are harmless but now misleading:
+
+- The **Template** badge at the top of `README.md` (the
+  `![Template](https://img.shields.io/badge/dynamic/yaml?...&label=template)`
+  entry) points at the now-deleted `.copier-answers.yml`. Remove it.
+- In the secrets table, the `RELEASE_TOKEN` row lists `copier-update.yml` as a
+  consumer. Drop that workflow from the row.
+- The `### \`uv.lock\` refresh after \`copier update\`` subsection no longer
+  applies. Remove it.
+
+## You are now standalone
+
+Commit the result:
+
+```bash
+git add -A
+git commit -m "chore: detach from fastmcp-server-template"
+```
+
+Future template or `fastmcp-pvl-core` fixes are no longer delivered
+automatically — pull in anything you want by hand.
+```
+
+- [ ] **Step 2: Commit (required before rendering)**
+
+```bash
+git add FORKING.md.jinja
+git commit -m "feat(scaffold): add FORKING.md detach guide (refs #182)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Render and verify `FORKING.md` is produced and Jinja-clean**
+
+Run:
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+test -f /tmp/smoke/FORKING.md && echo "OK: FORKING.md rendered"
+# No unrendered Jinja delimiters should remain:
+grep -nE '\{\{|\{%' /tmp/smoke/FORKING.md && echo "BAD: unrendered Jinja in FORKING.md" || echo "OK: no Jinja residue"
+# The four documented step headings are present:
+for h in "## Step 1 — Stop tracking the template" \
+         "## Step 2 — Prune template-origin CI and fleet review wiring" \
+         "## Step 3 — Scrub template-tracking guidance from \`CLAUDE.md\`" \
+         "## Step 4 — README cleanup (optional)"; do
+  grep -qF "$h" /tmp/smoke/FORKING.md || echo "BAD: missing heading: $h"
+done
+echo "heading check done"
+```
+Expected:
+```
+OK: FORKING.md rendered
+OK: no Jinja residue
+heading check done
+```
+(no `BAD:` lines)
+
+> Note: the ```` ```bash ```` fenced blocks inside `FORKING.md.jinja` are literal
+> Markdown — they contain no `{{ }}` or `{% %}`, so copier passes them through
+> untouched. If you later add a Jinja expression inside a fence, wrap that fence
+> in `{% raw %}`/`{% endraw %}`.
+
+---
+
+## Task 3: Detach-smoke step in `template-ci.yml`
+
+**Files:**
+- Modify: `.github/workflows/template-ci.yml` (append a new step at the end of the `render-and-gate` job)
+
+**Interfaces:**
+- Consumes: the `TEMPLATE-TRACKING` markers (Task 1) and the documented detach commands (Task 2). This step is the end-to-end test that ties both together.
+- Produces: a CI guarantee that the documented detach yields the state issue #182's Verification block requires.
+
+- [ ] **Step 1: Append the detach-smoke step to `template-ci.yml`**
+
+Add this as the **last** step of the `render-and-gate` job (after the final existing step). It mutates `/tmp/smoke` in place, which is safe because the idempotence check and the gate already ran on the pristine render:
+
+```yaml
+      - name: detach smoke (FORKING.md commands produce a clean standalone state)
+        working-directory: /tmp/smoke
+        run: |
+          # Mirrors the documented detach in the rendered FORKING.md. Runs LAST
+          # because it mutates the tree in place; idempotence + gate already ran
+          # on the pristine render. Asserts issue #182's Verification block.
+
+          # --- Step 1: stop tracking ---
+          rm -f .copier-answers.yml
+          # --- Step 2: prune template-origin CI + fleet review wiring ---
+          rm -f .github/workflows/copier-update.yml \
+                .github/workflows/claude.yml \
+                .github/workflows/claude-code-review.yml
+          rm -rf .gemini
+          # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
+          sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+
+          # --- assert the detached state ---
+          [ ! -f .copier-answers.yml ] \
+            || { echo "::error::.copier-answers.yml still present after detach"; exit 1; }
+          ! grep -rn "copier" .github/ \
+            || { echo "::error::copier reference remains under .github/ after detach"; exit 1; }
+          ! grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md \
+            || { echo "::error::fleet/downstream tracking language remains in CLAUDE.md"; exit 1; }
+          grep -qE '^## Shared Infrastructure$' CLAUDE.md \
+            && { echo "::error::Shared Infrastructure section survived the scrub"; exit 1; } || true
+          grep -qE '^## Contributing fixes upstream$' CLAUDE.md \
+            && { echo "::error::Contributing fixes upstream section survived the scrub"; exit 1; } || true
+          grep -qF 'claude-review, gemini-code-assist' CLAUDE.md \
+            && { echo "::error::bot-reviewer paragraph survived the scrub"; exit 1; } || true
+          # neutral guidance must remain:
+          grep -qE '^## Conventions$' CLAUDE.md \
+            || { echo "::error::Conventions section lost — scrub deleted too much"; exit 1; }
+          grep -qE '^## GitHub Review Types$' CLAUDE.md \
+            || { echo "::error::GitHub Review Types section lost — scrub deleted too much"; exit 1; }
+          # stripped files gone:
+          for gone in \
+              .github/workflows/copier-update.yml \
+              .github/workflows/claude.yml \
+              .github/workflows/claude-code-review.yml \
+              .gemini; do
+            [ ! -e "$gone" ] \
+              || { echo "::error::$gone not removed by detach"; exit 1; }
+          done
+          # kept files present:
+          for kept in \
+              .github/workflows/ci.yml \
+              .github/workflows/codeql.yml \
+              .github/workflows/coverage-status.yml \
+              .github/workflows/docs.yml \
+              .github/workflows/release.yml; do
+            [ -f "$kept" ] \
+              || { echo "::error::$kept was removed but should be kept"; exit 1; }
+          done
+          echo "detach smoke passed"
+```
+
+> Note on the `grep ... && { ...; exit 1; } || true` idiom: a "must be absent"
+> check cannot use `grep -q ... || { error }` (that errors when the pattern is
+> *absent*, which is the success case). Instead, fire the error only when grep
+> *matches*, and append `|| true` so a no-match (`grep` exit 1) does not trip
+> `bash -e`.
+
+- [ ] **Step 2: Verify the detach-smoke logic locally against a fresh render**
+
+Run (this reproduces exactly what the CI step does):
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+cd /tmp/smoke
+rm -f .copier-answers.yml
+rm -f .github/workflows/copier-update.yml .github/workflows/claude.yml .github/workflows/claude-code-review.yml
+rm -rf .gemini
+sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+echo "--- issue #182 verification ---"
+test ! -f .copier-answers.yml && echo "OK: copier answers removed"
+grep -rn "copier" .github/ && echo "BAD: copier ref under .github/" || echo "OK: no copier refs under .github/"
+grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md && echo "BAD: tracking language remains" || echo "OK: no tracking language"
+grep -qE '^## Conventions$' CLAUDE.md && echo "OK: Conventions kept" || echo "BAD: Conventions lost"
+cd -
+```
+Expected: every line is `OK:` (no `BAD:`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/template-ci.yml
+git commit -m "test(scaffold): CI smoke for clean template detach (refs #182)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Mark the spec implemented
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-20-template-detach-fork-design.md` (the `Status:` line)
+
+- [ ] **Step 1: Flip the spec status**
+
+Replace:
+```markdown
+- **Status:** Approved (design)
+```
+with:
+```markdown
+- **Status:** Implemented
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-20-template-detach-fork-design.md
+git commit -m "docs(spec): mark template-detach design implemented (refs #182)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] **Run the full local gate on a detached render once more** to confirm nothing in the strip/scrub broke the pristine gate (the gate runs on the pristine tree; the detach is the last CI step):
+  ```bash
+  rm -rf /tmp/smoke
+  uv run --no-project --with copier copier copy --trust --defaults \
+    --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+  cd /tmp/smoke
+  uv sync --all-extras --all-groups
+  uv run ruff check . && uv run ruff format --check .
+  uv run mypy src/ tests/ && uv run pytest -x -q
+  cd -
+  ```
+  Expected: gate passes (FORKING.md and the markers do not affect ruff/mypy/pytest).
+
+- [ ] **Open the PR** with `Closes #182` in the body (per the PR workflow, every PR closes an issue). The PR bundles all four commits on `feat/template-detach-fork`.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Deliverable 1 (detach guide) → Task 2 (`FORKING.md.jinja`).
+- Deliverable 2 (strip template-origin CI; document keep vs prune) → Task 2 Step 2 (guide) + Task 3 (CI asserts the prune; keep-set verified).
+- Deliverable 3 (scrub opinionated `CLAUDE.md`) → Task 1 (markers) + Task 2 Step 3 (documented `sed`) + Task 3 (CI asserts scrub result and that neutral sections survive). `.claude/CLAUDE.md` is not rendered by the template; the guide notes a fork that added one applies the same scrub.
+- Deliverable 4 (test/CI updates assert detached state) → Task 1 (marker-balance guard) + Task 3 (detach-smoke). No pre-existing smoke test asserts the old forking state, so nothing is rewritten/deleted — the new assertions are additive, matching the issue's "any … get updated" conditional.
+- Issue Verification block → reproduced verbatim in Task 3 Steps 1–2.
+
+**Placeholder scan:** none — every code/markdown block is complete and copy-pasteable.
+
+**Type/string consistency:** marker strings (`<!-- TEMPLATE-TRACKING-START -->` / `-END -->`), the scrub `sed` range, and the strip/keep file lists are identical across Tasks 1, 2, and 3.

--- a/docs/superpowers/specs/2026-06-20-template-detach-fork-design.md
+++ b/docs/superpowers/specs/2026-06-20-template-detach-fork-design.md
@@ -1,6 +1,6 @@
 # Clean detach from the copier template for independent forks
 
-- **Status:** Approved (design)
+- **Status:** Implemented
 - **Date:** 2026-06-20
 - **Issue:** [#182](https://github.com/pvliesdonk/fastmcp-server-template/issues/182)
 - **Related:** pvliesdonk/fastmcp-pvl-core#194 (the pvl-core half of the

--- a/docs/superpowers/specs/2026-06-20-template-detach-fork-design.md
+++ b/docs/superpowers/specs/2026-06-20-template-detach-fork-design.md
@@ -1,0 +1,222 @@
+# Clean detach from the copier template for independent forks
+
+- **Status:** Approved (design)
+- **Date:** 2026-06-20
+- **Issue:** [#182](https://github.com/pvliesdonk/fastmcp-server-template/issues/182)
+- **Related:** pvliesdonk/fastmcp-pvl-core#194 (the pvl-core half of the
+  foldability work — out of scope here)
+
+## Problem
+
+A fork that takes over a single server, or wants its own opinionated variant,
+must be able to **detach** from this copier template and from the fleet-wide
+guidance the template ships. A fork is not a downstream: it stops tracking the
+template entirely rather than receiving `copier update` PRs. Today the detach is
+undocumented and partly manual, and the rendered `CLAUDE.md` / CI actively
+assume the project still tracks the template (it tells you to `copier update`
+and to route fixes upstream to pvl-core / the template).
+
+The template cannot ship a *pre-detached* project — the rendered `CLAUDE.md` and
+CI are **correct for a tracked project**. So the work is to make the exit
+**mechanical and documented**, and to prove the documented exit actually
+produces a clean standalone state.
+
+## Goals
+
+1. Ship a rendered detach guide (`FORKING.md`) at the project root.
+2. Make the `CLAUDE.md` scrub a single mechanical `sed`, by wrapping the
+   genuinely template-coupled content in dedicated markers.
+3. Document which rendered CI workflows a standalone fork prunes vs keeps.
+4. Add template-CI smoke assertions that perform the documented detach and
+   verify the resulting state (the issue's Verification block).
+
+## Non-goals
+
+- Does **not** touch `fastmcp-pvl-core` (separate issue/PR).
+- Does **not** remove the template's ability to render new fleet members — this
+  documents the *fork's* exit, not a template teardown.
+- Does **not** ship a `scripts/detach.sh`. Per the design decision, the detach
+  is **documented copy-paste commands only**; `FORKING.md` is the source of
+  truth and template-CI mirrors the same commands inline.
+- Does **not** scrub `README.md` structurally. README cleanup is offered as a
+  documented optional step in the guide, not enforced by markers or CI.
+
+## Design decisions (resolved during brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Guide location | Top-level `FORKING.md` (rendered from `FORKING.md.jinja`), **not** in the mkdocs site nav. |
+| Review-bot wiring | A standalone fork strips **all** bot wiring: `claude.yml`, `claude-code-review.yml`, and `.gemini/config.yaml` — plus `copier-update.yml` (the unambiguous template-automation strip). |
+| Detach form | Documented commands only; no maintained script. |
+| Test placement | Inline shell steps in `template-ci.yml`, consistent with the existing `CLAUDE.md sentinel structure` / `Dockerfile sentinel structure` assertion steps — not a new `scripts/tests/*.py`. |
+
+## Workflow classification (rendered `.jinja` workflows)
+
+A standalone fork keeps its own CI/release and prunes template-origin
+automation and fleet review wiring:
+
+| Workflow / file | Fate | Why |
+|-----------------|------|-----|
+| `.github/workflows/ci.yml` | **Keep** | The fork's own CI gate. |
+| `.github/workflows/codeql.yml` | **Keep** | Generic security scanning. |
+| `.github/workflows/coverage-status.yml` | **Keep** | Generic coverage reporting. |
+| `.github/workflows/docs.yml` | **Keep** | The fork's own docs publishing. |
+| `.github/workflows/release.yml` | **Keep** | The fork's own release pipeline. |
+| `.github/workflows/copier-update.yml` | **Strip** | Template-update automation — meaningless once detached. |
+| `.github/workflows/claude.yml` | **Strip** | Fleet review-bot wiring. |
+| `.github/workflows/claude-code-review.yml` | **Strip** | Fleet review-bot wiring. |
+| `.gemini/config.yaml` | **Strip** | gemini-code-assist fleet scope control. |
+
+Note: `release.yml` still legitimately needs `RELEASE_TOKEN`; only the
+`copier-update` justification for that token disappears. The README cleanup step
+covers the now-stale `copier-update` references.
+
+## Components
+
+### 1. `FORKING.md.jinja` (new — repo root, template-owned)
+
+Renders to `FORKING.md` in every generated project. A normal `.jinja` file:
+re-rendered on `copier update` (so a still-tracked project always has the
+current guide), **not** in `_skip_if_exists`. The detach itself deletes the file
+as part of the exit (it is no longer relevant once standalone).
+
+Structure:
+
+1. **Fork vs downstream** — what detaching means and when to do it; a fork is
+   not a downstream (it stops receiving template updates entirely).
+2. **Step 1 — stop tracking:**
+   ```bash
+   rm .copier-answers.yml
+   ```
+   Stops `copier update` from ever reattaching. The weekly cron that runs it is
+   removed in Step 2.
+3. **Step 2 — prune template-origin CI:**
+   ```bash
+   rm -f .github/workflows/copier-update.yml \
+         .github/workflows/claude.yml \
+         .github/workflows/claude-code-review.yml
+   rm -rf .gemini
+   ```
+   Explicitly states which workflows are **kept** (`ci`, `codeql`,
+   `coverage-status`, `docs`, `release`).
+4. **Step 3 — scrub `CLAUDE.md`:**
+   ```bash
+   sed -i '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md
+   ```
+   Removes the bot-reviewer paragraph and the Shared-Infrastructure /
+   Contributing-fixes-upstream sections. Everything else stays as fork-useful
+   contributor guidance. Notes: a fork that has added its own
+   `.claude/CLAUDE.md` applies the same scrub there (the template does not
+   render `.claude/CLAUDE.md`, so a clean render has nothing to scrub there).
+5. **Step 4 — README cleanup (optional, documented):** remove the `Template`
+   badge, the `copier-update.yml` row in the `RELEASE_TOKEN` secrets table, and
+   the "uv.lock refresh after copier update" subsection.
+6. **Closing** — you are now standalone; future template/pvl-core fixes are
+   yours to port manually.
+
+The guide uses Jinja variables (`github_org`, `project_name`, …) only where it
+quotes paths that already vary; the commands above are static.
+
+### 2. `TEMPLATE-TRACKING` markers in `CLAUDE.md.jinja`
+
+Add two `<!-- TEMPLATE-TRACKING-START -->` / `<!-- TEMPLATE-TRACKING-END -->`
+marker pairs around exactly the content that is **wrong for a detached fork**.
+The markers are HTML comments (invisible in rendered Markdown) and live inside
+the existing `TEMPLATE-OWNED SECTIONS` block, so they are re-rendered on
+`copier update` and harmless to tracked projects.
+
+Wrapped range 1 — the bot-reviewer paragraph under `## PR Discipline`:
+
+> **Bot reviewers (claude-review, gemini-code-assist) are merge gates, not pair
+> reviewers.** …
+
+This paragraph becomes stale the moment the bot workflows are stripped, so it
+travels with the detach scrub. The surrounding "every PR needs an issue" and
+"GitHub Review Types" guidance is fork-neutral and stays **outside** the
+markers.
+
+Wrapped range 2 — the `## Shared Infrastructure` and
+`## Contributing fixes upstream` sections (contiguous, near the end of the
+template-owned block, before the `TEMPLATE-OWNED SECTIONS END` fence). These tell
+the reader to `copier update` and to route fixes to pvl-core / the template —
+both meaningless for a standalone fork.
+
+The single `sed` range-delete in Step 3 removes **all** `TEMPLATE-TRACKING`
+ranges in one pass.
+
+### 3. `template-ci.yml` assertions
+
+Two new steps, consistent with the existing inline-shell assertion pattern.
+
+**3a. Marker-balance step** (mirrors the existing `CLAUDE.md sentinel
+structure` step): assert the rendered `CLAUDE.md` has equal counts of
+`<!-- TEMPLATE-TRACKING-START -->` and `<!-- TEMPLATE-TRACKING-END -->`, and at
+least one of each. A dropped marker breaks copier's 3-way merge silently, so it
+must fail loudly. Uses the `grep -c … || true` idiom already established in the
+file (so a zero match surfaces as an `::error::` rather than aborting the step
+via `set -e`).
+
+**3b. Detach smoke step** (placed **last**, after the idempotence check and the
+gate, so mutating the render in place is safe — nothing downstream needs the
+pristine tree). Runs the exact commands `FORKING.md` documents, then asserts the
+issue's Verification block against the mutated tree:
+
+- `test ! -f .copier-answers.yml`
+- no `copier` references remain under `.github/`
+- `CLAUDE.md` contains none of `fleet`, `downstream conforms`,
+  `shape lives in pvl-core` (case-insensitive), **and** no
+  `## Shared Infrastructure` / `## Contributing fixes upstream` headings
+- the stripped workflows (`copier-update.yml`, `claude.yml`,
+  `claude-code-review.yml`) and `.gemini/` are gone
+- the kept workflows (`ci.yml`, `release.yml`) still exist
+
+## Test strategy (failure modes enumerated)
+
+Per the TDD discipline, the assertions exist to catch specific failure modes,
+not to decorate the happy path:
+
+- **Marker imbalance / drop.** A future edit deletes one
+  `TEMPLATE-TRACKING-START`/`END` line → the scrub `sed` deletes the wrong span
+  (or nothing). Caught by 3a.
+- **Marker rename / typo.** The guide's `sed` pattern and the markers drift out
+  of sync → 3b's "no Shared Infrastructure heading" assertion fails because the
+  scrub left the section in place.
+- **Workflow added to the template but not classified.** A new fleet workflow
+  ships without being added to the strip list → not auto-caught (documented
+  limitation; see Risks), but the kept/stripped assertions in 3b guard the named
+  ones against accidental relocation/removal.
+- **Detach corrupts kept CI.** The strip command's glob is too broad and removes
+  `ci.yml`/`release.yml` → caught by 3b's "kept workflows still exist".
+- **`.copier-answers.yml` path/name changes.** copier's `_answers_file` is
+  customised → 3b's `test ! -f .copier-answers.yml` would pass falsely; the
+  guide and CI both hard-code the default `.copier-answers.yml`, matching
+  `copier.yml`'s `_answers_file`. If that default ever changes, both must change
+  together (noted in the guide near the command).
+
+## Risks & mitigations
+
+- **Guide ↔ CI drift.** The detach commands live in two places (FORKING.md and
+  template-ci). Mitigation: 3b runs the *intent* of the commands and asserts the
+  end state, so a guide that documents a different command set will fail CI when
+  the end state diverges. Accepted consequence of "documented commands only, no
+  shared script."
+- **Root `FORKING.md` linting.** mkdocs reads `docs/` only, so a root-level
+  `FORKING.md` is not published and not built under `--strict`. Vale, if wired,
+  should likewise not target the repo root. **Verify during implementation**
+  that neither the local gate nor template-CI lints `FORKING.md`; if Vale does
+  pick it up, either exclude it or make the prose Vale-clean.
+- **New unclassified workflows.** Future template workflows are not
+  automatically added to the strip/keep lists. Mitigation: the workflow
+  classification table in this spec and in `FORKING.md` is the reference; a
+  reviewer adding a workflow updates both. Out of scope to auto-detect.
+
+## Verification (from the issue — run on a rendered + detached project)
+
+```bash
+test ! -f .copier-answers.yml && echo "copier answers removed"
+grep -rn "copier" .github/ ; echo "<-- expect no template-update workflow refs"
+grep -rniE "fleet|downstream conforms|shape lives in pvl-core" CLAUDE.md .claude/CLAUDE.md ; echo "<-- expect none"
+```
+
+(The `.claude/CLAUDE.md` path is absent in a clean render; the grep simply finds
+no file there, which satisfies "expect none".)


### PR DESCRIPTION
## Summary

Closes #182. Makes a generated project able to **cleanly detach** from this copier template and become an independent fork — the template-side half of pvl-core's foldability work. A fork is not a downstream: it stops tracking the template entirely. This makes the exit mechanical, documented, and CI-verified.

The template can't ship a *pre-detached* project (the rendered `CLAUDE.md`/CI are correct for a *tracked* project), so instead:

1. **`FORKING.md`** (new, rendered at repo root) — documents the detach: stop tracking (`rm .copier-answers.yml`), prune template-origin CI + fleet review wiring, scrub `CLAUDE.md`, optional README cleanup, then self-remove the guide.
2. **`TEMPLATE-TRACKING` markers** in `CLAUDE.md.jinja` — wrap the two template-coupled regions (the bot-reviewer merge-gate paragraph; `Shared Infrastructure` + `Contributing fixes upstream`) so the scrub is a single `sed` range-delete. Neutral contributor guidance stays.
3. **`template-ci.yml` detach-smoke** — performs the documented detach on the rendered project and asserts the standalone state (issue #182's Verification block), plus a marker-balance guard.

## What a fork strips vs keeps

| Strip | Keep |
|-------|------|
| `.copier-answers.yml`, `copier-update.yml` | `ci.yml`, `codeql.yml`, `coverage-status.yml`, `docs.yml`, `release.yml` |
| `claude.yml`, `claude-code-review.yml`, `.gemini/` | the `TEMPLATE-OWNED`/neutral sections of `CLAUDE.md` |
| `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` | |

## Verification

Rendered the template and ran the full documented detach end-to-end: `.copier-answers.yml` gone, no `copier` refs under `.github/`, tracking sections scrubbed while all neutral sections survive, orphaned scripts + guide removed, kept workflows intact. The detach-smoke CI step brackets all four `TEMPLATE-TRACKING` marker boundaries (a misplaced marker that swallowed an adjacent section, or over-ran to EOF, is caught) and the grep tokens bite on real scrubbed prose rather than passing vacuously. The full rendered-project gate (ruff/mypy/pytest) passes.

## Non-goals

- Does not touch `fastmcp-pvl-core` (separate issue).
- README structural cleanup stays **optional/documented**, not enforced (badge/secrets-row/uv.lock prose).
- The `CLAUDE.md` "overwritten on copier update" banner brackets kept neutral sections, so it can't be marker-wrapped — a candidate follow-up issue.

Design + plan: `docs/superpowers/specs/2026-06-20-template-detach-fork-design.md`, `docs/superpowers/plans/2026-06-20-template-detach-fork.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
