### PR TITLE
feat(scaffold): brownfield opt-out for the structural gate's whole-tree clean assertion

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -83,6 +83,69 @@ jobs:
           ! grep -qF 'Structural quality (diff) passes' CLAUDE.md \
             || { echo "::error::structural acceptance-gate item rendered with gate off"; exit 1; }
 
+      - name: structural gate clean-tree assertion present (default) / dropped (opt-out)
+        # structural_gate_assert_clean_tree gates ONLY the whole-tree clean
+        # assertion (test_shipped_code_passes_…): default true keeps it; false
+        # drops it so a brownfield repo with pre-existing structural debt can
+        # adopt the gate while the diff-scoped gate, pre-push hook, CI 'structure'
+        # job, and behavioural tests all remain. A test cannot assert its own
+        # absence, and a missing test passes pytest vacuously, so assert the
+        # rendered file directly — BOTH halves: present under the default render,
+        # absent under the opt-out (an inverted condition would otherwise drop the
+        # self-check from every downstream and still go green).
+        #
+        # --vcs-ref=HEAD renders the working-tree commit. Without it copier
+        # defaults to the latest git tag, which predates this variable: a clone
+        # that HAS tags (a normal local checkout) then renders the old template,
+        # ignores the --data, and these assertions break. CI's default checkout
+        # fetches no tags, so copier falls through to HEAD and the assertions pass
+        # even unpinned — i.e. an omitted pin slips through CI and breaks only on a
+        # local full clone. Pin it so behaviour is identical everywhere. (The
+        # sibling render steps omit the pin too; their assertions still pass
+        # because they toggle only tag-existing vars, but in a tag-bearing local
+        # clone they render the tagged template, not the working tree — a
+        # pre-existing gap, not fixed here.)
+        #
+        # Both rendered variants of the gate's own test file are then linted: the
+        # opt-out trim must leave no unused import, and the jinja if/endif
+        # whitespace seam must stay format-clean in both the present and absent
+        # branches.
+        run: |
+          rm -rf /tmp/smoke-cleantree-on /tmp/smoke-cleantree-off
+          # default render (flag true): the whole-tree self-check MUST be present.
+          uv run --no-project --with copier \
+            copier copy --trust --defaults --vcs-ref=HEAD \
+            --data-file tests/fixtures/smoke-answers.yml \
+            . /tmp/smoke-cleantree-on
+          grep -q 'def test_shipped_code_passes_the_structural_overlay_cleanly' /tmp/smoke-cleantree-on/tests/test_structural_gate.py \
+            || { echo "::error::clean-tree assertion missing from the default render"; exit 1; }
+          # opt-out render (flag false): the whole-tree self-check MUST be dropped,
+          # everything else MUST remain.
+          uv run --no-project --with copier \
+            copier copy --trust --defaults --vcs-ref=HEAD \
+            --data-file tests/fixtures/smoke-answers.yml \
+            --data structural_gate_assert_clean_tree=false \
+            . /tmp/smoke-cleantree-off
+          off=/tmp/smoke-cleantree-off
+          test -f "$off/tests/test_structural_gate.py" \
+            || { echo "::error::structural test file missing — gate should still render"; exit 1; }
+          ! grep -q 'def test_shipped_code_passes_the_structural_overlay_cleanly' "$off/tests/test_structural_gate.py" \
+            || { echo "::error::clean-tree assertion rendered despite opt-out"; exit 1; }
+          grep -q 'def test_options_reach_ruff_and_gate_is_diff_scoped' "$off/tests/test_structural_gate.py" \
+            || { echo "::error::diff-scope behavioural test dropped by clean-tree opt-out"; exit 1; }
+          grep -q 'structural-diff-gate' "$off/.pre-commit-config.yaml" \
+            || { echo "::error::pre-push hook dropped by clean-tree opt-out"; exit 1; }
+          grep -qE '^  structure:' "$off/.github/workflows/ci.yml" \
+            || { echo "::error::structure CI job dropped by clean-tree opt-out"; exit 1; }
+          # both branches of the conditional must lint + format clean (catches an
+          # unused import left by the trim and any if/endif whitespace regression).
+          for d in /tmp/smoke-cleantree-on /tmp/smoke-cleantree-off; do
+            ( cd "$d" \
+              && uv run --no-project --with ruff ruff check --config pyproject.toml tests/test_structural_gate.py \
+              && uv run --no-project --with ruff ruff format --check --config pyproject.toml tests/test_structural_gate.py ) \
+              || { echo "::error::rendered structural test ($d) is not lint/format-clean"; exit 1; }
+          done
+
       - name: Install rendered project
         working-directory: /tmp/smoke
         run: uv sync --all-extras --all-groups

