### PR TITLE
feat(scaffold): honor {PREFIX}_SERVER_NAME and {PREFIX}_INSTRUCTIONS

### DIFF
--- a/.env.example.jinja
+++ b/.env.example.jinja
@@ -1,6 +1,8 @@
 # {{ human_name }} environment variables (copy to .env and fill in).
 
 # --- Server ---
+# {{ env_prefix }}_SERVER_NAME={{ project_name }}   # rename this instance (default: {{ project_name }})
+# {{ env_prefix }}_INSTRUCTIONS=                     # replace the default MCP instructions text
 # {{ env_prefix }}_TRANSPORT=stdio   # stdio | http | sse
 # {{ env_prefix }}_HOST=127.0.0.1
 # {{ env_prefix }}_PORT=8000

--- a/docs/configuration.md.jinja
+++ b/docs/configuration.md.jinja
@@ -10,6 +10,18 @@ variables (`{{ env_prefix }}_TRANSPORT`, `{{ env_prefix }}_HOST`,
 `{{ env_prefix }}_PORT`, `{{ env_prefix }}_HTTP_PATH`,
 `{{ env_prefix }}_BASE_URL`, auth vars, etc.).
 
+## Server identity
+
+These two are read by the scaffold's `make_server()` (not by
+`ServerConfig`), so an operator can rename an instance or override its
+instructions without editing template-owned code:
+
+- `{{ env_prefix }}_SERVER_NAME`: the server name reported to clients and
+  by `get_server_info`. Defaults to `{{ project_name }}`.
+- `{{ env_prefix }}_INSTRUCTIONS`: replaces the default MCP instructions
+  text. Unset, the scaffold builds the default (which advertises this
+  override).
+
 <!-- DOMAIN-CONFIG-VARS-START -->
 ## Domain variables
 

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -20,6 +20,7 @@ from fastmcp_pvl_core import (
     build_instructions,
     build_kv_store,  # noqa: F401  — re-exported for downstream projects' convenience
     configure_logging_from_env,
+    env,
     register_server_info_tool,
     resolve_auth_mode,
     wire_middleware_stack,
@@ -55,6 +56,16 @@ def make_server(
     config = config or ProjectConfig.from_env()
     configure_logging_from_env()
 
+    # Operator overrides: SERVER_NAME renames this instance; INSTRUCTIONS
+    # replaces the default instructions text (the latter is the override that
+    # build_instructions' hint advertises). Both fall back when unset/empty.
+    server_name = env(_ENV_PREFIX, "SERVER_NAME", "{{ project_name }}")
+    instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(
+        read_only=True,
+        env_prefix=_ENV_PREFIX,
+        domain_line="{{ domain_description }}",
+    )
+
     auth = build_auth(config.server)
     auth_mode = resolve_auth_mode(config.server) if auth is not None else "none"
     if auth_mode == "none":
@@ -70,19 +81,16 @@ def make_server(
         pkg_ver = "unknown"
 
     logger.info(
-        "Server config: version=%s name={{ project_name }} transport=%s auth=%s",
+        "Server config: version=%s name=%s transport=%s auth=%s",
         pkg_ver,
+        server_name,
         transport,
         auth_mode,
     )
 
     mcp = FastMCP(
-        name="{{ project_name }}",
-        instructions=build_instructions(
-            read_only=True,
-            env_prefix=_ENV_PREFIX,
-            domain_line="{{ domain_description }}",
-        ),
+        name=server_name,
+        instructions=instructions,
         lifespan=server_lifespan,
         auth=auth,
     )
@@ -123,7 +131,7 @@ def make_server(
 
     register_server_info_tool(
         mcp,
-        server_name="{{ project_name }}",
+        server_name=server_name,
         server_version=pkg_ver,
         # DOMAIN-UPSTREAM-START — wire upstream version reporting for servers
         # that talk to a remote service (paperless-mcp, etc.). The provider is

--- a/tests/test_smoke.py.jinja
+++ b/tests/test_smoke.py.jinja
@@ -107,6 +107,73 @@ async def test_get_server_info_tool_registered(client: Client[Any]) -> None:
     assert "upstream" not in payload
 
 
+def test_server_name_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``{{ env_prefix }}_SERVER_NAME`` overrides the FastMCP server name.
+
+    Unset, the name defaults to ``{{ project_name }}`` (locked by the
+    ``get_server_info`` test above). Set, ``make_server()`` must honor it so an
+    operator can rename an instance without editing template-owned code.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_SERVER_NAME", "renamed-instance")
+    assert make_server().name == "renamed-instance"
+
+
+async def test_server_name_env_override_reaches_server_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The overridden name also flows through to ``get_server_info``.
+
+    ``register_server_info_tool`` is wired separately from the FastMCP ``name``,
+    so this pins that both surfaces honor the same resolved name.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_SERVER_NAME", "renamed-instance")
+    server = make_server()
+    async with Client(server) as smoke_client:
+        result = await smoke_client.call_tool("get_server_info", {})
+    first = result.content[0]
+    assert hasattr(first, "text"), (
+        f"expected text tool content, got {type(first).__name__}"
+    )
+    assert json.loads(first.text)["server_name"] == "renamed-instance"
+
+
+def test_instructions_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``{{ env_prefix }}_INSTRUCTIONS`` replaces the built-in instructions.
+
+    ``build_instructions`` advertises this override in its hint line; honoring
+    it here makes that advertisement true instead of a dead hint.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_INSTRUCTIONS", "Custom operator text.")
+    assert make_server().instructions == "Custom operator text."
+
+
+def test_instructions_default_falls_back_to_build_instructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset, instructions fall back to ``build_instructions`` (whose hint
+    advertises the override var). Guards the fallback arm of the override."""
+    monkeypatch.delenv("{{ env_prefix }}_INSTRUCTIONS", raising=False)
+    assert "{{ env_prefix }}_INSTRUCTIONS" in (make_server().instructions or "")
+
+
+def test_blank_overrides_fall_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only overrides fall back, honoring the "unset/empty" contract.
+
+    ``env`` strips and treats a blank value as unset, so a blank SERVER_NAME
+    must revert to ``{{ project_name }}`` rather than rename the instance to
+    whitespace, and a blank INSTRUCTIONS must revert to ``build_instructions``.
+    Guards against a future refactor (e.g. raw ``os.environ.get``) that would
+    pass the blank value through.
+    """
+    monkeypatch.setenv("{{ env_prefix }}_SERVER_NAME", "   ")
+    monkeypatch.setenv("{{ env_prefix }}_INSTRUCTIONS", "   ")
+    server = make_server()
+    assert server.name == "{{ project_name }}"
+    assert "{{ env_prefix }}_INSTRUCTIONS" in (server.instructions or "")
+
+
 async def test_summarize_prompt_includes_context(client: Client[Any]) -> None:
     """The example ``summarize`` prompt round-trips its ``context`` argument."""
     result = await client.get_prompt("summarize", {"context": "hello world"})


### PR DESCRIPTION
## What

`make_server()` now honors two operator env overrides that the scaffold previously advertised or implied but never read.

## Why

- **`{PREFIX}_INSTRUCTIONS` was a dead hint.** `build_instructions` (pvl-core) always appends `"Operators: set {PREFIX}_INSTRUCTIONS to describe this service's domain..."`, but nothing read it — the scaffold passed the statically-built string to `FastMCP(instructions=...)` and never consulted the env var. The scaffold can't drop the hint (pvl-core owns it), so honoring the var is the only fix.
- **The server name was hardcoded** in three spots (the FastMCP `name`, the config log line, and `register_server_info_tool`), so an instance could not be renamed without editing template-owned code. `markdown-vault-mcp` re-implements this per-repo — evidence the need is real.

## Changes

- `src/{{python_module}}/server.py.jinja`: resolve both once via pvl-core's `env` helper.
  - `server_name = env(_ENV_PREFIX, "SERVER_NAME", "{{ project_name }}")` — threaded into the FastMCP `name`, the config log line, and `register_server_info_tool`.
  - `instructions = env(_ENV_PREFIX, "INSTRUCTIONS") or build_instructions(...)`.
  - `env` strips and falls back on empty/whitespace, so a blank var behaves as unset.
- `tests/test_smoke.py.jinja`: five new tests — override on both surfaces (FastMCP `name` + `get_server_info`), the instructions fallback, and a blank/whitespace fallback guard (the "unset/empty" contract edge, guarding against a future raw-`os.environ.get` refactor).
- `.env.example.jinja` + `docs/configuration.md.jinja`: document the two scaffold-read vars (distinct from pvl-core's `ServerConfig` vars).

## Validation

TDD: the three override tests were watched failing pre-fix. Rendered the template at HEAD and ran the full gate on the generated project — ruff, ruff format, mypy, pytest (all smoke tests), `mkdocs build --strict`, and `vale docs/` (the touched doc is em-dash-clean) all pass. Local five-lens preflight review clean.

Out of scope (deliberate): wizard-seed wiring (write-once/domain-owned; #201/#203 cover drift) and any pvl-core change.

Closes #202

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._