### PR TITLE
fix(scaffold): neutralize copier-update wording in CLAUDE.md on detach

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -224,9 +224,17 @@ jobs:
           rm -rf .gemini
           rm -f scripts/copier_update_aggregator.py
           rm -rf scripts/copier_update_prompts
-          # --- Step 3: scrub CLAUDE.md template-tracking blocks ---
+          # --- Step 3: scrub CLAUDE.md template-tracking + copier-update wording ---
           # -i.bak + rm mirrors FORKING.md's portable form (GNU + BSD sed).
-          sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+          sed -i.bak \
+            -e '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' \
+            -e '/<!-- ===== TEMPLATE-OWNED SECTIONS BELOW/d' \
+            -e '/<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->/d' \
+            -e 's/ Kept across copier update\.//' \
+            -e 's/ on top of the shipped defaults survive `copier update`\./ on top of the shipped defaults are yours to maintain./' \
+            -e 's/ are preserved across `copier update`\./ are domain-owned./' \
+            -e 's/The block is preserved across `copier update`\./The block is domain-owned./' \
+            CLAUDE.md && rm -f CLAUDE.md.bak
           # --- Closing ("You are now standalone"): remove the detach guide.
           #     FORKING.md's numbered Step 4 (README cleanup) is intentionally
           #     NOT mirrored here — it mutates README prose this smoke does not
@@ -246,6 +254,12 @@ jobs:
           # grep bites on a regressed scrub rather than passing vacuously.
           ! grep -rniE "fleet|downstream conforms|shape lives in pvl-core|lives upstream|propagate here via .?copier update" CLAUDE.md \
             || { echo "::error::template-tracking language remains in CLAUDE.md after scrub"; exit 1; }
+          # A detached fork's CLAUDE.md must not claim its sections are
+          # overwritten or preserved by copier update (issue #184). The scrub
+          # strips every such mention (banner fences, DOMAIN "Kept across" notes,
+          # "preserved/survive across copier update" prose), so none may remain.
+          ! grep -niF 'copier update' CLAUDE.md \
+            || { echo "::error::copier-update wording remains in CLAUDE.md after detach scrub"; exit 1; }
           grep -qE '^## Shared Infrastructure$' CLAUDE.md \
             && { echo "::error::Shared Infrastructure section survived the scrub"; exit 1; } || true
           grep -qE '^## Contributing fixes upstream$' CLAUDE.md \
@@ -260,7 +274,10 @@ jobs:
           #   pair 1 START → ## PR Discipline (above)
           #   pair 1 END   → ## GitHub Review Types (below)
           #   pair 2 START → ## Server Info Tool (above)
-          #   pair 2 END   → TEMPLATE-OWNED END fence + ## Key Design Decisions (below)
+          #   pair 2 END   → ## Key Design Decisions (below; the TEMPLATE-OWNED
+          #                  END fence that used to sit here is removed by the
+          #                  scrub, so ## Key Design Decisions is now the sole
+          #                  below-the-boundary over-run guard)
           # The remaining entries are the other sections FORKING.md promises survive.
           for kept_section in \
               '^## Conventions$' \
@@ -274,11 +291,14 @@ jobs:
             grep -qE "$kept_section" CLAUDE.md \
               || { echo "::error::neutral section '$kept_section' lost — scrub deleted too much"; exit 1; }
           done
-          # Structural bottom boundary: pair 2 END is the last TEMPLATE-TRACKING
-          # marker, so a misplaced END would run the range delete to EOF past
-          # this fence. Assert it survives.
-          grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->$' CLAUDE.md \
-            || { echo "::error::TEMPLATE-OWNED END fence lost — scrub over-ran past pair 2"; exit 1; }
+          # The TEMPLATE-OWNED banner fences are intentionally removed by the
+          # scrub (a detached fork owns every section), so assert both are gone.
+          # The range-delete's bottom-boundary over-run guard is now
+          # '## Key Design Decisions' (asserted in the kept-section loop above):
+          # it sits below where the END fence was, so a range delete that ran to
+          # EOF past pair 2 would drop it too.
+          ! grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS (BELOW|END)' CLAUDE.md \
+            || { echo "::error::TEMPLATE-OWNED banner fence survived the detach scrub"; exit 1; }
           # stripped files gone:
           for gone in \
               .github/workflows/copier-update.yml \

