### PR TITLE
feat(scaffold): diff-scoped structural-health gate (Spec 1)

### DIFF
--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -330,3 +330,52 @@ jobs:
           # don't gate PRs that don't touch them. To enforce repo-wide
           # cleanliness, set this to `nofilter`.
           filter_mode: added
+{% if enable_structural_gate %}
+
+  structure:
+    name: Structural Quality (diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Diff-scoped, so only meaningful on a PR (needs a base branch to compare).
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Fetch base branch
+        run: git fetch origin {% raw %}${{ github.base_ref }}{% endraw %} --depth=50
+
+      - name: Structural quality (changed lines only)
+        env:
+          BASE_REF: {% raw %}${{ github.base_ref }}{% endraw %}
+        run: |
+          # Skip when the diff touches no Python — mirrors the diff-cover guard.
+          HAS_PY=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -c '\.py$' || true)
+          if [ "$HAS_PY" -eq 0 ]; then
+            echo "No Python source changes — skipping structural diff gate"
+            exit 0
+          fi
+          uv run diff-quality --violations=ruff.check \
+            --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+            --compare-branch="origin/${BASE_REF}" --fail-under=100
+{% endif %}

--- a/.github/workflows/ci.yml.jinja
+++ b/.github/workflows/ci.yml.jinja
@@ -376,6 +376,6 @@ jobs:
             exit 0
           fi
           uv run diff-quality --violations=ruff.check \
-            --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+            --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
             --compare-branch="origin/${BASE_REF}" --fail-under=100
 {% endif %}

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -80,6 +80,8 @@ jobs:
             || { echo "::error::structural tests/** S-ignore rendered with gate off"; exit 1; }
           ! grep -q '## Structural health' CLAUDE.md \
             || { echo "::error::structural-health section rendered with gate off"; exit 1; }
+          ! grep -qF 'Structural quality (diff) passes' CLAUDE.md \
+            || { echo "::error::structural acceptance-gate item rendered with gate off"; exit 1; }
 
       - name: Install rendered project
         working-directory: /tmp/smoke

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -47,13 +47,15 @@ jobs:
           fi
 
       - name: structural gate toggle-off render
-        # The smoke answers set enable_structural_gate=true, so the gate's
-        # artifacts and its own test suite are exercised by every step above.
-        # This step renders a second project with the gate OFF and asserts every
-        # gated artifact is absent — the generated suite cannot cover this
-        # (test_structural_gate.py does not render when the gate is off), so a
-        # jinja edit that leaks an artifact past its {% raw %}{% if %}{% endraw %}
-        # guard would otherwise pass CI silently.
+        # The smoke project rendered in the first step has the gate ON, so the
+        # install/lint/test steps that follow exercise the gate's artifacts and
+        # its own test suite. This step renders a SECOND project with the gate
+        # OFF and asserts every gated artifact is absent — the generated suite
+        # cannot cover this (test_structural_gate.py does not render when the
+        # gate is off), so a jinja edit that leaks an artifact past its
+        # {% raw %}{% if %}{% endraw %} guard would otherwise pass CI silently.
+        # One assertion per independently-gated block (pyproject has two: the
+        # mccabe/pylint thresholds AND the tests/** S-ignore).
         run: |
           rm -rf /tmp/smoke-gate-off
           uv run --no-project --with copier \
@@ -64,6 +66,8 @@ jobs:
           cd /tmp/smoke-gate-off
           test ! -f tests/test_structural_gate.py \
             || { echo "::error::structural test rendered with gate off"; exit 1; }
+          test ! -f tests/.jinja \
+            || { echo "::error::conditional filename left a stray tests/.jinja"; exit 1; }
           ! grep -q 'structural-diff-gate' .pre-commit-config.yaml \
             || { echo "::error::pre-push hook rendered with gate off"; exit 1; }
           ! grep -q 'default_install_hook_types' .pre-commit-config.yaml \
@@ -72,6 +76,8 @@ jobs:
             || { echo "::error::structure CI job rendered with gate off"; exit 1; }
           ! grep -q 'tool.ruff.lint.mccabe' pyproject.toml \
             || { echo "::error::structural thresholds rendered with gate off"; exit 1; }
+          ! grep -qF '"tests/**"' pyproject.toml \
+            || { echo "::error::structural tests/** S-ignore rendered with gate off"; exit 1; }
           ! grep -q '## Structural health' CLAUDE.md \
             || { echo "::error::structural-health section rendered with gate off"; exit 1; }
 

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -46,6 +46,35 @@ jobs:
             exit 1
           fi
 
+      - name: structural gate toggle-off render
+        # The smoke answers set enable_structural_gate=true, so the gate's
+        # artifacts and its own test suite are exercised by every step above.
+        # This step renders a second project with the gate OFF and asserts every
+        # gated artifact is absent — the generated suite cannot cover this
+        # (test_structural_gate.py does not render when the gate is off), so a
+        # jinja edit that leaks an artifact past its {% raw %}{% if %}{% endraw %}
+        # guard would otherwise pass CI silently.
+        run: |
+          rm -rf /tmp/smoke-gate-off
+          uv run --no-project --with copier \
+            copier copy --trust --defaults \
+            --data-file tests/fixtures/smoke-answers.yml \
+            --data enable_structural_gate=false \
+            . /tmp/smoke-gate-off
+          cd /tmp/smoke-gate-off
+          test ! -f tests/test_structural_gate.py \
+            || { echo "::error::structural test rendered with gate off"; exit 1; }
+          ! grep -q 'structural-diff-gate' .pre-commit-config.yaml \
+            || { echo "::error::pre-push hook rendered with gate off"; exit 1; }
+          ! grep -q 'default_install_hook_types' .pre-commit-config.yaml \
+            || { echo "::error::default_install_hook_types rendered with gate off"; exit 1; }
+          ! grep -qE '^  structure:' .github/workflows/ci.yml \
+            || { echo "::error::structure CI job rendered with gate off"; exit 1; }
+          ! grep -q 'tool.ruff.lint.mccabe' pyproject.toml \
+            || { echo "::error::structural thresholds rendered with gate off"; exit 1; }
+          ! grep -q '## Structural health' CLAUDE.md \
+            || { echo "::error::structural-health section rendered with gate off"; exit 1; }
+
       - name: Install rendered project
         working-directory: /tmp/smoke
         run: uv sync --all-extras --all-groups

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -43,6 +43,10 @@ repos:
         entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
         language: system
         pass_filenames: false
+        # Skip the hook when the push has no Python (with pass_filenames: false,
+        # pre-commit still uses `types` to decide whether to run at all). Mirrors
+        # the CI structure job's `HAS_PY` docs-only skip.
+        types: [python]
         stages: [pre-push]
 {% endif %}
 

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -1,3 +1,8 @@
+{% if enable_structural_gate %}
+# `pre-commit install` wires both stages so the pre-push structural gate is
+# installed alongside the commit-time hooks.
+default_install_hook_types: [pre-commit, pre-push]
+{% endif %}
 repos:
   - repo: local
     hooks:
@@ -23,6 +28,20 @@ repos:
         types: [python]
         pass_filenames: false
         args: [src/, tests/]
+
+{% if enable_structural_gate %}
+      # Structural-health gate: strict ruff structural rules on CHANGED LINES
+      # ONLY (diff vs origin/main), mirroring the CI `structure` job exactly.
+      # bash -c so the shell — not pre-commit's arg splitter — owns the
+      # --options quoting. Pre-push (not commit-time): a commit has no base to
+      # compare and may be partial; pre-push sees the full branch range CI checks.
+      - id: structural-diff-gate
+        name: structural quality (diff vs origin/main)
+        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+{% endif %}
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -37,7 +37,7 @@ repos:
       # compare and may be partial; pre-push sees the full branch range CI checks.
       - id: structural-diff-gate
         name: structural quality (diff vs origin/main)
-        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -31,7 +31,10 @@ repos:
 
 {% if enable_structural_gate %}
       # Structural-health gate: strict ruff structural rules on CHANGED LINES
-      # ONLY (diff vs origin/main), mirroring the CI `structure` job exactly.
+      # ONLY (diff vs origin/main), mirroring the CI `structure` job. NOTE the
+      # base is hardcoded `origin/main` here while CI compares against the PR's
+      # actual base (`github.base_ref`); the two coincide for a PR targeting
+      # `main` and diverge only for a non-main base branch.
       # bash -c so the shell — not pre-commit's arg splitter — owns the
       # --options quoting. Pre-push (not commit-time): a commit has no base to
       # compare and may be partial; pre-push sees the full branch range CI checks.

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -55,7 +55,7 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 - **Install once per clone:** `uv run pre-commit install`.
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
 {% if enable_structural_gate %}
-- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range.
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range, as long as your PR targets `main` (the hook hardcodes `origin/main`; CI compares against the PR's actual base branch).
 {% endif %}
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -34,10 +34,10 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 {% if enable_structural_gate %}
-5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, god-class, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
+5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
    ```bash
    uv run diff-quality --violations=ruff.check \
-     --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+     --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
      --compare-branch=origin/main --fail-under=100
    ```
    `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -33,8 +33,20 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
 3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
+{% if enable_structural_gate %}
+5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, god-class, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
+   ```bash
+   uv run diff-quality --violations=ruff.check \
+     --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+     --compare-branch=origin/main --fail-under=100
+   ```
+   `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
+6. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
+7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+{% else %}
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+{% endif %}
 
 ## Pre-commit Hooks
 
@@ -42,9 +54,44 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 
 - **Install once per clone:** `uv run pre-commit install`.
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+{% if enable_structural_gate %}
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range.
+{% endif %}
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 
 The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
+{% if enable_structural_gate %}
+
+## Structural health
+
+The structural gate stops *new* debt; these practices and the advisory audit keep existing debt visible.
+
+**Local-shape rules (checkable while you write):**
+
+- Keep functions short and single-purpose; if a function needs a comment to explain a *section*, that section is a function.
+- Nesting beyond ~3 levels is a smell — extract or invert/early-return.
+- Five parameters is the ceiling; past it, pass an object or split the function.
+- A new responsibility is a **new collaborator, not a longer class**. When a class grows a second reason to change, that reason belongs in its own unit.
+
+**Advisory audit (on demand — run before substantial work in an unfamiliar area, or when about to touch a flagged module):**
+
+```bash
+uv run --with radon python -m radon cc -s -n C src/    # complexity hotspots (grade C+)
+uv run --with radon python -m radon mi -s src/         # maintainability index
+uv run --with vulture vulture src/                     # dead-code candidates
+```
+
+Each analyzer is optional and degrades gracefully if absent. `vulture` over-reports on importable/decorated/framework-registered code — **confirm before deleting** and keep a whitelist.
+
+**When you notice decay outside the current change's scope** — a god class forming, a dead branch, a leaking abstraction, a name that no longer matches behaviour, or an audit hotspot — do **not** fix it inline (scope creep) and do **not** pass over it silently. **Open an issue** using this template:
+
+> **What:** the structural problem in one sentence.
+> **Where:** file/symbol and the metric or observation that flagged it.
+> **Why it compounds:** what gets harder or riskier if it's left.
+> **Suggested direction:** a starting point, not a prescribed refactor.
+
+Constrain issues to **decay that will compound**, not anything imperfect. The diff-gate blocks new debt; these issues are the refactor-later backlog for pre-existing debt — neither blocks the current PR.
+{% endif %}
 
 ## PR Discipline
 

--- a/copier.yml
+++ b/copier.yml
@@ -182,3 +182,8 @@ enable_authorization:
   type: bool
   default: false
   help: "Scaffold the opt-in per-subject authorization surface: the commented ACL middleware stubs in config.py/server.py, the brief README 'Authorization' pointer, the docs/guides/authorization.md guide and its nav entry, the *_ACL_PATH line in .env.example, and the cross-link in the authentication guide. Leave off unless this server needs per-caller scope gating (runtime enablement is still via the *_ACL_PATH env var)."
+
+enable_structural_gate:
+  type: bool
+  default: true
+  help: "Scaffold the diff-scoped structural-health gate: strict ruff structural rules (complexity, god-class, too-many-*, security) enforced on changed lines only via diff-quality, as a pre-push hook and a CI 'structure' job, plus the CLAUDE.md structural-health guidance (local-shape rules, advisory radon/vulture audit, decay-issue template). New code is held to the bar; pre-existing code is never blocked. Leave on unless a project deliberately opts out of structural enforcement."

--- a/docs/superpowers/plans/2026-06-28-structural-health-gate.md
+++ b/docs/superpowers/plans/2026-06-28-structural-health-gate.md
@@ -1,0 +1,756 @@
+# Structural-health gate (Spec 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a diff-scoped structural-health layer into generated projects — a blocking structural diff-gate (pre-push hook + CI backstop), a documented local advisory audit, and CLAUDE.md agent "eyes" — so agent-authored code can't grow structural debt and the agent reproduces every gate locally before CI.
+
+**Architecture:** Strict structural ruff rules (`C901`, `PLR0904`, `PLR0911-0915`, `S`) are applied **only to the diff** via `diff-quality --violations=ruff.check --options=--extend-select=...`, never added to the whole-repo `ruff check` (so existing downstream code stays green). The same one command runs as a pre-push `pre-commit` hook (local-first) and a PR-only CI `structure` job (backstop). The whole feature is gated behind a `copier.yml` toggle `enable_structural_gate`.
+
+**Tech Stack:** copier/jinja templating; `diff_cover`'s `diff-quality` (already in the generated project's `dev` group); ruff; pre-commit; GitHub Actions; pytest. Advisory analyzers (`radon`, `vulture`) are invoked on-demand via `uv run --with`, not added as dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-structural-health-gate-design.md`
+
+## Global Constraints
+
+- **Target = the generated project**, edited via `.jinja` files. This repo's own code is out of scope.
+- **Python floor `>=3.11`**; jinja workflow files MUST wrap every `${{ ... }}` GitHub expression in `{% raw %}...{% endraw %}` (existing `ci.yml.jinja` convention).
+- **Copier reads the git index, not the working tree.** To test a change you MUST commit it first (or `git commit --amend --no-edit`) and render with `--vcs-ref=HEAD`. Uncommitted edits render as empty.
+- **Everything new is gated behind `enable_structural_gate`** (`bool`, default `true`). When `false`: no hook, no CI job, no gate command in CLAUDE.md, and `tests/test_structural_gate.py` is not rendered (conditional filename).
+- **Canonical structural select string — byte-identical in all three sites** (pre-commit hook, CI job, CLAUDE.md command): `C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S`
+- **Gate policy:** `--fail-under=100`, non-zero-exit hard-fail. `# noqa` is the escape hatch.
+- **THE RENDER+TEST LOOP** (referenced as "run the loop" in steps below). Run from this repo root after committing your jinja edits:
+  ```bash
+  rm -rf /tmp/smoke
+  uv run --no-project --with copier copier copy --trust --defaults \
+    --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+  cd /tmp/smoke && uv sync --all-extras --all-groups
+  ```
+  Then run the named test, e.g. `uv run pytest tests/test_structural_gate.py -v`. Return to the repo root (`cd -`) before the next edit.
+- **Toggle-off render check** (run once at the end of each task that adds a conditional): render a second smoke with `enable_structural_gate: false` overriding the data file and confirm the gated artifact is absent:
+  ```bash
+  rm -rf /tmp/smoke-off
+  uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD \
+    --data-file tests/fixtures/smoke-answers.yml --data enable_structural_gate=false . /tmp/smoke-off
+  ```
+
+---
+
+## File Structure
+
+- `copier.yml` — **modify**: add `enable_structural_gate` toggle.
+- `tests/fixtures/smoke-answers.yml` — **modify**: add `enable_structural_gate: true`.
+- `pyproject.toml.jinja` — **modify**: add `[tool.ruff.lint.mccabe]`/`[tool.ruff.lint.pylint]` threshold constants and a template-managed `tests/**` `S` per-file-ignore, both toggle-gated.
+- `.pre-commit-config.yaml.jinja` — **modify**: add `default_install_hook_types` + the `structural-diff-gate` pre-push hook (toggle-gated).
+- `.github/workflows/ci.yml.jinja` — **modify**: add the `structure` job (toggle-gated).
+- `CLAUDE.md.jinja` — **modify**: gate command in the acceptance-gates + pre-commit sections; new "Structural health" section (local-shape rules, advisory audit commands, signalling instruction, decay-issue template).
+- `tests/{% raw %}{% if enable_structural_gate %}{% endraw %}test_structural_gate.py{% raw %}{% endif %}{% endraw %}.jinja` — **create**: the behavioral + wiring + anti-drift tests.
+
+---
+
+## Task 1: Two-tier structural selection (mechanism + proof)
+
+Establishes the toggle, the ruff threshold config the diff-pass reads, and proves the core invariant: the structural rules fire as an **overlay** (`--extend-select`) but are absent from the base whole-repo config.
+
+**Files:**
+- Modify: `copier.yml` (append toggle)
+- Modify: `tests/fixtures/smoke-answers.yml`
+- Modify: `pyproject.toml.jinja` (ruff threshold blocks + test S-ignore)
+- Create: `tests/{% raw %}{% if enable_structural_gate %}{% endraw %}test_structural_gate.py{% raw %}{% endif %}{% endraw %}.jinja`
+
+**Interfaces:**
+- Produces: the rendered `tests/test_structural_gate.py` module (later tasks add tests to the **same** file); the canonical select string constant `STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"` defined at module top and reused by later tasks.
+
+- [ ] **Step 1: Add the copier toggle**
+
+In `copier.yml`, append after the `enable_authorization` block:
+
+```yaml
+enable_structural_gate:
+  type: bool
+  default: true
+  help: "Scaffold the diff-scoped structural-health gate: strict ruff structural rules (complexity, god-class, too-many-*, security) enforced on changed lines only via diff-quality, as a pre-push hook and a CI 'structure' job, plus the CLAUDE.md structural-health guidance (local-shape rules, advisory radon/vulture audit, decay-issue template). New code is held to the bar; pre-existing code is never blocked. Leave on unless a project deliberately opts out of structural enforcement."
+```
+
+- [ ] **Step 2: Exercise the toggle in the smoke render**
+
+In `tests/fixtures/smoke-answers.yml`, append:
+
+```yaml
+enable_structural_gate: true
+```
+
+- [ ] **Step 3: Write the failing test (two-tier proof)**
+
+Create `tests/{% raw %}{% if enable_structural_gate %}{% endraw %}test_structural_gate.py{% raw %}{% endif %}{% endraw %}.jinja` with:
+
+```python
+"""Structural-health gate: behavioural, wiring, and anti-drift tests.
+
+These run inside the generated project's suite (and every downstream's CI),
+continuously verifying the diff-scoped structural gate actually enforces what
+the template intends. Only rendered when ``enable_structural_gate`` is true.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Canonical structural ruff selection — MUST stay byte-identical to the string
+# in .pre-commit-config.yaml, .github/workflows/ci.yml, and CLAUDE.md. The
+# anti-drift test in this module enforces that.
+STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A function whose cyclomatic complexity exceeds the mccabe default (10): a
+# long if/elif chain. Written to a temp file and linted via subprocess so this
+# test module itself stays simple (and never trips the gate it is testing).
+OVER_COMPLEX = '''
+def tangled(n):
+    if n == 1:
+        return 1
+    elif n == 2:
+        return 2
+    elif n == 3:
+        return 3
+    elif n == 4:
+        return 4
+    elif n == 5:
+        return 5
+    elif n == 6:
+        return 6
+    elif n == 7:
+        return 7
+    elif n == 8:
+        return 8
+    elif n == 9:
+        return 9
+    elif n == 10:
+        return 10
+    elif n == 11:
+        return 11
+    return 0
+'''
+
+
+def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--output-format", "concise", *args, str(target)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_structural_rule_fires_only_as_overlay(tmp_path: Path) -> None:
+    """C901 fires under --extend-select but NOT under the base project config.
+
+    Guards the core invariant: strict-on-diff, lenient-on-repo. If someone
+    promotes these rules into the whole-repo `select`, the base run starts
+    reporting C901 and this test fails.
+    """
+    target = tmp_path / "snippet.py"
+    target.write_text(OVER_COMPLEX)
+
+    overlay = _ruff([f"--extend-select={STRUCTURAL}"], target)
+    base = _ruff([], target)
+
+    assert "C901" in overlay.stdout, f"overlay should flag C901:\n{overlay.stdout}"
+    assert "C901" not in base.stdout, f"base config must NOT flag C901:\n{base.stdout}"
+```
+
+- [ ] **Step 4: Commit, render, and verify the test FAILS**
+
+```bash
+git add copier.yml tests/fixtures/smoke-answers.yml "tests/{% raw %}{% if enable_structural_gate %}{% endraw %}test_structural_gate.py{% raw %}{% endif %}{% endraw %}.jinja"
+git commit -m "test: two-tier structural selection proof (RED)"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py::test_structural_rule_fires_only_as_overlay -v
+```
+
+Expected: FAIL — `C901` appears in `base.stdout` only if mccabe is misconfigured, but more likely the test errors because `max-complexity` isn't set yet so C901 (even via overlay) may not fire at complexity 12 if the default differs, OR passes spuriously. The intent of RED here: the threshold config in Step 5 makes the overlay deterministic. If it already passes, proceed — Step 5 still locks the thresholds explicitly.
+
+- [ ] **Step 5: Add the ruff threshold constants + test S-ignore (toggle-gated)**
+
+In `pyproject.toml.jinja`, inside `[tool.ruff.lint.per-file-ignores]`, immediately **after** the header comment block and **before** the `# PROJECT-RUFF-IGNORES-START` sentinel, add:
+
+```jinja
+{%- raw %}{% endraw %}{% if enable_structural_gate %}
+# Template-managed: the structural diff-gate adds `S` (security) on the diff
+# pass; assert-based tests would trip S101. Scoped to tests/ so production code
+# is still security-linted on the diff. No-op for the base whole-repo select
+# (which excludes S).
+"tests/**" = ["S101"]
+{% endif %}
+```
+
+Then, after the `[tool.ruff.format]` block (before `[tool.pytest.ini_options]`), add:
+
+```jinja
+{% if enable_structural_gate %}
+# Structural-gate thresholds. These rules are NOT in the whole-repo `select`
+# above — they apply only on the diff via the structural gate's
+# `--extend-select` (see .pre-commit-config.yaml / ci.yml). Values are ruff
+# defaults, surfaced here as editable policy constants.
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 5
+max-branches = 12
+max-returns = 6
+max-statements = 50
+{% endif %}
+```
+
+- [ ] **Step 6: Commit, render, and verify the test PASSES**
+
+```bash
+git add pyproject.toml.jinja
+git commit -m "feat(scaffold): two-tier structural ruff selection + thresholds"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py::test_structural_rule_fires_only_as_overlay -v
+```
+
+Expected: PASS — overlay flags `C901`, base does not.
+
+- [ ] **Step 7: Verify toggle-off render omits the test file and ruff blocks**
+
+Run the toggle-off render (Global Constraints), then:
+
+```bash
+test ! -f /tmp/smoke-off/tests/test_structural_gate.py && echo "OK: test file absent"
+grep -q "tool.ruff.lint.mccabe" /tmp/smoke-off/pyproject.toml && echo "FAIL: mccabe present" || echo "OK: thresholds absent"
+```
+
+Expected: both `OK`.
+
+- [ ] **Step 8: Squash-commit the task**
+
+```bash
+git reset --soft HEAD~2 && git commit -m "feat(scaffold): two-tier structural ruff selection (gate Task 1)
+
+Add enable_structural_gate toggle; ship structural ruff thresholds applied
+only via the diff-gate overlay (not the whole-repo select); prove the
+overlay-only invariant with a rendered test."
+```
+
+---
+
+## Task 2: Diff-quality end-to-end + pre-push hook
+
+Proves the `--options` argv-splitting (the `vale_flags`-class trap) end-to-end, then wires the local-first pre-push hook.
+
+**Files:**
+- Modify: `.pre-commit-config.yaml.jinja`
+- Modify: `tests/test_structural_gate.py.jinja` (add tests to the existing file)
+
+**Interfaces:**
+- Consumes: `STRUCTURAL` constant and `REPO_ROOT` from Task 1's module.
+- Produces: the rendered `.pre-commit-config.yaml` with a `structural-diff-gate` hook and `default_install_hook_types: [pre-commit, pre-push]`.
+
+- [ ] **Step 1: Write the failing end-to-end test (the `--options` trap)**
+
+Append to `tests/test_structural_gate.py.jinja`:
+
+```python
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _diff_quality(repo: Path, extend: bool) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "diff_cover.diff_quality_tool",
+        "--violations=ruff.check",
+        "--compare-branch=main",
+        "--fail-under=100",
+    ]
+    if extend:
+        # EXACTLY the argv element a shell produces from the hook's
+        # --options="--extend-select=..." — this is the splitting under test.
+        cmd.append(f"--options=--extend-select={STRUCTURAL}")
+    return subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+
+
+def test_options_reach_ruff_and_gate_is_diff_scoped(tmp_path: Path) -> None:
+    """A new over-complex function fails the gate ONLY with the structural
+    overlay passed through diff-quality --options; a clean base run passes.
+
+    Proves three things at once: (1) --options actually reaches ruff,
+    (2) the diff scoping works, (3) without the overlay the same diff passes.
+    """
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(["init", "-b", "main"], repo)
+    (repo / "base.py").write_text("x = 1\n")
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "base"], repo)
+
+    _git(["checkout", "-b", "feature"], repo)
+    (repo / "tangled.py").write_text(OVER_COMPLEX)
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "add tangled"], repo)
+
+    with_overlay = _diff_quality(repo, extend=True)
+    without_overlay = _diff_quality(repo, extend=False)
+
+    assert with_overlay.returncode != 0, (
+        "structural overlay must fail the diff gate:\n"
+        f"{with_overlay.stdout}\n{with_overlay.stderr}"
+    )
+    assert without_overlay.returncode == 0, (
+        "base ruff (no structural overlay) must pass the same diff:\n"
+        f"{without_overlay.stdout}\n{without_overlay.stderr}"
+    )
+```
+
+- [ ] **Step 2: Commit, render, verify it FAILS for the right reason**
+
+```bash
+git add tests/test_structural_gate.py.jinja
+git commit -m "test: diff-quality --options end-to-end gate (RED)"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py::test_options_reach_ruff_and_gate_is_diff_scoped -v
+```
+
+Expected: this test should actually **PASS** once rendered, because it exercises `diff-quality` directly (no template wiring needed yet). It is the executable proof that the `--options=--extend-select=...` form works. If it FAILS, the `--options` form is wrong — fix the `cmd.append(...)` form here and mirror the corrected form into Step 3's hook before proceeding. Do not continue past a failing version of this test.
+
+- [ ] **Step 3: Add the pre-push hook**
+
+In `.pre-commit-config.yaml.jinja`, add at the very top of the file (before `repos:`):
+
+```jinja
+{% if enable_structural_gate %}
+# `pre-commit install` wires both stages so the pre-push structural gate is
+# installed alongside the commit-time hooks.
+default_install_hook_types: [pre-commit, pre-push]
+{% endif %}
+```
+
+Then, inside the first `- repo: local` block's `hooks:` list (after the `mypy` hook), add:
+
+```jinja
+{% if enable_structural_gate %}
+      # Structural-health gate: strict ruff structural rules on CHANGED LINES
+      # ONLY (diff vs origin/main), mirroring the CI `structure` job exactly.
+      # bash -c so the shell — not pre-commit's arg splitter — owns the
+      # --options quoting. Pre-push (not commit-time): a commit has no base to
+      # compare and may be partial; pre-push sees the full branch range CI checks.
+      - id: structural-diff-gate
+        name: structural quality (diff vs origin/main)
+        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+{% endif %}
+```
+
+- [ ] **Step 4: Write the wiring-presence test**
+
+Append to `tests/test_structural_gate.py.jinja`:
+
+```python
+def test_precommit_config_wires_pre_push_hook() -> None:
+    text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    assert "default_install_hook_types: [pre-commit, pre-push]" in text
+    assert "id: structural-diff-gate" in text
+    assert "stages: [pre-push]" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+```
+
+- [ ] **Step 5: Commit, render, verify both tests PASS**
+
+```bash
+git add .pre-commit-config.yaml.jinja tests/test_structural_gate.py.jinja
+git commit -m "feat(scaffold): structural diff-gate pre-push hook"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py -k "options_reach_ruff or pre_push_hook" -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Verify toggle-off render omits the hook**
+
+Run the toggle-off render, then:
+
+```bash
+grep -q "structural-diff-gate" /tmp/smoke-off/.pre-commit-config.yaml && echo "FAIL" || echo "OK: hook absent"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 7: Squash-commit the task**
+
+```bash
+git reset --soft HEAD~3 && git commit -m "feat(scaffold): local-first structural diff-gate pre-push hook (gate Task 2)
+
+Prove diff-quality --options reaches ruff and scopes to the diff (the
+vale_flags-class quoting trap, closed end-to-end), then wire the pre-push
+hook + default_install_hook_types so the agent hits the same gate CI runs."
+```
+
+---
+
+## Task 3: CI `structure` job (backstop)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml.jinja`
+- Modify: `tests/test_structural_gate.py.jinja`
+
+**Interfaces:**
+- Consumes: `STRUCTURAL`, `REPO_ROOT`.
+- Produces: rendered `.github/workflows/ci.yml` with a PR-only `structure` job.
+
+- [ ] **Step 1: Write the failing CI-wiring test**
+
+Append to `tests/test_structural_gate.py.jinja`:
+
+```python
+def test_ci_has_structure_job() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert "structure:" in text
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # PR-only, like the diff-cover patch-coverage steps.
+    assert "github.event_name == 'pull_request'" in text
+```
+
+- [ ] **Step 2: Commit, render, verify it FAILS**
+
+```bash
+git add tests/test_structural_gate.py.jinja
+git commit -m "test: CI structure job wiring (RED)"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py::test_ci_has_structure_job -v
+```
+
+Expected: FAIL — `structure:` not found.
+
+- [ ] **Step 3: Add the `structure` job**
+
+In `.github/workflows/ci.yml.jinja`, append at the end of the `jobs:` block (after the `vale:` job), preserving two-space indentation:
+
+```jinja
+{% if enable_structural_gate %}
+
+  structure:
+    name: Structural Quality (diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Diff-scoped, so only meaningful on a PR (needs a base branch to compare).
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Fetch base branch
+        run: git fetch origin {% raw %}${{ github.base_ref }}{% endraw %} --depth=50
+
+      - name: Structural quality (changed lines only)
+        env:
+          BASE_REF: {% raw %}${{ github.base_ref }}{% endraw %}
+        run: |
+          # Skip when the diff touches no Python — mirrors the diff-cover guard.
+          HAS_PY=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -c '\.py$' || true)
+          if [ "$HAS_PY" -eq 0 ]; then
+            echo "No Python source changes — skipping structural diff gate"
+            exit 0
+          fi
+          uv run diff-quality --violations=ruff.check \
+            --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+            --compare-branch="origin/${BASE_REF}" --fail-under=100
+{% endif %}
+```
+
+- [ ] **Step 4: Commit, render, verify the test PASSES**
+
+```bash
+git add .github/workflows/ci.yml.jinja
+git commit -m "feat(scaffold): CI structure job (structural diff backstop)"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py::test_ci_has_structure_job -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Validate the rendered workflow is well-formed YAML**
+
+```bash
+uv run --no-project --with pyyaml python -c "import yaml,sys; yaml.safe_load(open('/tmp/smoke/.github/workflows/ci.yml')); print('OK: ci.yml parses')"
+```
+
+Expected: `OK: ci.yml parses`. (Catches a stray jinja/indentation error in the appended job.)
+
+- [ ] **Step 6: Verify toggle-off render omits the job**
+
+```bash
+grep -q "Structural Quality (diff)" /tmp/smoke-off/.github/workflows/ci.yml && echo "FAIL" || echo "OK: job absent"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 7: Squash-commit the task**
+
+```bash
+git reset --soft HEAD~2 && git commit -m "feat(scaffold): CI structure job as structural diff backstop (gate Task 3)"
+```
+
+---
+
+## Task 4: CLAUDE.md eyes, advisory audit, gate docs + anti-drift test
+
+Documents the gate in the local routine (so the agent knows it exists), adds the local-shape rules + signalling instruction + decay-issue template + advisory audit commands, and locks the three structural select strings against drift.
+
+**Files:**
+- Modify: `CLAUDE.md.jinja`
+- Modify: `tests/test_structural_gate.py.jinja`
+
+**Interfaces:**
+- Consumes: `STRUCTURAL`, `REPO_ROOT`.
+- Produces: a self-contained "Structural health" section in the rendered `CLAUDE.md`; no forward references to Spec 2.
+
+- [ ] **Step 1: Write the failing docs + anti-drift tests**
+
+Append to `tests/test_structural_gate.py.jinja`:
+
+```python
+def test_claudemd_documents_the_gate_command() -> None:
+    text = (REPO_ROOT / "CLAUDE.md").read_text()
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # Advisory audit + eyes content present.
+    assert "radon" in text and "vulture" in text
+    assert "Why it compounds" in text  # decay-issue template marker
+
+
+def test_structural_select_string_is_identical_across_surfaces() -> None:
+    """The select string lives in three rendered files; drift between them is a
+    silent gate weakening. Assert all three carry the canonical string verbatim.
+    """
+    needle = f"--extend-select={STRUCTURAL}"
+    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
+    for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
+        assert needle in text, f"{name} missing canonical structural select"
+```
+
+- [ ] **Step 2: Commit, render, verify they FAIL**
+
+```bash
+git add tests/test_structural_gate.py.jinja
+git commit -m "test: CLAUDE.md gate docs + structural-select anti-drift (RED)"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py -k "claudemd or identical_across" -v
+```
+
+Expected: both FAIL (CLAUDE.md has no structural content yet).
+
+- [ ] **Step 3: Add the gate to the acceptance-gates + pre-commit sections**
+
+In `CLAUDE.md.jinja`, in the `## Hard PR Acceptance Gates` list, add a new numbered item after the patch-coverage item (item 4):
+
+```jinja
+{% if enable_structural_gate %}
+5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, god-class, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
+   ```bash
+   uv run diff-quality --violations=ruff.check \
+     --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+     --compare-branch=origin/main --fail-under=100
+   ```
+   `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
+{% endif %}
+```
+
+In the `## Pre-commit Hooks` section, after the "Run on demand" bullet, add:
+
+```jinja
+{% if enable_structural_gate %}
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range.
+{% endif %}
+```
+
+- [ ] **Step 4: Add the "Structural health" section**
+
+In `CLAUDE.md.jinja`, add a new top-level section (place it after the `## Pre-commit Hooks` section):
+
+```jinja
+{% if enable_structural_gate %}
+## Structural health
+
+The structural gate stops *new* debt; these practices and the advisory audit keep existing debt visible.
+
+**Local-shape rules (checkable while you write):**
+
+- Keep functions short and single-purpose; if a function needs a comment to explain a *section*, that section is a function.
+- Nesting beyond ~3 levels is a smell — extract or invert/early-return.
+- Five parameters is the ceiling; past it, pass an object or split the function.
+- A new responsibility is a **new collaborator, not a longer class**. When a class grows a second reason to change, that reason belongs in its own unit.
+
+**Advisory audit (on demand — run before substantial work in an unfamiliar area, or when about to touch a flagged module):**
+
+```bash
+uv run --with radon python -m radon cc -s -n C src/    # complexity hotspots (grade C+)
+uv run --with radon python -m radon mi -s src/         # maintainability index
+uv run --with vulture vulture src/                     # dead-code candidates
+```
+
+Each analyzer is optional and degrades gracefully if absent. `vulture` over-reports on importable/decorated/framework-registered code — **confirm before deleting** and keep a whitelist.
+
+**When you notice decay outside the current change's scope** — a god class forming, a dead branch, a leaking abstraction, a name that no longer matches behaviour, or an audit hotspot — do **not** fix it inline (scope creep) and do **not** pass over it silently. **Open an issue** using this template:
+
+> **What:** the structural problem in one sentence.
+> **Where:** file/symbol and the metric or observation that flagged it.
+> **Why it compounds:** what gets harder or riskier if it's left.
+> **Suggested direction:** a starting point, not a prescribed refactor.
+
+Constrain issues to **decay that will compound**, not anything imperfect. The diff-gate blocks new debt; these issues are the refactor-later backlog for pre-existing debt — neither blocks the current PR.
+{% endif %}
+```
+
+- [ ] **Step 5: Commit, render, verify the tests PASS**
+
+```bash
+git add CLAUDE.md.jinja tests/test_structural_gate.py.jinja
+git commit -m "docs(scaffold): CLAUDE.md structural-health guidance + anti-drift test"
+```
+
+Run the loop, then:
+
+```bash
+uv run pytest tests/test_structural_gate.py -v
+```
+
+Expected: ALL tests in the module PASS.
+
+- [ ] **Step 6: Verify toggle-off render omits the structural section**
+
+```bash
+grep -q "## Structural health" /tmp/smoke-off/CLAUDE.md && echo "FAIL" || echo "OK: section absent"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 7: Squash-commit the task**
+
+```bash
+git reset --soft HEAD~2 && git commit -m "docs(scaffold): CLAUDE.md structural-health eyes + advisory + anti-drift (gate Task 4)"
+```
+
+---
+
+## Task 5: Full gate verification
+
+Confirms the rendered smoke project passes its **entire** gate (not just the new tests) with the feature on, and that `mkdocs`/lint are unaffected.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Render and run the full generated gate**
+
+Run the loop, then from `/tmp/smoke`:
+
+```bash
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/ tests/
+uv run pytest -x -q
+```
+
+Expected: all green. The new test module is type-checked by mypy (strict) and linted by ruff under the **base** config — confirm it passes both (it uses `from __future__ import annotations`, typed signatures, no `S`-selected base violations).
+
+- [ ] **Step 2: Confirm pre-commit accepts the rendered config**
+
+From `/tmp/smoke` (a git repo after copier init):
+
+```bash
+uv run pre-commit validate-config
+uv run pre-commit install --install-hooks
+git rev-parse --abbrev-ref HEAD >/dev/null && echo "pre-push hook installed:" && ls .git/hooks/pre-push
+```
+
+Expected: config valid; a `.git/hooks/pre-push` file exists (proves `default_install_hook_types` wired the stage).
+
+- [ ] **Step 3: Final repo-root commit note**
+
+No code change. Confirm the feature branch contains exactly four squashed feature commits (Tasks 1–4) plus this plan/spec, and that `git status` at the repo root is clean.
+
+```bash
+cd - && git log --oneline origin/main..HEAD
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- Diff-gate mechanism (diff-quality + extend-select, two-tier) → Tasks 1–2. ✓
+- Pre-push hook + `default_install_hook_types` → Task 2. ✓
+- CI `structure` backstop → Task 3. ✓
+- `copier.yml` toggle → Task 1. ✓
+- Thresholds as policy constants + `tests/` S-ignore → Task 1. ✓
+- Advisory audit (documented commands) → Task 4. ✓
+- Eyes: local-shape rules, signalling, decay-issue template, ownership → Task 4. ✓
+- All five spec tests (two-tier, `--options` splitting, pre-push wiring, CI wiring, doc/hook anti-drift) → Tasks 1–4. ✓
+- Failure modes (ordering/base fetch, S in tests, no-diff renders, hook-not-installed, stale origin/main) → handled in CI guard (Task 3), per-file-ignore (Task 1), CI `if` (Task 3), Task 5 hook-install check, and documented in CLAUDE.md (Task 4). ✓
+- No forward references to Spec 2 in shipped prose → Task 4 prose is self-contained. ✓
+
+**Placeholder scan:** no TBD/TODO/"handle edge cases"; every code step shows complete content. ✓
+
+**Type consistency:** `STRUCTURAL`, `REPO_ROOT`, `_ruff`, `_git`, `_diff_quality`, `OVER_COMPLEX` defined in Task 1/2 and reused consistently; the canonical select string is identical everywhere (and Task 4 adds the test that enforces it). ✓

