### PR TITLE
fix(config-wizard): orphan check accepts non-prefixed vars read in src

### DIFF
--- a/tests/test_config_wizard_drift.py.jinja
+++ b/tests/test_config_wizard_drift.py.jinja
@@ -119,7 +119,17 @@ def _orphan_vars(spec: dict[str, Any]) -> list[str]:
             continue  # native, read by FastMCP / configure_logging_from_env
         suffix = _suffix(var)
         if suffix is None:
-            out.append(f"{var} (not {_ENV_PREFIX}_-prefixed and not FASTMCP_*)")
+            # A non-prefixed var (e.g. a standard external-service var such as
+            # OLLAMA_HOST / OPENAI_API_KEY read directly by a composed client,
+            # not a {PREFIX}_ field) is legitimate IFF the scaffold actually
+            # reads it in src — same read-site test as a prefixed var. Only flag
+            # it when nothing consumes it. ``_read_in_src``'s quoted-literal arm
+            # (``"VAR"``) matches the ``os.environ.get("VAR")`` idiom.
+            if not _read_in_src(var, src_text):
+                out.append(
+                    f"{var} (not {_ENV_PREFIX}_-prefixed, not FASTMCP_*, "
+                    "and not read in src)"
+                )
         elif suffix not in core_domain and not _read_in_src(suffix, src_text):
             out.append(f"{var} (no read site consumes {suffix})")
     return out
@@ -152,6 +162,27 @@ def test_orphan_guard_flags_unread_var() -> None:
     }
     orphans = _orphan_vars(spec)
     assert any("NONSENSE_XYZ" in o for o in orphans)
+
+
+def test_orphan_guard_flags_unread_non_prefixed_var() -> None:
+    """A NON-prefixed var nothing in src reads is still reported as an orphan."""
+    spec: dict[str, Any] = {
+        "questions": [{"id": "x", "var": "TOTALLY_EXTERNAL_NEVER_READ_XYZ"}]
+    }
+    orphans = _orphan_vars(spec)
+    assert any("TOTALLY_EXTERNAL_NEVER_READ_XYZ" in o for o in orphans)
+
+
+def test_read_in_src_matches_non_prefixed_external_var() -> None:
+    """``_read_in_src`` clears a bare external var read via the standard idiom.
+
+    A composed client reads a non-prefixed env var directly (e.g.
+    ``os.environ.get("OLLAMA_HOST")``); the quoted-literal arm matches it, so a
+    wizard offering ``OLLAMA_HOST`` is not flagged as an orphan.
+    """
+    src = 'host = os.environ.get("OLLAMA_HOST") or "http://localhost:11434"'
+    assert _read_in_src("OLLAMA_HOST", src) is True
+    assert _read_in_src("UNRELATED_EXTERNAL_VAR", src) is False
 
 
 def _missing_suffixes(surface: set[str], emitted_suffixes: set[str]) -> list[str]:


### PR DESCRIPTION
Closes #227.

## What
`_orphan_vars` (config-wizard drift gate) flagged any wizard var that isn't `{PREFIX}_`-prefixed or `FASTMCP_*` as an orphan **without running the `_read_in_src` read-site check** — that check ran only for prefixed vars. So a downstream project whose config legitimately reads a standard external-service env var directly (`os.environ.get("OLLAMA_HOST")`, `os.environ.get("OPENAI_API_KEY")`) and offers it in the wizard had no way to satisfy the gate.

The fix runs the **same** read-site test for non-prefixed vars: `_read_in_src`'s quoted-literal arm (`"VAR"`) already matches the `os.environ.get("VAR")` idiom, so a bare external var that's actually read clears, while one read nowhere is still flagged.

## Tests
- `test_orphan_guard_flags_unread_non_prefixed_var` — a non-prefixed var read nowhere is still an orphan.
- `test_read_in_src_matches_non_prefixed_external_var` — a bare external var read via the standard idiom clears.

Verified against the downstream consumer (markdown-vault-mcp #784): with this change rendered in, its wizard drift suite goes 25/26 → 26/26 (the `OLLAMA_HOST`/`OPENAI_API_KEY` orphans clear; no other behavior changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
