### PR TITLE
fix(config-wizard): skip smoke tests on a stale site/ instead of false-failing

### DIFF
--- a/tests/test_config_wizard_smoke.py.jinja
+++ b/tests/test_config_wizard_smoke.py.jinja
@@ -34,14 +34,47 @@ if typing.TYPE_CHECKING:
     from playwright.sync_api import Browser, Page
 
 SITE = Path(__file__).resolve().parent.parent / "site"
+_DOCS_WIZARD = (
+    Path(__file__).resolve().parent.parent / "docs" / "javascripts" / "config-wizard"
+)
+_SITE_WIZARD = SITE / "javascripts" / "config-wizard"
 
 pytestmark = pytest.mark.browser
+
+
+def _stale_wizard_assets() -> list[str]:
+    """Names of wizard assets whose built copy is missing or differs from source.
+
+    mkdocs copies the ``docs/javascripts/config-wizard`` files into ``site/``
+    verbatim, so a byte mismatch means ``site/`` is stale relative to the source
+    these tests actually exercise. Comparing bytes (not mtimes) is robust across
+    fresh checkouts, where mtimes carry no build ordering.
+    """
+    stale: list[str] = []
+    for src in sorted(_DOCS_WIZARD.glob("*")):
+        if not src.is_file():
+            continue
+        built = _SITE_WIZARD / src.name
+        if not built.is_file() or built.read_bytes() != src.read_bytes():
+            stale.append(src.name)
+    return stale
 
 
 @pytest.fixture(scope="module")
 def site_url() -> typing.Iterator[str]:
     if not (SITE / "configuration-generator" / "index.html").exists():
         pytest.skip("site/ not built -- run `uv run mkdocs build` first")
+    # A built-but-stale site/ (source edited under docs/ without rebuilding)
+    # would silently run these tests against outdated assets and false-fail.
+    # Skip with an actionable message instead. CI always builds fresh, so this
+    # only ever trips locally.
+    stale = _stale_wizard_assets()
+    if stale:
+        pytest.skip(
+            "site/ is stale relative to docs/ ("
+            + ", ".join(stale)
+            + ") -- rebuild with `uv run mkdocs build`"
+        )
     handler = functools.partial(
         http.server.SimpleHTTPRequestHandler, directory=str(SITE)
     )


### PR DESCRIPTION
Closes #185

## Problem

The config-wizard browser smoke tests serve the pre-built `site/` directory, and the `site_url` fixture checked only that `site/` *exists*, not that it is *fresh*. A developer who built `site/` once and then edited a wizard asset under `docs/javascripts/config-wizard/` without rebuilding would run the Playwright tests against outdated assets and get cryptic assertion failures. (Observed downstream in markdown-vault-mcp: four generator unit tests failed on a stale `site/`, all passed after `mkdocs build`.)

## Change

Add `_stale_wizard_assets()`: it byte-compares each file under `docs/javascripts/config-wizard/` against its copy in `site/javascripts/config-wizard/`. mkdocs copies these assets verbatim, so a content mismatch means `site/` is stale relative to the source the tests exercise. The `site_url` fixture now skips with an actionable message — `site/ is stale relative to docs/ (...) -- rebuild with mkdocs build` — instead of running against outdated assets.

Bytes, not mtimes: mtimes carry no build ordering across fresh checkouts.

CI always builds fresh before running these tests, so this only ever trips locally. The existing `site/ not built` skip and the fresh-run path are unchanged.

## Verification (in a rendered smoke project)

- `copier copy` renders with no leftover Jinja tags; rendered Python compiles; `ruff` / `ruff format --check` / `mypy` clean.
- No `site/` → tests skip "not built" (unchanged).
- Fresh `site/` + Chromium → **13 smoke tests pass** (guard does not block legitimate runs).
- Corrupt one built asset → `_stale_wizard_assets()` reports it and the fixture skips with the stale message.
- Deterministic (`sorted(glob(...))`, no time/random), so the template idempotence check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