--- a/docs/superpowers/plans/2026-06-28-structural-health-gate.md
+++ b/docs/superpowers/plans/2026-06-28-structural-health-gate.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship a diff-scoped structural-health layer into generated projects — a blocking structural diff-gate (pre-push hook + CI backstop), a documented local advisory audit, and CLAUDE.md agent "eyes" — so agent-authored code can't grow structural debt and the agent reproduces every gate locally before CI.
 
-**Architecture:** Strict structural ruff rules (`C901`, `PLR0904`, `PLR0911-0915`, `S`) are applied **only to the diff** via `diff-quality --violations=ruff.check --options=--extend-select=...`, never added to the whole-repo `ruff check` (so existing downstream code stays green). The same one command runs as a pre-push `pre-commit` hook (local-first) and a PR-only CI `structure` job (backstop). The whole feature is gated behind a `copier.yml` toggle `enable_structural_gate`.
+**Architecture:** Strict structural ruff rules (`C901`, `PLR0911`-`PLR0915` excl. preview-only `PLR0904`/`PLR0914`, `S`) are applied **only to the diff** via `diff-quality --violations=ruff.check --options=--extend-select=...`, never added to the whole-repo `ruff check` (so existing downstream code stays green). The same one command runs as a pre-push `pre-commit` hook (local-first) and a PR-only CI `structure` job (backstop). The whole feature is gated behind a `copier.yml` toggle `enable_structural_gate`.
 
 **Tech Stack:** copier/jinja templating; `diff_cover`'s `diff-quality` (already in the generated project's `dev` group); ruff; pre-commit; GitHub Actions; pytest. Advisory analyzers (`radon`, `vulture`) are invoked on-demand via `uv run --with`, not added as dependencies.
 
