### PR TITLE
docs(claude-md): add Tool Registration Checklist section

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -144,6 +144,17 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 - `# DOCKERFILE-STATE-DIRS-START` / `-END` — state subdirectories created under `/data` (chowned to the runtime user)
 - `# DOCKERFILE-VOLUMES-START` / `-END` — `VOLUME` declarations on the final image
 
+## Tool Registration Checklist
+
+Every MCP tool you register must carry the full set of metadata below — not just the behaviour. A tool that works but lacks a title, hints, or docs is incomplete. When adding or changing a tool, verify each item:
+
+- **Title** — a human-readable `annotations.title` (e.g. `"Search Vault"`). Title-aware clients (notably VS Code, which honours only `title` and `readOnlyHint` among annotations) render this as the tool's label; without it they fall back to the raw machine name. Set it inline in the tool's `annotations={...}` dict.
+- **Behavioural hints** — `readOnlyHint`, and where they apply `destructiveHint` / `idempotentHint`, in the same `annotations` dict. These describe side effects accurately (a destructive tool must set `destructiveHint=True`).
+- **Icon** — an entry wired via `register_tool_icons(...)` or `@mcp.tool(icons=[...])` (see [Tool icons](#tool-icons)).
+- **Docstring** — a Google-style docstring; FastMCP surfaces it as the tool description and per-parameter docs.
+- **Docs entry** — a row in your published tools reference (e.g. `docs/tools/index.md`) so the tool is documented for users (per [Documentation Discipline](#documentation-discipline)).
+- **Enforcement test** — keep a test that enumerates the registered tools and asserts each carries the metadata above (at minimum a non-empty `annotations.title`). Enumerate the *full* registry, not just the client-facing listing, so app-only / hidden tools cannot slip past. Such a test turns this checklist into a CI gate: a future tool added without a title fails loudly rather than silently shipping its machine name.
+
 ## Server Info Tool (`get_server_info`)
 
 `make_server()` registers `get_server_info` (via `fastmcp_pvl_core.register_server_info_tool`) so operators can answer "is the latest fix actually deployed?" with a single MCP call. The default response carries `server_name`, `server_version`, and `core_version`.


### PR DESCRIPTION
## Summary
The templated `CLAUDE.md` documents tool icons and the server-info tool individually but has no single checklist enumerating what every registered MCP tool must carry. Generated servers consequently omit per-tool concerns one at a time.

## Motivation
A downstream server generated from this template (`pvliesdonk/markdown-vault-mcp`) shipped its full tool set with behavioural hints and icons but **no `title` annotation**, so title-aware clients (VS Code) rendered raw machine names. Fixed there as `pvliesdonk/markdown-vault-mcp#751` (37 tools across 7 modules) — the omission was systemic, not a one-off, because nothing in the shared guidance said "every tool also needs a title."

## Changes
Add a **`## Tool Registration Checklist`** section to `CLAUDE.md.jinja` (inside the TEMPLATE-OWNED region, before the Server Info Tool section), listing the per-tool requirements:
- a human-readable `annotations.title`,
- behavioural hints (`readOnlyHint` / `destructiveHint` / `idempotentHint`),
- an icon,
- a Google-style docstring,
- a `docs/tools/` entry,
- an enforcement test that enumerates the **full** tool registry (not just the client-facing listing, so app-only/hidden tools can't slip past) and asserts each tool carries the metadata.

## Validation
- `CLAUDE.md.jinja` parses as valid Jinja2.
- Sentinel structure unchanged: still 3 `DOMAIN-START`/`END` pairs and 2 `TEMPLATE-TRACKING` pairs; the new section sits between existing template-owned sections.
- Internal anchors (`#tool-icons`, `#documentation-discipline`) resolve to existing headers.
- Root `CLAUDE.md` (the template's own dev instructions, distinct from the rendered `.jinja`) is unaffected.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._