### PR TITLE
ci: bump pinned GitHub Actions (checkout v7, cache v5, setup-uv v8.2)

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -43,15 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -89,15 +89,15 @@ jobs:
           - python-version: "3.14"
             experimental: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
           # separate from the uv package cache and not covered by setup-uv's
@@ -211,15 +211,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -251,7 +251,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -272,7 +272,7 @@ jobs:
       # need to add `pull-requests: write` here too.
       checks: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache Vale style packages
         # Cache only the downloaded pack directories — NOT .vale/styles/config/.
@@ -283,7 +283,7 @@ jobs:
         # Pack list mirrors the Packages = line in .vale.ini; if you add or
         # remove a pack, update both. Bump the v1- prefix to evict all cached
         # packs if Vale changes pack format backward-incompatibly.
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .vale/styles/Google

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml.jinja
+++ b/.github/workflows/claude-code-review.yml.jinja
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml.jinja
+++ b/.github/workflows/claude.yml.jinja
@@ -32,7 +32,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml.jinja
+++ b/.github/workflows/codeql.yml.jinja
@@ -18,7 +18,7 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/copier-update.yml.jinja
+++ b/.github/workflows/copier-update.yml.jinja
@@ -34,13 +34,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: {{ '${{ secrets.RELEASE_TOKEN }}' }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 

--- a/.github/workflows/docs.yml.jinja
+++ b/.github/workflows/docs.yml.jinja
@@ -24,14 +24,14 @@ jobs:
     # in `deploy` on release:published.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # On release events the triggering tag may move after the workflow is
           # queued (semantic-release pushes a version-bump commit); build main.
           ref: {% raw %}${{ github.event_name == 'release' && 'main' || github.ref }}{% endraw %}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
@@ -80,14 +80,14 @@ jobs:
     steps:
       # `needs: build` is a sequencing gate only — mike drives its own
       # build internally; no artifact is passed from the build job.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Full history required: mike reads and pushes the gh-pages branch.
           fetch-depth: 0
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 

--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: {% raw %}${{ github.ref_name }}{% endraw %}
@@ -76,7 +76,7 @@ jobs:
           exit 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.6"
 
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
           fetch-depth: 1
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
           fetch-depth: 1
@@ -319,7 +319,7 @@ jobs:
     env:
       MCPB_VERSION: "2.1.2"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
       - name: Install mcpb CLI
@@ -398,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout catalog repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: {{ github_org }}/claude-plugins
           token: {% raw %}${{ secrets.RELEASE_TOKEN }}{% endraw %}
@@ -459,7 +459,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -13,10 +13,10 @@ jobs:
         python: ["3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.6"
 
@@ -312,10 +312,10 @@ jobs:
     name: Downstream workflow gate (docs + packaging)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.6"
 
@@ -381,10 +381,10 @@ jobs:
     name: Aggregator script unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.6"
 

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Closes #188

## Change

Bump the pinned GitHub Actions across the workflow templates:

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v6` (+ one stray `v4` in `claude.yml`) | `v7` |
| `actions/cache` | `v4` | `v5` |
| `astral-sh/setup-uv` | `v8.1.0` | `v8.2.0` |

Applied to both the rendered `.jinja` workflows (which propagate downstream) and the template's own workflows (`template-ci.yml`, `template-release.yml`, `claude.yml`, `claude-code-review.yml`).

## Why upstream

Dependabot's `github-actions` ecosystem scans `.github/workflows/*.yml`, not `*.yml.jinja`, so the templates never auto-bump. Every downstream instead gets Dependabot PRs (e.g. `markdown-vault-mcp` #716/#717/#718) that land in template-owned files and get clobbered on the next `copier update`. Fixing here propagates the current versions via copier and supersedes those per-repo PRs. Side benefit: clears the "Node.js 20 is deprecated" runner warnings (checkout v7 / cache v5 run on Node 24).

## Verification

- `copier copy` renders cleanly; rendered downstream workflows carry `checkout@v7`, `cache@v5`, `setup-uv@v8.2.0`.
- All workflow YAML (rendered + template's own) parses valid.
- No SHA-pinned actions among the changed lines (all version-tagged); no leftover old versions.

## Note on propagation

Template releases are cut manually (`template-release.yml` `workflow_dispatch`), so this needs a release (patch bump) to reach downstreams via copier. The 3 downstream Dependabot PRs can be closed as "handled upstream" once a release including this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
