### PR TITLE
test(scaffold): assert app_domain log by arg equality, not URL substring

### DIFF
--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -53,7 +53,13 @@ def test_register_apps_logs_when_app_domain_set(
     monkeypatch.setenv("{{ env_prefix }}_APP_DOMAIN", "example.com")
     with caplog.at_level("INFO", logger="{{ python_module }}._server_apps"):
         register_apps(make_server())
-    assert any("example.com" in r.message for r in caplog.records)
+    # Assert on the structured log argument by exact equality rather than a
+    # substring test of the formatted message.  ``"example.com" in r.message``
+    # trips CodeQL's ``py/incomplete-url-substring-sanitization`` rule on the
+    # host-shaped literal, even though this is a log assertion and not URL
+    # sanitization; ``==`` is not a substring-membership pattern, so it does
+    # not.  The branch logs the configured domain as its sole ``%s`` arg.
+    assert any(r.args == ("example.com",) for r in caplog.records)
 
 
 {% endif -%}


### PR DESCRIPTION
## Summary

A freshly generated repo (inert / non-MCP-Apps variant) shipped a **high-severity** CodeQL alert on template-shipped test code before any domain code existed (#190). The inert smoke test asserted:

```python
assert any("example.com" in r.message for r in caplog.records)
```

CodeQL's `py/incomplete-url-substring-sanitization` rule fires on `"<host>" in <str>` substring-membership against the host-shaped literal, even though this is a log assertion, not URL sanitization. The alert failed the `CodeQL` results check on the first push of every generated repo using the inert variant.

## Fix

Assert the configured domain by **exact equality on the structured log argument** instead — `==` is not a substring-membership pattern, so the rule does not model it:

```python
assert any(r.args == ("example.com",) for r in caplog.records)
```

The code under test logs the domain as its sole `%s` arg (`logger.info("...app_domain=%s", app_domain)` in `_server_apps.py.jinja`), so `r.args == ("example.com",)` matches the same record the old check did — and is in fact stricter: it now fails on a *wrong/empty* logged value, not just an absent one. An inline comment documents the CodeQL motivation and the `%s`-arg contract the assertion depends on.

## Scope

Line 56 (the inert `{% else %}` branch) was the only substring-membership assertion in the file; the MCP-Apps (`{% if %}`) branch has none. The `BASE_URL` setenv at line ~129 is a plain assignment, not a substring check, so it does not trip the rule — left untouched (matches the issue's scope boundary).

## Verification

- Rendered the **inert** variant (`include_mcp_apps_scaffold=false`, the variant that ships this test) and ran the gate: ruff ✅, mypy ✅, the changed test `test_register_apps_logs_when_app_domain_set` passes, full smoke 22 passed / 14 skipped ✅.
- Verified `LogRecord.args` is `("example.com",)` for a single positional `%s` arg (CPython does not scalar-normalize a non-Mapping single-arg tuple).

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._