@@ -16,7 +16,7 @@
 - **Python floor `>=3.11`**; jinja workflow files MUST wrap every `${{ ... }}` GitHub expression in `{% raw %}...{% endraw %}` (existing `ci.yml.jinja` convention).
 - **Copier reads the git index, not the working tree.** To test a change you MUST commit it first (or `git commit --amend --no-edit`) and render with `--vcs-ref=HEAD`. Uncommitted edits render as empty.
 - **Everything new is gated behind `enable_structural_gate`** (`bool`, default `true`). When `false`: no hook, no CI job, no gate command in CLAUDE.md, and `tests/test_structural_gate.py` is not rendered (conditional filename).
-- **Canonical structural select string — byte-identical in all three sites** (pre-commit hook, CI job, CLAUDE.md command): `C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S`
+- **Canonical structural select string — byte-identical in all three sites** (pre-commit hook, CI job, CLAUDE.md command): `C901,PLR0911,PLR0912,PLR0913,PLR0915,S`
 - **Gate policy:** `--fail-under=100`, non-zero-exit hard-fail. `# noqa` is the escape hatch.
 - **THE RENDER+TEST LOOP** (referenced as "run the loop" in steps below). Run from this repo root after committing your jinja edits:
   ```bash
@@ -58,7 +58,7 @@ Establishes the toggle, the ruff threshold config the diff-pass reads, and prove
 - Create: `tests/{% raw %}{% if enable_structural_gate %}{% endraw %}test_structural_gate.py{% raw %}{% endif %}{% endraw %}.jinja`
 
 **Interfaces:**
-- Produces: the rendered `tests/test_structural_gate.py` module (later tasks add tests to the **same** file); the canonical select string constant `STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"` defined at module top and reused by later tasks.
+- Produces: the rendered `tests/test_structural_gate.py` module (later tasks add tests to the **same** file); the canonical select string constant `STRUCTURAL = "C901,PLR0911,PLR0912,PLR0913,PLR0915,S"` defined at module top and reused by later tasks.
 
 - [ ] **Step 1: Add the copier toggle**
 
