### PR TITLE
fix(scaffold): point pre-commit mypy at scripts/, not unrendered Jinja src/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,16 @@ repos:
         types: [python]
         pass_filenames: true
 
+      # Type-check the template's OWN Python (scripts/).  The generated
+      # project's src/ is unrendered Jinja here and cannot be mypy'd locally;
+      # template-ci.yml renders the template and runs mypy on the output.
       - id: mypy
         name: mypy
         language: system
         entry: uv run mypy
-        files: ^src/
+        files: ^scripts/
         pass_filenames: false
-        args: [src/]
+        args: [scripts/]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## Summary

The template repo's own `.pre-commit-config.yaml` mypy hook ran `mypy src/`, but `src/` is entirely Jinja (`*.py.jinja`) — **zero real `.py` files** — so mypy exited non-zero and every `src/`-touching commit needed `git commit --no-verify` (silently skipping *all* hooks). It also never type-checked the template's actual Python.

Retarget the hook at `scripts/` (the template's real Python; `mypy scripts/` was already clean). The generated project's `src/` is still type-checked by `template-ci.yml`, which renders the template and runs `mypy` on the output.

## Verification

- `uv run pre-commit run mypy --all-files` → **Passed** (`mypy scripts/`, 5 files).
- This PR's own fix commit was made **with hooks enabled — no `--no-verify`**.
- `pre-commit run --files src/{{python_module}}/server.py.jinja` → mypy **Skipped** (no spurious failure), confirming the original failing scenario is resolved.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._