### PR TITLE
docs(scaffold): add MCP Registry mcp-name marker to README header

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -1,5 +1,7 @@
 # {{ human_name }}
 
+<!-- mcp-name: io.github.{{ github_org }}/{{ project_name }} -->
+
 [![CI](https://github.com/{{ github_org }}/{{ project_name }}/actions/workflows/ci.yml/badge.svg)](https://github.com/{{ github_org }}/{{ project_name }}/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/{{ github_org }}/{{ project_name }}/graph/badge.svg)](https://codecov.io/gh/{{ github_org }}/{{ project_name }}) [![PyPI](https://img.shields.io/pypi/v/{{ pypi_name }})](https://pypi.org/project/{{ pypi_name }}/) [![Python](https://img.shields.io/pypi/pyversions/{{ pypi_name }})](https://pypi.org/project/{{ pypi_name }}/) [![License](https://img.shields.io/github/license/{{ github_org }}/{{ project_name }})](LICENSE) [![Docker](https://img.shields.io/github/v/release/{{ github_org }}/{{ project_name }}?label=ghcr.io&logo=docker)](https://github.com/{{ github_org }}/{{ project_name }}/pkgs/container/{{ project_name }}) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://{{ github_org }}.github.io/{{ project_name }}/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://{{ github_org }}.github.io/{{ project_name }}/llms.txt) [![Template](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/{{ github_org }}/{{ project_name }}/main/.copier-answers.yml&query=%24._commit&label=template)](https://github.com/pvliesdonk/fastmcp-server-template)
 
 {{ domain_description }}


### PR DESCRIPTION
## Summary

A generated repo could not publish to the MCP Registry: the `publish-registry` job failed with `the server name 'io.github.<org>/<project>' must appear as 'mcp-name: io.github.<org>/<project>' in the package README` (#191). The template's `README.md.jinja` shipped no `mcp-name` marker, so each downstream had to hand-add one into a template-owned region (reverted by the next `copier update`).

## Fix

Render the marker directly in the template-owned README header, immediately after the H1:

```html
<!-- mcp-name: io.github.{{ github_org }}/{{ project_name }} -->
```

The value is sourced from the same two Jinja variables (`github_org`, `project_name`) that drive `server.json.jinja`'s `name`, so the README marker and the manifest stay consistent **by construction** — no hand-copied string that can drift. Placement matches the established downstream convention (e.g. `scholar-mcp/README.md:3`).

## Verification

- Rendered with smoke-answers: the marker renders as `<!-- mcp-name: io.github.pvliesdonk/smoke-mcp -->`, byte-for-byte equal to the rendered `server.json` `"name": "io.github.pvliesdonk/smoke-mcp"`.
- `pyproject.toml` sets `readme = "README.md"`, so the marker reaches the PyPI long-description the registry validator reads.
- Generated project gate green (ruff/mypy/pytest: 22 passed, 14 skipped).
- The marker is an inert HTML comment (invisible in rendered Markdown) and sits in the unmarked header region — above the first `DOMAIN-START` sentinel and well above the `TEMPLATE-OWNED SECTIONS BELOW` banner — so it disrupts no sentinel block.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._