### PR TITLE
fix(scaffold): drop inert git.py CodeQL filter; ship benign config seam

### DIFF
--- a/.github/codeql/codeql-config.yml.jinja
+++ b/.github/codeql/codeql-config.yml.jinja
@@ -1,7 +1,15 @@
 name: "CodeQL config"
 
-query-filters:
-  - exclude:
-      id: py/clear-text-storage-of-sensitive-information
-      paths:
-        - src/{{ python_module }}/git.py
+# Add project-specific CodeQL tuning here, e.g. `paths-ignore:` to skip
+# generated/vendored code, or a `query-filters:` block to suppress a
+# specific alert on a specific path once you've reviewed it.  Example:
+#
+#   query-filters:
+#     - exclude:
+#         id: py/clear-text-storage-of-sensitive-information
+#         paths:
+#           - src/{{ python_module }}/some_module.py
+#
+# This scaffold ships no filters: suppress an alert only after you've
+# confirmed it's a false positive for a path that actually exists, so a
+# real finding is never silently hidden.


### PR DESCRIPTION
## Summary

`.github/codeql/codeql-config.yml.jinja` shipped a `query-filters` block excluding `py/clear-text-storage-of-sensitive-information` for `src/{{ python_module }}/git.py` — a leftover from the source project (markdown-vault-mcp, which has a real `git` module). Generated projects have no `git.py`, so the filter suppressed nothing today while creating a **latent security hazard**: a project that later added a real `src/<module>/git.py` storing a secret in clear text would have that CodeQL alert silently suppressed.

This PR removes the filter and replaces it with a documented, no-op config that explains where and how to add a suppression deliberately (only for a path that actually exists). The rendered file remains valid YAML (`{name: "CodeQL config"}`), which CodeQL accepts, and the consuming workflow's `config-file:` reference is unchanged.

The file stays always-rendered (now benign), so downstream re-convergence no longer fights to re-add a misleading block — cf. `image-generation-mcp` PR #34, which deliberately removed this exact block on reviewer + maintainer consensus.

## Verification

- Rendered with smoke-answers (`--vcs-ref=HEAD`); output parses to `{'name': 'CodeQL config'}`.
- No tests reference the CodeQL config (no test churn).
- Pre-flight five-lens review + `pr-review-toolkit:code-reviewer`: clean, no findings ≥80.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._