@@ -100,7 +100,7 @@ from pathlib import Path
 # Canonical structural ruff selection — MUST stay byte-identical to the string
 # in .pre-commit-config.yaml, .github/workflows/ci.yml, and CLAUDE.md. The
 # anti-drift test in this module enforces that.
-STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"
+STRUCTURAL = "C901,PLR0911,PLR0912,PLR0913,PLR0915,S"
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -194,7 +194,7 @@ In `pyproject.toml.jinja`, inside `[tool.ruff.lint.per-file-ignores]`, immediate
 # pass; assert-based tests would trip S101. Scoped to tests/ so production code
 # is still security-linted on the diff. No-op for the base whole-repo select
 # (which excludes S).
-"tests/**" = ["S101"]
+"tests/**" = ["S101", "S603", "S607"]
 {% endif %}
 ```
 
@@ -368,7 +368,7 @@ Then, inside the first `- repo: local` block's `hooks:` list (after the `mypy` h
       # compare and may be partial; pre-push sees the full branch range CI checks.
       - id: structural-diff-gate
         name: structural quality (diff vs origin/main)
-        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
         language: system
         pass_filenames: false
         stages: [pre-push]
@@ -515,7 +515,7 @@ In `.github/workflows/ci.yml.jinja`, append at the end of the `jobs:` block (aft
             exit 0
           fi
           uv run diff-quality --violations=ruff.check \
-            --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+            --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
             --compare-branch="origin/${BASE_REF}" --fail-under=100
 {% endif %}
 ```