--- a/copier.yml
+++ b/copier.yml
@@ -199,3 +199,9 @@ enable_structural_gate:
   type: bool
   default: true
   help: "Scaffold the diff-scoped structural-health gate: strict ruff structural rules (complexity, god-class, too-many-*, security) enforced on changed lines only via diff-quality, as a pre-push hook and a CI 'structure' job, plus the CLAUDE.md structural-health guidance (local-shape rules, advisory radon/vulture audit, decay-issue template). New code is held to the bar; pre-existing code is never blocked. Leave on unless a project deliberately opts out of structural enforcement."
+
+structural_gate_assert_clean_tree:
+  type: bool
+  default: true
+  when: "{{ enable_structural_gate }}"
+  help: "Also assert the project's EXISTING src/ + tests/ tree is already clean under the structural overlay (the test_shipped_code_passes_the_structural_overlay_cleanly check). True is correct for new projects and the template's own CI. Set to false when ADOPTING the gate onto a brownfield codebase that already carries structural debt: you still get the diff-scoped gate, pre-push hook, CI 'structure' job, and the behavioural tests — only the whole-tree clean assertion is dropped, so enabling the gate does not force refactoring or blanket-noqa of all legacy debt first (the diff-scoped gate still grandfathers it and blocks new debt). Only asked when the structural gate is on."

--- a/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-structural-health-gate-design.md
@@ -208,6 +208,28 @@ A new `tests/test_structural_gate.py.jinja` (skipped/absent when
 5. **Doc/hook anti-drift** — rendered `CLAUDE.md` local-gate routine contains the
    structural command, so the documented command and the hook command cannot
    silently diverge.
+6. **Shipped-code self-check** — `test_shipped_code_passes_the_structural_overlay_cleanly`
+   runs the overlay over the whole rendered `src/` + `tests/` tree and asserts zero
+   violations (and zero inert/preview-only rules). This is gated by
+   `structural_gate_assert_clean_tree` (see below); template-ci asserts the test is
+   present in the default render and absent under the opt-out.
+
+### Brownfield opt-out (`structural_gate_assert_clean_tree`)
+
+The whole-tree self-check in test 6 holds for a freshly-rendered project and for
+this template's own CI, but it is **whole-repo**, not diff-scoped — so a downstream
+repo adopting the gate onto an **existing** codebase that already carries
+structural debt would see it fail, which contradicts the gate's "never block on
+pre-existing debt" principle (every other artifact that holds repo code to the
+bar — the pre-push hook and the CI `structure` job — is diff-scoped; only this
+self-check lints the whole `src/` + `tests/` tree). The
+`structural_gate_assert_clean_tree` copier question (`bool`, default `true`, asked
+only `when enable_structural_gate`) lets such an adopter render the gate, the
+pre-push hook, the CI `structure` job, and the behavioural tests **without** test 6.
+New code is still held to the bar by the diff-scoped gate; the existing debt is
+grandfathered. Default `true` preserves the self-check for new projects. This is a
+stopgap for the brownfield case until Spec 2's committed baseline (below) lets the
+self-check assert "no new violations outside the baseline" instead of "none at all".
 
 ## Failure modes tracked
 

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -212,6 +212,7 @@ def test_structural_select_string_is_identical_across_surfaces() -> None:
     claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
     for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
         assert needle in text, f"{name} missing canonical structural select"