--- a/FORKING.md.jinja
+++ b/FORKING.md.jinja
@@ -52,15 +52,28 @@ the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
 ```bash
 # -i.bak + rm keeps this portable across GNU sed (Linux) and BSD sed (macOS),
 # which disagree on the in-place flag's syntax.
-sed -i.bak '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' CLAUDE.md && rm -f CLAUDE.md.bak
+sed -i.bak \
+  -e '/<!-- TEMPLATE-TRACKING-START -->/,/<!-- TEMPLATE-TRACKING-END -->/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS BELOW/d' \
+  -e '/<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->/d' \
+  -e 's/ Kept across copier update\.//' \
+  -e 's/ on top of the shipped defaults survive `copier update`\./ on top of the shipped defaults are yours to maintain./' \
+  -e 's/ are preserved across `copier update`\./ are domain-owned./' \
+  -e 's/The block is preserved across `copier update`\./The block is domain-owned./' \
+  CLAUDE.md && rm -f CLAUDE.md.bak
 ```
 
 This deletes the template-coupled sections — the bot-reviewer merge-gate
-paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** —
-while keeping the fork-neutral contributor guidance (Conventions, the PR
-acceptance gates, the Logging Standard, the config contract, GitHub Review
-Types). If your fork added its own `.claude/CLAUDE.md`, apply the same scrub
-there.
+paragraph, **Shared Infrastructure**, and **Contributing fixes upstream** — and
+strips the copier-update wording that no longer describes a detached fork: the
+`TEMPLATE-OWNED SECTIONS` banner fences (a fork owns every section, so the
+template/domain split is moot), the "Kept across copier update" notes on the
+DOMAIN blocks, and the remaining "preserved/survive across copier update" notes
+(the pre-commit defaults, the `Dockerfile` sentinels, and the upstream sentinel).
+The fork-neutral contributor guidance
+(Conventions, the PR acceptance gates, the Logging Standard, the config
+contract, GitHub Review Types) is kept. If your fork added its own
+`.claude/CLAUDE.md`, apply the same scrub there.
 
 ## Step 4 — README cleanup (optional)
 


### PR DESCRIPTION
## Summary

A detached fork's retained `CLAUDE.md` still claimed its sections were overwritten/preserved by `copier update` (#184): the `TEMPLATE-OWNED SECTIONS` banner fences, the DOMAIN "Kept across copier update" notes, and the "preserved/survive across copier update" prose all sit **outside** the `TEMPLATE-TRACKING` ranges the existing detach scrub deletes.

## Approach — detach-time, not template-wide

The phrasing is a **pervasive, accurate-for-tracked-projects convention**: `kept across copier update` appears in ~15 rendered files and correctly tells a *tracked* project's maintainer which content survives an update. Rewording the template source would dump a noisy ~15-file diff into **every tracked downstream's next `copier update`** — purely to cover a detach that may never happen.

So this fix changes nothing in the template's normal output. Instead it extends the documented detach procedure (`FORKING.md` Step 3) + its `template-ci` detach-smoke to strip the copier-update wording **only when a fork actually detaches**:

- delete the two `<!-- ===== TEMPLATE-OWNED SECTIONS BELOW/END ===== -->` banner fences (a detached fork owns every section, so the template/domain split is moot);
- strip the `Kept across copier update` notes on the DOMAIN blocks;
- reword the `preserved/survive across copier update` notes (pre-commit defaults, `Dockerfile` sentinels, upstream sentinel) to ownership-neutral wording.

`FORKING.md`'s `sed` and the detach-smoke's `sed` stay **byte-identical** (the existing lockstep invariant). The detach-smoke gains an assertion that **zero** `copier update` wording remains in the post-detach `CLAUDE.md`, directly encoding #184's expectation. The removed `TEMPLATE-OWNED END` fence was the range-delete's over-run guard; that role moves to `## Key Design Decisions` (already asserted in the kept-section loop, and it sits below the former fence).

## Scope

CLAUDE.md only, matching #184. README's own banner/`uv.lock` leftovers remain the documented optional `FORKING.md` Step 4 cleanup (#184 scope boundary).

## Verification

- Rendered the template at HEAD, ran the exact new scrub against the generated `CLAUDE.md`: zero `copier update` wording remains, both banner fences gone, all 8 fork-neutral sections survive, tracking sections gone, prose neutralized.
- Generated project gate green (ruff/mypy/pytest 22 passed, 14 skipped).
- `git diff` confirms **no change** to `CLAUDE.md.jinja` / `README.md.jinja` — zero churn for tracked projects.

## Follow-up

A low-priority follow-up issue will track hardening the detach-smoke against source/scrub *drift* (anchor-existence guards, property-based phrase assertion) — a pre-existing harness property, not introduced here.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._