### PR TITLE
fix(docs): replace spaced em-dash in authentication guide to satisfy Vale

### DIFF
--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -82,7 +82,7 @@ Full OAuth 2.1 authentication using an external identity provider. Supports user
 
 ### How it works
 
-The server proxies OIDC itself — no external auth sidecar to deploy:
+The server proxies OIDC itself, with no external auth sidecar to deploy:
 
 ```
 Client → mcp-server → OIDC Provider


### PR DESCRIPTION
## Problem

`docs/guides/authentication.md.jinja` line 85 uses a spaced em-dash:

> The server proxies OIDC itself — no external auth sidecar to deploy:

The Vale styles this template ships (`Google.EmDash`, `ai-tells.EmDashUsage`) flag spaced em-dashes as **error-level**. So when a `copier update` brings this line into a downstream project's changed-docs set, the downstream `Docs Prose (Vale)` gate fails on prose the template authored. Observed in markdown-vault-mcp's v2.5.1 update (PR #724): 2 errors at `docs/guides/authentication.md:112`.

## Change

Replace the em-dash with a comma:

> The server proxies OIDC itself, with no external auth sidecar to deploy:

## Verification

Applied the same edit to a downstream rendered copy and ran the shipped Vale config: **0 errors, 0 warnings, 0 suggestions**. The line carries no Jinja tags, so rendering is unaffected.

## Note

Pure prose/linter-compliance fix (trivial-exception, no tracking issue per the no-orphan-PR rule's typo carve-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
