### PR TITLE
fix: bump vendored ext-apps SDK 1.3.1 → 1.7.4

### DIFF
--- a/scripts/tests/test_vendor_spa.py
+++ b/scripts/tests/test_vendor_spa.py
@@ -52,7 +52,7 @@ def _make_tree(tmp_path: Path, src_html: str) -> Path:
 def test_vendored_versions_has_ext_apps_only():
     mod = _load_module()
     assert set(mod.VENDORED_VERSIONS) == {"ext-apps"}
-    assert mod.VENDORED_VERSIONS["ext-apps"]["version"] == "1.3.1"
+    assert mod.VENDORED_VERSIONS["ext-apps"]["version"] == "1.7.4"
 
 
 def test_check_fails_when_app_html_absent(tmp_path: Path):
@@ -108,7 +108,7 @@ def test_starter_src_html_is_inlineable():
         raise FileNotFoundError("app.src.html not found under src/*/static/")
     text = matches[0].read_text(encoding="utf-8")
     assert "import { App }" in text
-    assert "@modelcontextprotocol/ext-apps@1.3.1/app-with-deps" in text
+    assert "@modelcontextprotocol/ext-apps@1.7.4/app-with-deps" in text
     assert "app___get_status" in text
     assert "app___get_info" in text
     assert "{{" not in text and "{%" not in text  # no Jinja in static body

--- a/scripts/{% if include_mcp_apps_scaffold %}vendor_spa.py{% endif %}
+++ b/scripts/{% if include_mcp_apps_scaffold %}vendor_spa.py{% endif %}
@@ -36,9 +36,9 @@ VENDORED_VERSIONS: dict[str, dict[str, str]] = {
     # The MCP Apps frontend SDK — required by every MCP Apps UI.  Template-owned;
     # bump the version + sha256 here to roll the whole fleet at once.
     "ext-apps": {
-        "version": "1.3.1",
-        "url": "https://unpkg.com/@modelcontextprotocol/ext-apps@1.3.1/app-with-deps",
-        "sha256": "36495489aa8939e4eb7421c8a03c220b9f502d79e87895f88599eb6c02377fdd",
+        "version": "1.7.4",
+        "url": "https://unpkg.com/@modelcontextprotocol/ext-apps@1.7.4/app-with-deps",
+        "sha256": "e72bf921bc15d38951cf85abbb8e572688a30572db89b5344e3a447b1f8d6b40",
         "type": "module",
         "import_specifier": "@modelcontextprotocol/ext-apps",
     },

--- a/src/{{python_module}}/static/{% if include_mcp_apps_scaffold %}app.src.html{% endif %}
+++ b/src/{{python_module}}/static/{% if include_mcp_apps_scaffold %}app.src.html{% endif %}
@@ -19,7 +19,7 @@
 // Static import (Android webview compatibility); the SDK is vendored inline
 // via an import map by scripts/vendor_spa.py. The CDN URL below is the
 // vendoring source and is rewritten to the bare specifier at vendor time.
-import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@1.3.1/app-with-deps";
+import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@1.7.4/app-with-deps";
 
 const app = new App(
   { name: "MCP App", version: "0.0.0" },


### PR DESCRIPTION
## Summary

Bumps the template-owned vendored `@modelcontextprotocol/ext-apps` SDK pin from **1.3.1** to **1.7.4** (fleet-wide). 1.3.1's `setupSizeChangedNotifications()` measures width via `html.style.width = "fit-content"`, forcing a synchronous 0px-width reflow that destroys horizontal scroll positions on responsive apps — fixed in ext-apps PR #567 (1.3.2), with further sizing/fullscreen fixes through 1.7.4. Downstream MCP Apps that rely on `autoResize` (e.g. `markdown-vault-mcp`, which just adopted container-dimensions-aware sizing) inherit the defect until this pin moves.

## Changes (3 touchpoints)

- `scripts/…/vendor_spa.py` — `VENDORED_VERSIONS["ext-apps"]`: `version`, `url`, and `sha256` (`e72bf921bc15d38951cf85abbb8e572688a30572db89b5344e3a447b1f8d6b40`).
- `src/{{python_module}}/static/…/app.src.html` — the scaffold CDN import URL.
- `scripts/tests/test_vendor_spa.py` — `version` and import-URL assertions.

## Verification

- `sha256` recomputed with the same method the current pin uses — re-hashing 1.3.1 reproduced the existing pinned value (`36495489…`), confirming the method, and 1.7.4 hashes to `e72bf921…`.
- API surface stable: the `app-with-deps` entry still exports `App`, `applyDocumentTheme`, `applyHostStyleVariables`, `applyHostFonts` (the symbols downstream domains import). No host-context / protocol schema changes between 1.3.1 and 1.7.4 — only client-side measurement fixes. Drop-in for downstream imports.
- `uv run --with pytest pytest scripts/tests/test_vendor_spa.py` → 4 passed.
- `docs/superpowers/` plan/spec docs still reference 1.3.1 as **frozen historical implementation records**; left unchanged (the authoritative pin is `vendor_spa.py`). Happy to update them if you'd prefer they track current.

Once merged + released, downstreams pick this up via the next `copier update`.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._