### PR TITLE
fix(scaffold): make vendor_spa.py starter self-contained

### DIFF
--- a/scripts/vendor_spa.py
+++ b/scripts/vendor_spa.py
@@ -1,16 +1,16 @@
 """Vendor SPA dependencies inline (starter).
 
-Copy MV's scripts/vendor_spa.py once you're ready to ship a real MCP
-Apps UI.  Until then, this is a documented no-op.
+No-op placeholder.  When you ship a real MCP Apps UI, replace this with
+a script that builds the served ``static/app.html`` with its frontend
+SDK vendored inline.  Until then, this is a documented no-op.
 """
-
-from __future__ import annotations
 
 
 def main() -> None:
     """No-op placeholder — replace with real vendor pipeline when needed."""
     print(
-        "vendor_spa.py: no-op placeholder — see MV's scripts/vendor_spa.py for the real pipeline."
+        "vendor_spa.py: no-op placeholder — replace with a real vendor "
+        "pipeline before shipping an MCP Apps UI."
     )
 
 


### PR DESCRIPTION
## Summary

`scripts/vendor_spa.py` ships verbatim into generated projects (it's not in `copier.yml`'s `_exclude`). It carried two scaffold-accuracy defects:

1. **Unused `from __future__ import annotations`** — the file's only annotation is `def main() -> None:`, which needs no deferred evaluation. (No `required-imports` enforcement in the ruff config, so removal is safe.)
2. **Opaque "MV's scripts/vendor_spa.py" references** (docstring + `print()`) — "MV" abbreviates the source project (markdown-vault); the reference doesn't resolve for a downstream reader.

This PR drops the dead import and rewrites the docstring/print to describe the no-op honestly, referencing only `static/app.html` (the SPA shell that actually renders from `src/{{python_module}}/static/app.html.jinja`). No private-repo reference and no reference to files the template doesn't generate — the starter is now reviewable using only the artifacts in front of the reader.

## Verification

- Rendered with smoke-answers (`--vcs-ref=HEAD`); rendered file has no `MV` refs and no `__future__` import, and passes `ruff check` + `ruff format --check` in the generated project.
- No tests reference `vendor_spa.py`; it's a no-op placeholder, so no test is warranted (the template-CI render-and-gate already covers "renders + import-clean").
- Pre-flight eight-agent circus (5 core lenses + code-reviewer + comment-analyzer + pr-test-analyzer): clean after one fix round (an earlier draft referenced a nonexistent `static/app.src.html`; corrected and re-verified clean).

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._