### PR TITLE
ci(scaffold): bump pinned actions and seed dependencies label

### DIFF
--- a/.github/workflows/bootstrap.yml.jinja
+++ b/.github/workflows/bootstrap.yml.jinja
@@ -1,0 +1,37 @@
+name: Bootstrap repo
+
+# Seeds repository labels that checked-in config references but that GitHub
+# does not create on its own.  `.github/dependabot.yml` applies the
+# `dependencies` label to the PRs it opens; a freshly generated repo has no
+# such label, so without this those PRs would land unlabelled (Dependabot
+# silently drops labels that don't exist).
+#
+# Idempotent: `gh label create --force` creates the label or updates it in
+# place, so every run is a no-op once the label exists.  The first push to the
+# default branch seeds it; `workflow_dispatch` lets you re-seed on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/bootstrap.yml
+      - .github/dependabot.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  labels:
+    name: Ensure repository labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create dependencies label
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
+        run: |
+          gh label create dependencies \
+            --color 0366d6 \
+            --description "Pull requests that update a dependency" \
+            --force

--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -21,7 +21,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -51,7 +51,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -97,7 +97,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           # `uv python install` writes to UV_PYTHON_INSTALL_DIR, which is
           # separate from the uv package cache and not covered by setup-uv's
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
@@ -219,7 +219,7 @@ jobs:
           version: "latest"
 
       - name: Cache Python interpreter
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/uv/python
           key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
@@ -283,7 +283,7 @@ jobs:
         # Pack list mirrors the Packages = line in .vale.ini; if you add or
         # remove a pack, update both. Bump the v1- prefix to evict all cached
         # packs if Vale changes pack format backward-incompatibly.
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             .vale/styles/Google


### PR DESCRIPTION
## Summary

Eliminates day-one friction in freshly generated repos coming from three template-owned `.github` files.

- **#192** — bump `codecov/codecov-action` v6 → v7 in `ci.yml.jinja`.
- **#193** — bump `actions/cache` v5 → v6 and re-pin `gitleaks/gitleaks-action` v2 → **v3.0.0** (SHA `e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e`, verified against the upstream `v3.0.0` tag). Without these, every generated repo opens same-day Dependabot bumps against a template-owned workflow, which a downstream-only fix can't durably resolve (next `copier update` reverts it).
- **#194** — add `.github/workflows/bootstrap.yml`, a tiny idempotent workflow that runs `gh label create dependencies --force` so the `dependencies` label `dependabot.yml` references actually exists. GitHub labels are repo settings, not files, so `copier copy` can't create them; Dependabot silently drops a configured label that doesn't exist, leaving its PRs unlabelled. The workflow seeds it on first push to `main` (and on demand via `workflow_dispatch`).

## Notes

- `gitleaks-action` v3.0.0 is solely a runner migration (Node 20 → 24); inputs/outputs/behaviour are unchanged, and the `GITLEAKS_LICENSE` requirement (org-owned repos only) is unchanged from v2 — no regression.
- `bootstrap.yml` requests least-privilege `permissions: issues: write` (the scope the labels API needs).

## Verification

- Rendered the template at HEAD with smoke-answers and ran the generated project's gate: ruff ✅, mypy ✅, pytest (22 passed, 14 skipped — the known unbuilt-`site/` config-wizard skips) ✅.
- `bootstrap.yml` parses as valid YAML; rendered `ci.yml` pins confirmed (`codecov-action@v7`, `actions/cache@v6`, `gitleaks-action@e0c47f4… # v3.0.0`).

Closes #192
Closes #193
Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._