### PR TITLE
fix(docs): remove dead env vars and mcp-server hardcodes from shared deployment docs

### DIFF
--- a/docs/deployment/claude-desktop.md.jinja
+++ b/docs/deployment/claude-desktop.md.jinja
@@ -36,9 +36,7 @@ Otherwise, add the server to your Claude Desktop configuration file. The path va
     "{{ project_name }}": {
       "command": "{{ project_name }}",
       "args": ["serve"],
-      "env": {
-        "{{ env_prefix }}_READ_ONLY": "true"
-      }
+      "env": {}
     }
   }
 }
@@ -76,9 +74,7 @@ macOS/Linux:
     "{{ project_name }}": {
       "command": "/Users/me/.venvs/mcp/bin/{{ project_name }}",
       "args": ["serve"],
-      "env": {
-        "{{ env_prefix }}_READ_ONLY": "true"
-      }
+      "env": {}
     }
   }
 }
@@ -92,9 +88,7 @@ Windows (`Scripts\` not `bin\`, `.exe` suffix):
     "{{ project_name }}": {
       "command": "C:\\Users\\me\\.venvs\\mcp\\Scripts\\{{ project_name }}.exe",
       "args": ["serve"],
-      "env": {
-        "{{ env_prefix }}_READ_ONLY": "true"
-      }
+      "env": {}
     }
   }
 }

--- a/docs/deployment/docker.md.jinja
+++ b/docs/deployment/docker.md.jinja
@@ -12,9 +12,8 @@ The server listens on port 8000 with HTTP transport by default.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `{{ env_prefix }}_READ_ONLY` | `true` | Disable write tools |
 | `{{ env_prefix }}_BEARER_TOKEN` | n/a | Enable bearer token auth |
-| `{{ env_prefix }}_LOG_LEVEL` | `INFO` | Log level |
+| `FASTMCP_LOG_LEVEL` | `INFO` | Log level (`DEBUG` / `INFO` / `WARNING` / `ERROR`) |
 | `{{ env_prefix }}_INSTRUCTIONS` | (computed at startup) | System instructions for LLM context |
 | `{{ env_prefix }}_DEBUG_PORT` | n/a | Remote-debugger TCP port (see [Remote debugging](#remote-debugging); requires `--build-arg DEBUG=true` image) |
 | `{{ env_prefix }}_DEBUG_WAIT` | `false` | Block startup until IDE attaches (see [Remote debugging](#remote-debugging)) |

--- a/docs/deployment/oidc.md.jinja
+++ b/docs/deployment/oidc.md.jinja
@@ -72,7 +72,7 @@ identity_providers:
 ### 3. Start with HTTP transport
 
 ```bash
-mcp-server serve --transport http --port 8000
+{{ project_name }} serve --transport http --port 8000
 ```
 
 ## Architecture
@@ -80,7 +80,7 @@ mcp-server serve --transport http --port 8000
 The server uses FastMCP's built-in `OIDCProxy` auth provider (not the external `mcp-auth-proxy` sidecar). The authentication flow:
 
 ```
-Client → mcp-server (with OIDCProxy) → OIDC Provider (Authelia/Keycloak)
+Client → {{ project_name }} (with OIDCProxy) → OIDC Provider (Authelia/Keycloak)
 ```
 
 1. Client connects to the MCP server
@@ -93,7 +93,7 @@ Client → mcp-server (with OIDCProxy) → OIDC Provider (Authelia/Keycloak)
 
 ```yaml
 services:
-  mcp-server:
+  {{ project_name }}:
     image: {{ docker_registry }}/{{ project_name }}:latest
     env_file: .env
     volumes:
@@ -103,9 +103,9 @@ services:
     restart: unless-stopped
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.mcp-server.rule=Host(`mcp.example.com`)"
-      - "traefik.http.routers.mcp-server.tls.certresolver=letsencrypt"
-      - "traefik.http.services.mcp-server.loadbalancer.server.port=8000"
+      - "traefik.http.routers.{{ project_name }}.rule=Host(`mcp.example.com`)"
+      - "traefik.http.routers.{{ project_name }}.tls.certresolver=letsencrypt"
+      - "traefik.http.services.{{ project_name }}.loadbalancer.server.port=8000"
     networks:
       - traefik
 
@@ -120,7 +120,6 @@ networks:
 With the corresponding `.env`:
 
 ```bash
-{{ env_prefix }}_READ_ONLY=true
 {{ env_prefix }}_BASE_URL=https://mcp.example.com
 {{ env_prefix }}_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
 {{ env_prefix }}_OIDC_CLIENT_ID=my-mcp-server

--- a/docs/guides/authentication.md.jinja
+++ b/docs/guides/authentication.md.jinja
@@ -41,7 +41,7 @@ The simplest way to protect your server. A single static token shared between se
 3. Start the server with HTTP transport:
 
     ```bash
-    mcp-server serve --transport http --port 8000
+    {{ project_name }} serve --transport http --port 8000
     ```
 
 ### Client usage
@@ -85,7 +85,7 @@ Full OAuth 2.1 authentication using an external identity provider. Supports user
 The server proxies OIDC itself, with no external auth sidecar to deploy:
 
 ```
-Client → mcp-server → OIDC Provider
+Client → {{ project_name }} → OIDC Provider
 ```
 
 1. Client connects to the server


### PR DESCRIPTION
## Summary
The sentinel-protected shared deployment/auth docs advertised env vars no generated code reads, and hardcoded `mcp-server` where `{{ project_name }}` belongs. Every scaffolded project inherited broken docs (found downstream in `openapi-mcp`).

Fixes, all verified by smoke-render:

- **`{{ env_prefix }}_READ_ONLY`** — removed from `docker.md.jinja`, `oidc.md.jinja`, and the three `claude-desktop.md.jinja` example `env` blocks (now `"env": {}`). `server.py.jinja` passes a literal `read_only=` to `build_instructions` (hint text only); nothing reads the env var.
- **`{{ env_prefix }}_LOG_LEVEL`** (`docker.md.jinja`) → **`FASTMCP_LOG_LEVEL`**, the single log-level control per the Logging Standard.
- **`mcp-server`** → **`{{ project_name }}`** in `oidc.md.jinja` (start command, flow diagram, compose service, traefik router/service labels) and `authentication.md.jinja` (start command, flow diagram) — the residual `mcp-server` refs a prior pass (#31) missed. `claude-desktop.md.jinja` already used `{{ project_name }}`.

## Verification
Smoke-rendered with `copier copy --defaults --data project_name=smoke-mcp --data env_prefix=SMOKE …`; the rendered `docs/deployment/*` and `docs/guides/authentication.md` contain **no** `mcp-server` / `*_READ_ONLY` / `*_LOG_LEVEL` references, and the `{{ project_name }}` / `FASTMCP_LOG_LEVEL` substitutions render correctly.

## Notes
- Docs-only; no rendered code changes. All edits are within the template-owned prose of already-sentinel-protected shared docs.
- Whether `read_only` should become env-configurable (making a `_READ_ONLY` var *real*) is left out of scope and noted in the issue.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._