@@ -621,7 +621,7 @@ In `CLAUDE.md.jinja`, in the `## Hard PR Acceptance Gates` list, add a new numbe
 5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, god-class, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
    ```bash
    uv run diff-quality --violations=ruff.check \
-     --options="--extend-select=C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S" \
+     --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
      --compare-branch=origin/main --fail-under=100
    ```
    `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.

--- a/docs/superpowers/plans/2026-06-28-structural-health-gate.md
+++ b/docs/superpowers/plans/2026-06-28-structural-health-gate.md
@@ -136,8 +136,16 @@ def tangled(n):
 
 
 def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    # --config pins THIS project's pyproject.toml. ruff otherwise discovers
+    # config from the target file's directory (tmp_path here), which would test
+    # ruff's defaults instead of the project's `select` — the base-config
+    # assertion below must reflect the project's real selection.
     return subprocess.run(
-        [sys.executable, "-m", "ruff", "check", "--output-format", "concise", *args, str(target)],
+        [
+            sys.executable, "-m", "ruff", "check",
+            "--config", str(REPO_ROOT / "pyproject.toml"),
+            "--output-format", "concise", *args, str(target),
+        ],
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,

--- a/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
@@ -77,16 +77,16 @@ dependency, no new tooling.
 from the whole-repo `[tool.ruff.lint] select`:
 
 - `C901` — mccabe cyclomatic complexity
-- `PLR0904` — too-many-public-methods (god-class by shape; radon's per-block score
-  misses it)
-- `PLR0911` / `PLR0912` / `PLR0913` / `PLR0914` / `PLR0915` — too-many
-  returns / branches / args / locals / statements
+- `PLR0911` / `PLR0912` / `PLR0913` / `PLR0915` — too-many
+  returns / branches / args / statements
 - `S` — security (bandit-equivalent)
 
-Diff attribution is by line: a `C901`/`PLR0904` violation is reported at the
-function/class `def` line, so a **new** complex function or god-class (its `def`
-is in the diff) blocks, while adding one line inside an existing complex function
-(its `def` unchanged) does not. This is the intended "don't grow worse" semantics.
+> `PLR0904` (god-class) and `PLR0914` (too-many-locals) were dropped: both are ruff preview-only rules and enabling them requires the global `--preview` flag, which would ship all of ruff's unstable preview behaviour to downstream — god-class detection stays with the CLAUDE.md eyes and the deferred full-repo audit.
+
+Diff attribution is by line: a `C901` violation is reported at the function `def`
+line, so a **new** complex function (its `def` is in the diff) blocks, while
+adding one line inside an existing complex function (its `def` unchanged) does
+not. This is the intended "don't grow worse" semantics.
 
 **Thresholds** (`max-complexity`, `max-args`, `max-statements`, …) live as
 commented policy constants in the rendered `pyproject.toml` under

--- a/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
@@ -1,0 +1,244 @@
+# Structural-health gate (Spec 1: local-first gate + eyes + advisory)
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-06-28
+**Scope:** the *generated* project (ships via `.jinja`); additive/advisory to the
+four downstream consumers.
+
+## Problem
+
+The template ships strong **correctness** gates (ruff lint/format, mypy strict,
+pytest, 80% patch coverage via diff-cover, pip-audit, gitleaks, vale) and **zero
+structural** ones. Structure is an orthogonal axis: cyclomatic complexity, god
+classes/functions, dead code, leaking abstractions, names that drift from
+behaviour. Without a structural layer, agent-authored ("vibe-coded") changes grow
+this debt unchecked, and the debt is invisible until a human reads the code.
+
+The goal is to **stop structural debt from growing** while **never blocking on
+pre-existing debt**, and to surface bigger pre-existing problems as refactor-later
+issues — the structural analogue of how patch-coverage gates the diff (hard) while
+full coverage is informational (soft).
+
+## Two non-negotiable constraints (why the obvious design is wrong)
+
+1. **This is a template feeding four downstream repos.** Adding strict structural
+   rules to the *whole-repo* `ruff check` (the brief's original "Door" bucket of
+   absolute thresholds) would make every consumer's next `copier update` fail CI
+   wherever their *existing* code trips a new rule. The gate must therefore be
+   **diff-scoped**: new/changed code is held to the bar; existing code is not,
+   until it is touched.
+
+2. **CI-only enforcement guarantees whack-a-mole.** If the only place the gate
+   runs is CI, the coding agent commits, pushes, watches CI go red, and patches
+   blindly against a signal it cannot reproduce locally. Every gate must be
+   **runnable locally and named in CLAUDE.md**, with CI as a backstop — not the
+   primary signal.
+
+## Decomposition
+
+This is Spec 1 of two. The split is along **"what the agent runs locally" (now)**
+vs **"what CI persists for everyone" (later)** — *not* "blocking now / advisory
+later". The advisory full-repo signal is local-first because its primary consumer
+is the agent, and the agent is local.
+
+|                         | Spec 1 — local-first (the agent)                       | Spec 2 — CI persistence (deferred)                          |
+| ----------------------- | ------------------------------------------------------ | ----------------------------------------------------------- |
+| **Diff-gate** (block)   | pre-push hook + CLAUDE.md command                      | CI `structure` job (backstop) — *included in Spec 1*        |
+| **Full-repo** (advise)  | documented analyzer commands + CLAUDE.md when/what     | committed baseline, deduped+capped issue filing, ratchet    |
+| **Eyes** (qualitative)  | CLAUDE.md signalling + decay-issue template            | —                                                           |
+
+Spec 2 (the committed `structural-baseline.json`, automated deduped/capped issue
+filing, and the ratchet that tightens over time) is **explicitly out of scope
+here** and is the part that genuinely needs CI and the most tuning. Spec 1 ships
+nothing that forward-references it.
+
+## Spec 1 design
+
+### 1. Diff-gate — blocking, local-first
+
+**Mechanism (de-risked empirically).** `diff-quality` from the `diff_cover`
+package (already in the `dev` dependency group) runs a linter and reports
+violations **only on changed lines**, with `--fail-under`. Its `ruff.check` driver
+runs `ruff check --output-format pylint`; its `--options` flag passes arguments
+straight through to ruff. So:
+
+```bash
+uv run diff-quality --violations=ruff.check \
+  --options="--extend-select=<STRUCTURAL>" \
+  --compare-branch=origin/main --fail-under=100
+```
+
+runs ruff with the strict structural rules **added on top of** the project config,
+filtered to the diff. The whole-repo `ruff check` keeps **today's** selection, so
+existing downstream code stays green. Two-tier selection, one already-present
+dependency, no new tooling.
+
+**`<STRUCTURAL>` rule set** — complexity + size + security, deliberately **absent**
+from the whole-repo `[tool.ruff.lint] select`:
+
+- `C901` — mccabe cyclomatic complexity
+- `PLR0904` — too-many-public-methods (god-class by shape; radon's per-block score
+  misses it)
+- `PLR0911` / `PLR0912` / `PLR0913` / `PLR0914` / `PLR0915` — too-many
+  returns / branches / args / locals / statements
+- `S` — security (bandit-equivalent)
+
+Diff attribution is by line: a `C901`/`PLR0904` violation is reported at the
+function/class `def` line, so a **new** complex function or god-class (its `def`
+is in the diff) blocks, while adding one line inside an existing complex function
+(its `def` unchanged) does not. This is the intended "don't grow worse" semantics.
+
+**Thresholds** (`max-complexity`, `max-args`, `max-statements`, …) live as
+commented policy constants in the rendered `pyproject.toml` under
+`[tool.ruff.lint.mccabe]` / `[tool.ruff.lint.pylint]`, starting at ruff defaults
+(complexity 10, args 5, statements 50). One commented block; editable on
+instantiation.
+
+**Escape hatch.** `# noqa: C901` (etc.) plus a justifying comment, for genuinely
+irreducible new code.
+
+**Local-first placement.** A pre-commit **pre-push** hook is the natural home: a
+commit-time hook has no base branch and sees only partial commits, but pre-push
+has the full branch and a base, so the hook runs the *identical* command CI runs
+over the *same* range (`HEAD` vs `origin/main`). Green-locally ⇒ green-in-CI by
+construction.
+
+```yaml
+# .pre-commit-config.yaml.jinja
+default_install_hook_types: [pre-commit, pre-push]
+# ...
+  - repo: local
+    hooks:
+      - id: structural-diff-gate
+        name: structural quality (diff vs origin/main)
+        entry: uv run diff-quality --violations=ruff.check
+               --options=--extend-select=<STRUCTURAL>
+               --compare-branch=origin/main --fail-under=100
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+```
+
+The exact `--options` quoting above is illustrative, not asserted: how
+`diff-quality` splits the `--options` string into ruff argv is resolved
+empirically by test #2 below, and the hook/CI commands are then written to match
+that verified form byte-for-byte.
+
+The strict rules stay **out** of the commit-time whole-file `ruff check` —
+including them there would re-fail pre-existing debt in any file the agent touches,
+which is the *other* whack-a-mole.
+
+**CI backstop.** A new PR-only `structure` job in `ci.yml.jinja`, structurally a
+sibling of the existing diff-cover steps: checkout `fetch-depth: 0`, fetch the base
+branch, skip when the diff touches no `.py` files, then run the same
+`diff-quality` command. Non-zero exit fails the job; downstream marks it required
+in branch protection (like `codecov/patch`).
+
+**Toggle.** `copier.yml` gains `enable_structural_gate` (`bool`, default `true`),
+mirroring `enable_authorization` / `include_mcp_apps_scaffold`. When `false`, the
+hook, the CI job, and the CLAUDE.md gate line are not rendered.
+
+### 2. Local advisory full-repo audit — non-blocking
+
+**Delivery: documented commands only** (no vendored script → zero cross-repo sync
+burden; each analyzer optional and degrades gracefully if absent). CLAUDE.md.jinja
+documents on-demand invocations:
+
+```bash
+uv run --with radon python -m radon cc -s -n C src/    # complexity hotspots
+uv run --with radon python -m radon mi -s src/         # maintainability index
+uv run --with vulture vulture src/                     # dead-code candidates
+```
+
+CLAUDE.md states **when** to run (before substantial work in an unfamiliar area;
+when about to touch a flagged module) and **what to do** with the output:
+
+- File a **refactor-later issue** (using the decay template below, via the
+  writing-issues skill) for a **tier-1 hotspot**, an **extreme single-function
+  complexity outlier**, or a **god-class**.
+- **Never fix inline** — that is scope creep.
+- **vulture findings need confirmation** before action (it over-reports on
+  importable/decorated/framework-registered code); keep a whitelist.
+
+Raw analyzer output without churn weighting is the accepted tradeoff for
+commands-only delivery; churn × complexity hotspot fusion belongs with Spec 2's
+baseline.
+
+### 3. Eyes — qualitative, in CLAUDE.md.jinja
+
+Added to the generated project's CLAUDE.md (the gate routine integrates into the
+existing **Hard PR Acceptance Gates** / **Pre-commit Hooks** sections):
+
+- **Local-shape rules** — concrete and checkable: function length, nesting depth,
+  parameter count ≤ 5, "a new responsibility is a new collaborator, not a longer
+  class".
+- **Full local-gate routine names every gate inline** — ruff (check then format),
+  mypy, pytest, diff-cover patch coverage, **and the structural diff command** —
+  so the agent knows the structural gate exists even if hooks are not installed.
+- **Signalling instruction** — when you notice decay that will *compound*
+  (god class forming, dead branch, leaking abstraction, a name no longer matching
+  behaviour) **outside the scope of the current change**, neither fix it inline
+  (scope creep) nor pass over it silently: open an issue. Constrained to "decay
+  that will compound", not "anything imperfect".
+- **Decay-issue template** — What / Where / Why it compounds / Suggested direction.
+- **Ownership statement** — the diff-gate blocks new code; pre-existing problems
+  get filed as refactor-later issues. **No forward reference** to the deferred
+  Spec 2 ratchet; the prose is self-contained and reviewable on its own.
+
+## Testing (TDD; runs inside the smoke gate)
+
+A new `tests/test_structural_gate.py.jinja` (skipped/absent when
+`enable_structural_gate` is `false`):
+
+1. **Two-tier proof** — a deliberately over-complex snippet fires the structural
+   rule under `--extend-select=<STRUCTURAL>` but **not** under the project's base
+   config. Guards the core invariant (strict-on-diff, lenient-on-repo) and that
+   the structural rules are never accidentally promoted into the whole-repo
+   `select`.
+2. **`--options` argv-splitting** — an empirical red test that ruff actually
+   *receives* the extended rules through `diff-quality --options`. This closes the
+   `vale_flags`-class quoting trap (a string passed to a tool that splits it into
+   argv): write the failing test first, confirm the splitting behaviour, then wire
+   the hook/CI to match exactly.
+3. **Pre-push wiring** — rendered `.pre-commit-config.yaml` contains the
+   `structural-diff-gate` hook with `stages: [pre-push]` and the file declares
+   `default_install_hook_types: [pre-commit, pre-push]`.
+4. **CI wiring** — rendered `.github/workflows/ci.yml` contains the `structure`
+   job invoking `diff-quality` with `--extend-select`.
+5. **Doc/hook anti-drift** — rendered `CLAUDE.md` local-gate routine contains the
+   structural command, so the documented command and the hook command cannot
+   silently diverge.
+
+## Failure modes tracked
+
+- **Ordering** — the base branch must be fetched before `diff-quality` runs in CI,
+  or the compare resolves against a missing/stale ref. Mirrors the existing
+  diff-cover "fetch base branch" step.
+- **`S` in tests** — `S101` (assert) and friends would fire on new test lines.
+  Rendered `pyproject.toml` `[tool.ruff.lint.per-file-ignores]` adds the test-only
+  `S` ignores (no-op for the base select, active for the diff pass).
+- **No-diff renders** — in template-ci's smoke render there is no PR diff →
+  `diff-quality` reports 100% → passes (step present but inert). Correct.
+- **Hook not installed** — if `pre-commit install` was skipped, the pre-push hook
+  is silent; CI still catches the violation, and CLAUDE.md's documented command is
+  the manual fallback. Bootstrap installs hooks; implementation confirms it picks
+  up the `pre-push` type via `default_install_hook_types`.
+- **Stale `origin/main` at push** — the hook compares against the local
+  `origin/main` ref without fetching (no network in hooks). Minor staleness
+  possible; CI does the authoritative fetch+compare.
+
+## Policy decisions (settled)
+
+- `--fail-under=100` — zero new structural violations on the diff; `# noqa` is the
+  escape hatch.
+- **Non-zero-exit hard-fail** (not a soft commit status) — so the *one* command is
+  byte-identical as pre-push hook and CI gate. The `codecov/patch` soft-status
+  pattern cannot run in a hook and would break local/CI parity.
+- **Documented commands only** for the advisory audit — no vendored `audit.py`.
+
+## Out of scope (Spec 2)
+
+Committed `structural-baseline.json`; automated, deduped, capped issue filing in
+CI; ratchet that tightens ceilings after genuine improvement; churn × complexity
+hotspot fusion. Also out of scope for both specs: applying the layer to this
+template repo's own `scripts/` (generated projects only).

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -93,6 +93,13 @@ ignore = ["E501"]
 # FastMCP dependency injection pattern — B008 is a false positive here.
 # Context/FastMCP/Service imports must stay runtime (not TYPE_CHECKING) for
 # DI resolution — TC001/TC002/TC003.
+{% if enable_structural_gate %}
+# Template-managed: the structural diff-gate adds `S` (security) on the diff
+# pass; assert-based tests would trip S101. Scoped to tests/ so production code
+# is still security-linted on the diff. No-op for the base whole-repo select
+# (which excludes S).
+"tests/**" = ["S101"]
+{% endif %}
 # PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below
 # for your project's real source/test paths (split _server_apps.py into
 # per-domain modules, rename tests, add per-file overrides as needed); kept
