### PR TITLE
feat(scaffold): DOMAIN-COMMANDS sentinel in cli.py for domain subcommands

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -200,7 +200,7 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `{{ env_prefix }}_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
-- **Domain CLI subcommands** go in the `# DOMAIN-COMMANDS-START` / `-END` block in `cli.py` (preserved across copier update, like `CONFIG-FIELDS`). Register them as `@app.command()` and use function-local imports for domain modules.
+- **Domain CLI subcommands** go in the `# DOMAIN-COMMANDS-START` / `-END` block in `cli.py` (like `CONFIG-FIELDS` in `config.py`). Register them as `@app.command()` and use function-local imports for domain modules. The block is preserved across `copier update`.
 
 ### Config wizard
 

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -200,6 +200,8 @@ Domain configuration composes `fastmcp_pvl_core.ServerConfig` inside your domain
 
 Env var prefix is `{{ env_prefix }}_` — all env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 
+- **Domain CLI subcommands** go in the `# DOMAIN-COMMANDS-START` / `-END` block in `cli.py` (preserved across copier update, like `CONFIG-FIELDS`). Register them as `@app.command()` and use function-local imports for domain modules.
+
 ### Config wizard
 
 `docs/javascripts/config-wizard/wizard-spec.json` drives the guided-setup page. It is **domain-owned and write-once** (`_skip_if_exists`): the runtime (`wizard.js`, `generators.js`, `wizard-spec-schema.json`, the generic tests) is template-owned and re-rendered, but the spec itself is never re-rendered, so it does **not** auto-update when you add config or when the template grows new questions. Reconcile it by hand.

--- a/src/{{python_module}}/cli.py.jinja
+++ b/src/{{python_module}}/cli.py.jinja
@@ -113,6 +113,19 @@ def serve(
         server.run(transport=transport)
 
 
+# DOMAIN-COMMANDS-START — add domain @app.command()s (and their helpers) below; kept across copier update
+# Domain CLI subcommands live here so the rest of this file stays byte-identical
+# to the template and applies cleanly on copier update. Use function-local
+# imports for domain modules (as ``serve`` does) to keep the top-level import
+# surface template-owned.
+# (example)
+# @app.command()
+# def widgets() -> None:
+#     """List widgets."""
+#     typer.echo("...")
+# DOMAIN-COMMANDS-END
+
+
 def main() -> None:
     """CLI entry point — used by ``[project.scripts]`` in pyproject.toml."""
     app()


### PR DESCRIPTION
Closes #225.

## What

Adds a `# DOMAIN-COMMANDS-START`/`-END` sentinel to the typer `cli.py.jinja`, between the `serve` command and `main()` — a copier-preserved block (like the existing `CONFIG-FIELDS` in `config.py.jinja`) where a downstream registers domain `@app.command()`s and their helpers. Plus one bullet in `CLAUDE.md.jinja` documenting it.

## Why

A project with domain CLI subcommands had nowhere update-safe to put them and ended up forking the whole `cli.py` (which then conflicts on every update). With the sentinel, domain commands live in the preserved block and the rest of `cli.py` stays byte-identical to the template, applying cleanly on `copier update`. (`markdown-vault-mcp` is the live case — its de-fork, epic #766, fills this sentinel.)

## Notes

Comment-only scaffold change; the rendered block is vacuous (commented example). Verified by rendering the scaffold at this branch: the generated `cli.py` parses and passes `ruff format --check`. No change to `serve`/`_root`/`main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
