### PR TITLE
fix(release): gate detect-rc on the latest stable release

### DIFF
--- a/.github/workflows/release.yml.jinja
+++ b/.github/workflows/release.yml.jinja
@@ -43,17 +43,25 @@ jobs:
         id: detect-rc
         run: |
           latest_rc=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1 || true)
+          latest_stable=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          in_rc_series=false
           if [ -n "$latest_rc" ]; then
             rc_base="${latest_rc%-rc.*}"
-            if ! git tag --list | grep -qx "$rc_base"; then
-              echo "in_rc_series=true" >> "$GITHUB_OUTPUT"
+            # Active only when the rc's stable base is not yet tagged AND the
+            # series targets a version newer than the latest stable release. An
+            # rc whose base is <= the latest stable is an abandoned/superseded
+            # series (e.g. a v2.0.0-rc left behind when the project jumped to
+            # v3.x); it must not trigger the force=prerelease revision bump,
+            # which from a stable base produces <current>-rc.1 instead of a
+            # bumped version.
+            newest=$(printf '%s\n%s\n' "$rc_base" "${latest_stable:-v0.0.0}" | sort -V | tail -1)
+            if ! git tag --list | grep -qx "$rc_base" \
+               && [ "$newest" = "$rc_base" ] && [ "$rc_base" != "${latest_stable:-v0.0.0}" ]; then
+              in_rc_series=true
               echo "rc_series_target=$rc_base" >> "$GITHUB_OUTPUT"
-            else
-              echo "in_rc_series=false" >> "$GITHUB_OUTPUT"
             fi
-          else
-            echo "in_rc_series=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "in_rc_series=$in_rc_series" >> "$GITHUB_OUTPUT"
 
       - name: Compute effective PSR force
         id: compute-force


### PR DESCRIPTION
Closes #235. Follow-up to #165.

## Problem

`detect-rc` reports an active pre-release series whenever the highest rc tag across all history has an untagged stable base — with no comparison against the latest **stable** release. An abandoned rc series (e.g. a `v2.0.0-rc.5` left behind when a project jumped to `v3.0.0`) therefore fools it forever. `compute-force` then injects `force=prerelease`, which from a stable base cuts `<current>-rc.1` (#165's matrix flags this as the one wrong case).

Real downstream hit: markdown-vault-mcp dispatched `prerelease=true, force=''` from stable `v3.0.4` and cut `v3.0.4-rc.1`.

## Fix

A series is active only when the rc's base is untagged **and** targets a version newer than the latest stable release:

```bash
newest=$(printf '%s\n%s\n' "$rc_base" "${latest_stable:-v0.0.0}" | sort -V | tail -1)
if ! git tag --list | grep -qx "$rc_base" \
   && [ "$newest" = "$rc_base" ] && [ "$rc_base" != "${latest_stable:-v0.0.0}" ]; then
  in_rc_series=true
  ...
```

- Abandoned series (`rc_base v2.0.0` ≤ `latest_stable v3.0.4`) → `in_rc_series=false`.
- Genuine in-progress series (`rc_base` > latest stable) → `in_rc_series=true` (rc.N→rc.N+1 preserved).

Only trusted `git tag` values are used, quoted — no untrusted event input.

## Note

Downstream markdown-vault-mcp carries a transient local copy (its PR #854) so its next prerelease works before this propagates via copier update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._