@@ -114,6 +121,21 @@ known-first-party = ["{{ python_module }}"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+{% if enable_structural_gate %}
+# Structural-gate thresholds. These rules are NOT in the whole-repo `select`
+# above — they apply only on the diff via the structural gate's
+# `--extend-select` (see .pre-commit-config.yaml / ci.yml). Values are ruff
+# defaults, surfaced here as editable policy constants.
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 5
+max-branches = 12
+max-returns = 6
+max-statements = 50
+{% endif %}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -109,12 +109,18 @@ ignore = ["E501"]
 # for your project's real source/test paths (split _server_apps.py into
 # per-domain modules, rename tests, add per-file overrides as needed); kept
 # across copier update.
-"src/{{ python_module }}/cli.py" = ["B008"]
-"src/{{ python_module }}/_server_deps.py" = ["B008", "TC002", "TC003"]
-"src/{{ python_module }}/_server_apps.py" = ["B008", "TC001", "TC002"]
-"src/{{ python_module }}/tools.py" = ["B008", "TC001", "TC002"]
-"src/{{ python_module }}/resources.py" = ["B008", "TC001", "TC002"]
-"src/{{ python_module }}/prompts.py" = ["B008", "TC002"]
+# PLR0913 (too-many-args) is ignored on the DI/wiring modules below: FastMCP
+# inflates their arg counts with `Context` + `Depends()` injections, so the
+# structural diff-gate would flag every new tool/resource/prompt and make
+# `# noqa: PLR0913` routine. It only bites when enable_structural_gate is on
+# (PLR0913 isn't in the base select); domain modules keep the check, and
+# C901/PLR0912/PLR0915 still catch a genuinely complex tool here.
+"src/{{ python_module }}/cli.py" = ["B008", "PLR0913"]
+"src/{{ python_module }}/_server_deps.py" = ["B008", "TC002", "TC003", "PLR0913"]
+"src/{{ python_module }}/_server_apps.py" = ["B008", "TC001", "TC002", "PLR0913"]
+"src/{{ python_module }}/tools.py" = ["B008", "TC001", "TC002", "PLR0913"]
+"src/{{ python_module }}/resources.py" = ["B008", "TC001", "TC002", "PLR0913"]
+"src/{{ python_module }}/prompts.py" = ["B008", "TC002", "PLR0913"]
 "tests/conftest.py" = ["TC002", "TC003"]
 "tests/test_smoke.py" = ["TC002", "TC003"]
 "tests/test_tools.py" = ["TC002"]

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -95,10 +95,12 @@ ignore = ["E501"]
 # DI resolution — TC001/TC002/TC003.
 {% if enable_structural_gate %}
 # Template-managed: the structural diff-gate adds `S` (security) on the diff
-# pass; assert-based tests would trip S101. Scoped to tests/ so production code
-# is still security-linted on the diff. No-op for the base whole-repo select
-# (which excludes S).
-"tests/**" = ["S101"]
+# pass; assert-based tests would trip S101. S603/S607 cover the shipped
+# structural-gate test, which legitimately shells out via subprocess (S603) with
+# partial executable paths like git/ruff/diff-quality (S607) — both are safe in
+# test code and would otherwise cause the gate to self-block on its own test
+# module. No-op for the base whole-repo select (which excludes S).
+"tests/**" = ["S101", "S603", "S607"]
 {% endif %}
 # PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below
 # for your project's real source/test paths (split _server_apps.py into

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -95,11 +95,13 @@ ignore = ["E501"]
 # DI resolution — TC001/TC002/TC003.
 {% if enable_structural_gate %}
 # Template-managed: the structural diff-gate adds `S` (security) on the diff
-# pass; assert-based tests would trip S101. S603/S607 cover the shipped
-# structural-gate test, which legitimately shells out via subprocess (S603) with
-# partial executable paths like git/ruff/diff-quality (S607) — both are safe in
-# test code and would otherwise cause the gate to self-block on its own test
-# module. No-op for the base whole-repo select (which excludes S).
+# pass; assert-based tests would trip S101. The shipped structural-gate test
+# legitimately shells out via subprocess (S603), invoking `git` by bare name
+# (S607, a partial executable path); the ruff/diff-quality calls go through
+# `sys.executable -m ...` (an absolute path) so they are S603-only. Ignoring
+# S101/S603/S607 in tests keeps the gate from self-blocking on its own test
+# module; all three are safe in test code. No-op for the base whole-repo select
+# (which excludes S).
 "tests/**" = ["S101", "S603", "S607"]
 {% endif %}
 # PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -95,13 +95,14 @@ ignore = ["E501"]
 # DI resolution — TC001/TC002/TC003.
 {% if enable_structural_gate %}
 # Template-managed: the structural diff-gate adds `S` (security) on the diff
-# pass; assert-based tests would trip S101. The shipped structural-gate test
-# legitimately shells out via subprocess (S603), invoking `git` by bare name
-# (S607, a partial executable path); the ruff/diff-quality calls go through
-# `sys.executable -m ...` (an absolute path) so they are S603-only. Ignoring
-# S101/S603/S607 in tests keeps the gate from self-blocking on its own test
+# pass, so the shipped structural-gate test would self-block: its asserts trip
+# S101, and its bare-name `git` call trips S607 (a partial executable path —
+# the `sys.executable -m ...` calls are NOT flagged). S603 (subprocess use) is
+# included defensively: inert in current ruff but emitted by some versions.
+# Ignoring all three in tests keeps the gate from self-blocking on its own test
 # module; all three are safe in test code. No-op for the base whole-repo select
-# (which excludes S).
+# (which excludes S). If your project needs its own tests/** ignores, EXTEND
+# this list in place — do not add a second "tests/**" key (duplicate TOML key).
 "tests/**" = ["S101", "S603", "S607"]
 {% endif %}
 # PROJECT-RUFF-IGNORES-START — replace, extend, or override the entries below

--- a/tests/fixtures/smoke-answers.yml
+++ b/tests/fixtures/smoke-answers.yml
@@ -10,3 +10,4 @@ github_org: pvliesdonk
 docker_registry: ghcr.io/pvliesdonk
 include_mcp_apps_scaffold: true
 enable_authorization: true
+enable_structural_gate: true

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -1,0 +1,83 @@
+"""Structural-health gate: behavioural, wiring, and anti-drift tests.
+
+These run inside the generated project's suite (and every downstream's CI),
+continuously verifying the diff-scoped structural gate actually enforces what
+the template intends. Only rendered when ``enable_structural_gate`` is true.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Canonical structural ruff selection — MUST stay byte-identical to the string
+# in .pre-commit-config.yaml, .github/workflows/ci.yml, and CLAUDE.md. The
+# anti-drift test in this module enforces that.
+STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A function whose cyclomatic complexity exceeds the mccabe default (10): a
+# long if/elif chain. Written to a temp file and linted via subprocess so this
+# test module itself stays simple (and never trips the gate it is testing).
+OVER_COMPLEX = '''
+def tangled(n):
+    if n == 1:
+        return 1
+    elif n == 2:
+        return 2
+    elif n == 3:
+        return 3
+    elif n == 4:
+        return 4
+    elif n == 5:
+        return 5
+    elif n == 6:
+        return 6
+    elif n == 7:
+        return 7
+    elif n == 8:
+        return 8
+    elif n == 9:
+        return 9
+    elif n == 10:
+        return 10
+    elif n == 11:
+        return 11
+    return 0
+'''
+
+
+def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    # --config pins THIS project's pyproject.toml. ruff otherwise discovers
+    # config from the target file's directory (tmp_path here), which would test
+    # ruff's defaults instead of the project's `select` — the base-config
+    # assertion below must reflect the project's real selection.
+    return subprocess.run(
+        [
+            sys.executable, "-m", "ruff", "check",
+            "--config", str(REPO_ROOT / "pyproject.toml"),
+            "--output-format", "concise", *args, str(target),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_structural_rule_fires_only_as_overlay(tmp_path: Path) -> None:
+    """C901 fires under --extend-select but NOT under the base project config.
+
+    Guards the core invariant: strict-on-diff, lenient-on-repo. If someone
+    promotes these rules into the whole-repo `select`, the base run starts
+    reporting C901 and this test fails.
+    """
+    target = tmp_path / "snippet.py"
+    target.write_text(OVER_COMPLEX)
+
+    overlay = _ruff([f"--extend-select={STRUCTURAL}"], target)
+    base = _ruff([], target)
+
+    assert "C901" in overlay.stdout, f"overlay should flag C901:\n{overlay.stdout}"
+    assert "C901" not in base.stdout, f"base config must NOT flag C901:\n{base.stdout}"

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -1,9 +1,9 @@
 """Structural-health gate: behavioural, wiring, and anti-drift tests.
 
-These run inside the generated project's suite (and any downstream's CI that
-keeps the structural gate enabled),
-continuously verifying the diff-scoped structural gate actually enforces what
-the template intends. Only rendered when ``enable_structural_gate`` is true.
+These run inside the rendered project's suite (and any downstream's suite that
+keeps the structural gate enabled), continuously verifying that this project's
+own rendered gate artifacts (pre-commit hook, CI job, pyproject, CLAUDE.md) are
+wired correctly. Only rendered when ``enable_structural_gate`` is true.
 """
 
 from __future__ import annotations
@@ -91,6 +91,25 @@ def test_structural_rule_fires_only_as_overlay(tmp_path: Path) -> None:
     assert "C901" not in base.stdout, f"base config must NOT flag C901:\n{base.stdout}"
 
 
+def test_security_rules_are_overlay_only(tmp_path: Path) -> None:
+    """The `S` (security) family fires under --extend-select but NOT under the
+    base config — the same strict-on-diff/lenient-on-repo invariant as C901, for
+    the other high-stakes cluster. If `S` were promoted into the whole-repo
+    `select`, the tests/** per-file-ignores would silently become load-bearing
+    for the entire repo lint, not just the gate; this test fails first.
+    """
+    target = tmp_path / "insecure.py"
+    # `assert` trips S101; the snippet lives outside tests/, so the tests/**
+    # per-file-ignores do not apply and the overlay's `S` is free to fire.
+    target.write_text("def check(x):\n    assert x\n    return x\n")
+
+    overlay = _ruff([f"--extend-select={STRUCTURAL}"], target)
+    base = _ruff([], target)
+
+    assert "S101" in overlay.stdout, f"overlay should flag S101:\n{overlay.stdout}"
+    assert "S101" not in base.stdout, f"base config must NOT flag S101:\n{base.stdout}"
+
+
 def _git(args: list[str], cwd: Path) -> None:
     subprocess.run(
         ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
@@ -154,10 +173,11 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     assert "default_install_hook_types: [pre-commit, pre-push]" in text
     assert "id: structural-diff-gate" in text
     assert "stages: [pre-push]" in text
-    # The bash -c wrapper is load-bearing: it makes the shell (not pre-commit's
-    # arg splitter) own the --options quoting verified by the end-to-end test.
-    # Assert it so a refactor that drops it can't pass silently.
     assert "language: system" in text
+    # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
+    # pre-commit's arg splitter) own the --options quoting verified by the
+    # end-to-end test. Assert it so a refactor to a direct `uv run` entry —
+    # which would break that quoting — can't pass silently.
     assert "entry: bash -c " in text
     assert f"--extend-select={STRUCTURAL}" in text
 

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -81,3 +81,69 @@ def test_structural_rule_fires_only_as_overlay(tmp_path: Path) -> None:
 
     assert "C901" in overlay.stdout, f"overlay should flag C901:\n{overlay.stdout}"
     assert "C901" not in base.stdout, f"base config must NOT flag C901:\n{base.stdout}"
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _diff_quality(repo: Path, extend: bool) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "diff_cover.diff_quality_tool",
+        "--violations=ruff.check",
+        "--compare-branch=main",
+        "--fail-under=100",
+    ]
+    if extend:
+        # EXACTLY the argv element a shell produces from the hook's
+        # --options="--extend-select=..." — this is the splitting under test.
+        cmd.append(f"--options=--extend-select={STRUCTURAL}")
+    return subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+
+
+def test_options_reach_ruff_and_gate_is_diff_scoped(tmp_path: Path) -> None:
+    """A new over-complex function fails the gate ONLY with the structural
+    overlay passed through diff-quality --options; a clean base run passes.
+
+    Proves three things at once: (1) --options actually reaches ruff,
+    (2) the diff scoping works, (3) without the overlay the same diff passes.
+    """
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(["init", "-b", "main"], repo)
+    (repo / "base.py").write_text("x = 1\n")
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "base"], repo)
+
+    _git(["checkout", "-b", "feature"], repo)
+    (repo / "tangled.py").write_text(OVER_COMPLEX)
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "add tangled"], repo)
+
+    with_overlay = _diff_quality(repo, extend=True)
+    without_overlay = _diff_quality(repo, extend=False)
+
+    assert with_overlay.returncode != 0, (
+        "structural overlay must fail the diff gate:\n"
+        f"{with_overlay.stdout}\n{with_overlay.stderr}"
+    )
+    assert without_overlay.returncode == 0, (
+        "base ruff (no structural overlay) must pass the same diff:\n"
+        f"{without_overlay.stdout}\n{without_overlay.stderr}"
+    )
+
+
+def test_precommit_config_wires_pre_push_hook() -> None:
+    text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    assert "default_install_hook_types: [pre-commit, pre-push]" in text
+    assert "id: structural-diff-gate" in text
+    assert "stages: [pre-push]" in text
+    assert f"--extend-select={STRUCTURAL}" in text

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -14,7 +14,7 @@ from pathlib import Path
 # Canonical structural ruff selection — MUST stay byte-identical to the string
 # in .pre-commit-config.yaml, .github/workflows/ci.yml, and CLAUDE.md. The
 # anti-drift test in this module enforces that.
-STRUCTURAL = "C901,PLR0904,PLR0911,PLR0912,PLR0913,PLR0914,PLR0915,S"
+STRUCTURAL = "C901,PLR0911,PLR0912,PLR0913,PLR0915,S"
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -184,3 +184,30 @@ def test_structural_select_string_is_identical_across_surfaces() -> None:
     claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
     for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
         assert needle in text, f"{name} missing canonical structural select"
+
+
+def test_shipped_code_passes_the_structural_overlay_cleanly() -> None:
+    """The scaffold must itself pass the structural gate it ships. Runs the
+    exact overlay (--extend-select=STRUCTURAL) over src/ and tests/ and asserts
+    zero violations AND zero inert-rule warnings. Catches two failure classes a
+    string-only check cannot: a preview-only rule silently disabled (ruff prints
+    'has no effect'), and the gate self-blocking on its own shipped code.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "ruff", "check",
+            "--config", str(REPO_ROOT / "pyproject.toml"),
+            f"--extend-select={STRUCTURAL}",
+            "--output-format", "concise",
+            str(REPO_ROOT / "src"), str(REPO_ROOT / "tests"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert "has no effect" not in proc.stderr, (
+        f"a STRUCTURAL rule is inert (preview-only?):\n{proc.stderr}"
+    )
+    assert proc.returncode == 0, (
+        f"shipped code fails its own structural overlay:\n{proc.stdout}"
+    )

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -21,7 +21,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # A function whose cyclomatic complexity exceeds the mccabe default (10): a
 # long if/elif chain. Written to a temp file and linted via subprocess so this
 # test module itself stays simple (and never trips the gate it is testing).
-OVER_COMPLEX = '''
+OVER_COMPLEX = """
 def tangled(n):
     if n == 1:
         return 1
@@ -46,7 +46,7 @@ def tangled(n):
     elif n == 11:
         return 11
     return 0
-'''
+"""
 
 
 def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
@@ -56,9 +56,16 @@ def _ruff(args: list[str], target: Path) -> subprocess.CompletedProcess[str]:
     # assertion below must reflect the project's real selection.
     return subprocess.run(
         [
-            sys.executable, "-m", "ruff", "check",
-            "--config", str(REPO_ROOT / "pyproject.toml"),
-            "--output-format", "concise", *args, str(target),
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--config",
+            str(REPO_ROOT / "pyproject.toml"),
+            "--output-format",
+            "concise",
+            *args,
+            str(target),
         ],
         capture_output=True,
         text=True,
@@ -156,3 +163,24 @@ def test_ci_has_structure_job() -> None:
     assert f"--extend-select={STRUCTURAL}" in text
     # PR-only, like the diff-cover patch-coverage steps.
     assert "github.event_name == 'pull_request'" in text
+
+
+def test_claudemd_documents_the_gate_command() -> None:
+    text = (REPO_ROOT / "CLAUDE.md").read_text()
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # Advisory audit + eyes content present.
+    assert "radon" in text and "vulture" in text
+    assert "Why it compounds" in text  # decay-issue template marker
+
+
+def test_structural_select_string_is_identical_across_surfaces() -> None:
+    """The select string lives in three rendered files; drift between them is a
+    silent gate weakening. Assert all three carry the canonical string verbatim.
+    """
+    needle = f"--extend-select={STRUCTURAL}"
+    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
+    for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
+        assert needle in text, f"{name} missing canonical structural select"

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -1,6 +1,7 @@
 """Structural-health gate: behavioural, wiring, and anti-drift tests.
 
-These run inside the generated project's suite (and every downstream's CI),
+These run inside the generated project's suite (and any downstream's CI that
+keeps the structural gate enabled),
 continuously verifying the diff-scoped structural gate actually enforces what
 the template intends. Only rendered when ``enable_structural_gate`` is true.
 """
@@ -153,6 +154,11 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     assert "default_install_hook_types: [pre-commit, pre-push]" in text
     assert "id: structural-diff-gate" in text
     assert "stages: [pre-push]" in text
+    # The bash -c wrapper is load-bearing: it makes the shell (not pre-commit's
+    # arg splitter) own the --options quoting verified by the end-to-end test.
+    # Assert it so a refactor that drops it can't pass silently.
+    assert "language: system" in text
+    assert "entry: bash -c " in text
     assert f"--extend-select={STRUCTURAL}" in text
 
 

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -147,3 +147,12 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     assert "id: structural-diff-gate" in text
     assert "stages: [pre-push]" in text
     assert f"--extend-select={STRUCTURAL}" in text
+
+
+def test_ci_has_structure_job() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert "structure:" in text
+    assert "diff-quality" in text
+    assert f"--extend-select={STRUCTURAL}" in text
+    # PR-only, like the diff-cover patch-coverage steps.
+    assert "github.event_name == 'pull_request'" in text

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -195,11 +195,17 @@ def test_shipped_code_passes_the_structural_overlay_cleanly() -> None:
     """
     proc = subprocess.run(
         [
-            sys.executable, "-m", "ruff", "check",
-            "--config", str(REPO_ROOT / "pyproject.toml"),
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--config",
+            str(REPO_ROOT / "pyproject.toml"),
             f"--extend-select={STRUCTURAL}",
-            "--output-format", "concise",
-            str(REPO_ROOT / "src"), str(REPO_ROOT / "tests"),
+            "--output-format",
+            "concise",
+            str(REPO_ROOT / "src"),
+            str(REPO_ROOT / "tests"),
         ],
         capture_output=True,
         text=True,

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -174,6 +174,8 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     assert "id: structural-diff-gate" in text
     assert "stages: [pre-push]" in text
     assert "language: system" in text
+    # Mirrors the CI HAS_PY skip: no Python in the push → hook does not run.
+    assert "types: [python]" in text
     # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
     # pre-commit's arg splitter) own the --options quoting verified by the
     # end-to-end test. Assert it so a refactor to a direct `uv run` entry —


### PR DESCRIPTION
Closes #210.

## What

Ships a **diff-scoped structural-health gate** into generated projects, so agent-authored code can't *grow* structural debt while pre-existing debt is never blocked. Local-first (the agent reproduces every gate before CI), gated behind `enable_structural_gate` (default `true`).

Three surfaces (all toggle-gated):

1. **Diff-gate (blocking, local-first).** Strict ruff rules `C901,PLR0911,PLR0912,PLR0913,PLR0915,S` applied to **changed lines only** via `diff-quality --options=--extend-select=...` (`diff_cover` is already a dev dep) — as a **pre-push `pre-commit` hook** and a **PR-only CI `structure` job** running the identical command. The strict rules are **not** in the whole-repo `ruff check` select, so existing downstream code stays green; only the diff is held to the bar. `--fail-under=100`; `# noqa` is the escape hatch.
2. **Local advisory audit (non-blocking).** CLAUDE.md documents on-demand `radon`/`vulture` commands.
3. **Agent "eyes" (qualitative).** CLAUDE.md local-shape rules + a decay-issue template (What / Where / Why it compounds / Suggested direction).

A `template-ci.yml` step renders with the gate **off** and asserts no gated artifact leaks.

## Why diff-scoped + local-first

- **Template feeds 4 downstream repos.** Adding strict rules to the whole-repo `ruff check` would break every consumer's next `copier update` on *existing* code. Diff-scoping holds only new/changed code.
- **CI-only enforcement = whack-a-mole.** The agent commits, pushes, watches CI go red, patches blind. The pre-push hook runs the *same* command CI runs over the *same* range, so green-locally ⇒ green-in-CI.

## Preview rules dropped

`PLR0904` (god-class) and `PLR0914` (too-many-locals) are ruff **preview-only** — enabling them needs the global `--preview` flag, which would ship all of ruff's unstable preview behaviour downstream. Dropped; god-class detection stays with the CLAUDE.md eyes and the deferred full-repo audit.

## Tests (run in every smoke render and downstream CI)

8 tests in `tests/test_structural_gate.py`: two-tier overlay proofs for **both** `C901` and the `S` family (fire under `--extend-select`, absent from base); `diff-quality --options` end-to-end in a tmp git repo (fails with overlay, passes without — the `vale_flags`-class quoting trap, closed); pre-commit hook wiring (incl. `language: system`, `bash -c`, `types: [python]`); CI job wiring; CLAUDE.md gate-command presence; anti-drift (select string byte-identical across all three surfaces); and shipped-code-passes-overlay (runs the overlay on `src/`+`tests/`, asserting zero violations and zero inert-rule warnings). Plus the `template-ci.yml` toggle-off guard.

Full rendered gate passes: ruff/mypy clean, 50 passed / 16 skipped (mkdocs).

## Out of scope (Spec 2)

CI persistence: committed `structural-baseline.json`, automated deduped/capped issue filing, ratchet tightening.

Spec: `docs/superpowers/specs/2026-06-28-structural-health-gate-design.md`
Plan: `docs/superpowers/plans/2026-06-28-structural-health-gate.md`

## Downstream

Ships to the 4 consumer repos via `copier update` (manual, non-breaking by construction). Default-on, so consumers adopt the gate on their next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._