+{%- if structural_gate_assert_clean_tree %}
 
 
 def test_shipped_code_passes_the_structural_overlay_cleanly() -> None:
@@ -245,3 +246,4 @@ def test_shipped_code_passes_the_structural_overlay_cleanly() -> None:
     assert proc.returncode == 0, (
         f"shipped code fails its own structural overlay:\n{proc.stdout}"
     )
+{%- endif %}


### PR DESCRIPTION
## Summary

Adds a `structural_gate_assert_clean_tree` copier question (bool, default `true`, asked only `when enable_structural_gate`). When `false`, the rendered `tests/test_structural_gate.py` omits `test_shipped_code_passes_the_structural_overlay_cleanly` — the **only whole-tree (non-diff-scoped) artifact** the gate ships. The diff-scoped gate, pre-push hook, CI `structure` job, and the behavioural tests all still render.

This lets a **brownfield** repo adopt the structural gate without first refactoring or blanket-`noqa`'ing all pre-existing structural debt, which the whole-tree clean assertion would otherwise force — contradicting the gate's own *"never block on pre-existing debt"* principle (every artifact that holds repo code to the bar is diff-scoped; only this self-check linted the whole `src/` + `tests/` tree). Default `true` preserves the self-check for new projects and this template's own CI.

Closes #230.

## What changed

- **`copier.yml`** — new `structural_gate_assert_clean_tree` bool question (the first `when:`-gated question in the file).
- **`tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja`** — wraps only the clean-tree test in `{%- if structural_gate_assert_clean_tree %}` / `{%- endif %}`. Whitespace-control verified: the default (ON) render is byte-identical to the prior file; the opt-out (OFF) render ends cleanly with no stray blank line.
- **`.github/workflows/template-ci.yml`** — a render-and-assert step that renders both variants (pinned with `--vcs-ref=HEAD`) and asserts the clean-tree test is **present** under the default and **absent** under the opt-out (closing the inverted-condition / vacuous-pass hole), that the gate artifacts survive the opt-out, and that **both** rendered variants are `ruff check` + `ruff format --check` clean.
- **`docs/superpowers/specs/2026-06-28-structural-health-gate-design.md`** — documents the opt-out as test 6 + a "Brownfield opt-out" subsection, framed as a stopgap until Spec 2's committed baseline.

## Why `--vcs-ref=HEAD` on the new renders

`copier copy` defaults to the latest git **tag** for a git source. The new variable does not exist at the latest tag (`v2.9.1`), so an unpinned render in a tag-bearing local clone would render the old template, silently ignore the `--data`, and misfire. CI's tagless shallow checkout falls through to HEAD and would pass even unpinned — i.e. an omitted pin slips through CI and breaks only on a local full clone. The pin makes behaviour identical everywhere.

## Known follow-up (not in this PR)

The **sibling** render steps in `template-ci.yml` omit `--vcs-ref=HEAD` too. They are currently safe (they toggle only tag-existing vars), but in a tag-bearing local clone they render the tagged template rather than the working tree — a pre-existing latent gap. Worth standardizing `--vcs-ref=HEAD` across all render steps (or asserting any step passing a `--data <newvar>=` also pins the ref) as a separate change.

## Verification

- Rendered both variants from HEAD: ON keeps the test (8 tests pass), OFF drops it (7 pass); idempotent; both renders `ruff check` + `ruff format --check` clean.
- Pre-commit (ruff/whitespace/yaml/json) green.
- Local five-lens + supplementary pre-push review run to a clean pass.

## Downstream

Unblocks **pvliesdonk/markdown-vault-mcp#783**: once this releases, MVM adopts the gate with `structural_gate_assert_clean_tree=false`, keeping its pre-existing complexity debt as honest, diff-grandfathered debt rather than force-suppressing it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
