### PR TITLE
fix: harden Claude review workflows (inline comments, write perms, REVIEW.md scoping, CI-gated review)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,26 +69,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          version: "latest"
-
-      - name: Cache Python interpreter
-        uses: actions/cache@v6
-        with:
-          path: ~/.local/share/uv/python
-          key: uv-python-3.12-${{ runner.os }}
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Install dependencies
-        # Gives the reviewer a working venv so its targeted `uv run` checks
-        # (freedom to investigate one finding) actually execute. REVIEW.md
-        # tells it not to re-run the full gate.
-        run: uv sync --all-extras --all-groups
-
+      # NB: unlike the rendered .jinja twin, this repo's own reviewer has NO uv
+      # env — the template has no root pyproject.toml (its Python lives in
+      # scripts/ and runs via `uv run --no-project`), so `uv sync` would fail.
+      # This reviewer reviews template files and reads template-ci results via
+      # `gh run view` rather than re-running a gate.
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -103,8 +88,9 @@ jobs:
           track_progress: true
           display_report: true
           # Grant the inline-comment tool (NOT in the default allow-set — this is
-          # what lets the reviewer post inline), gh read tools to read CI results,
-          # and scoped `uv run` for targeted investigation (REVIEW.md sets norms).
+          # what lets the reviewer post inline) and gh read tools to read CI
+          # results. No `uv run` here (no root pyproject to sync); the .jinja
+          # twin keeps the uv-investigation allow-list for generated projects.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,33 +3,89 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+  wait-for-ci:
+    # Skip PRs from forks: GitHub does not expose repository secrets
+    # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
+    # context, regardless of maintainer approval. Running anyway produces
+    # a hard-failing check on every external contribution.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+    outputs:
+      ci_passed: ${{ steps.wait.outputs.ci_passed }}
+    steps:
+      - name: Wait for CI to conclude on this PR head
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Gate the review on the CI workflow: only review code the gate
+          # accepted. Poll the CI run for THIS PR head SHA (not github.sha,
+          # which is the merge commit) until it completes; tolerate the
+          # not-yet-created race by looping. Gate on the run *conclusion*
+          # so CI's continue-on-error 3.14 matrix job never blocks.
+          deadline=$(( SECONDS + 25 * 60 ))
+          conclusion=""
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            runs=$(gh api "repos/${REPO}/actions/workflows/template-ci.yml/runs?head_sha=${HEAD_SHA}&per_page=1" 2>/dev/null || echo '{}')
+            status=$(echo "$runs" | jq -r '.workflow_runs[0].status // empty')
+            conclusion=$(echo "$runs" | jq -r '.workflow_runs[0].conclusion // empty')
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            echo "CI status: ${status:-not-found-yet}; waiting 20s..."
+            sleep 20
+          done
+          if [ "$conclusion" = "success" ]; then
+            echo "ci_passed=true" >> "$GITHUB_OUTPUT"
+            echo "CI passed — review will run."
+          else
+            echo "ci_passed=false" >> "$GITHUB_OUTPUT"
+            echo "CI did not pass (conclusion=${conclusion:-timeout}) — skipping review."
+          fi
 
+  claude-review:
+    needs: wait-for-ci
+    if: ${{ needs.wait-for-ci.outputs.ci_passed == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write  # Required so the review action can post inline comments
+      contents: read          # Reviewer reads code; it must never commit
+      pull-requests: write     # Post inline review comments
       issues: read
       id-token: write
-
+      actions: read            # Read CI results instead of re-running them
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-${{ runner.os }}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        # Gives the reviewer a working venv so its targeted `uv run` checks
+        # (freedom to investigate one finding) actually execute. REVIEW.md
+        # tells it not to re-run the full gate.
+        run: uv sync --all-extras --all-groups
 
       - name: Run Claude Code Review
         id: claude-review
@@ -41,10 +97,12 @@ jobs:
           # `--comment` tells the plugin to actually post (without it, the plugin
           # runs the full review and stops silently — burning ~$3/PR for no output).
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # Surface progress so a silent failure is visible: a sticky tracking
-          # comment updates during the run, and the Claude Code Report appears
-          # in the job's GitHub Step Summary.
+          # Surface progress so a silent failure is visible.
           track_progress: true
           display_report: true
+          # Grant the inline-comment tool (NOT in the default allow-set — this is
+          # what lets the reviewer post inline), gh read tools to read CI results,
+          # and scoped `uv run` for targeted investigation (REVIEW.md sets norms).
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,8 @@ name: Claude Code Review
 
 on:
   pull_request:
+    # No branches filter here (unlike the rendered .jinja twin): this repo's
+    # template-ci runs on all PRs, so the wait-for-ci poll always finds a run.
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:

--- a/.github/workflows/claude-code-review.yml.jinja
+++ b/.github/workflows/claude-code-review.yml.jinja
@@ -3,41 +3,89 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
+  wait-for-ci:
     # Skip PRs from forks: GitHub does not expose repository secrets
     # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
     # context, regardless of maintainer approval. Running anyway produces
-    # a hard-failing check on every external contribution. Maintainers who
-    # want a bot review on a fork PR can push the contributor's branch to
-    # this repo under a topic name and the workflow will run.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # a hard-failing check on every external contribution.
+    if: {% raw %}${{ github.event.pull_request.head.repo.full_name == github.repository }}{% endraw %}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+    outputs:
+      ci_passed: {% raw %}${{ steps.wait.outputs.ci_passed }}{% endraw %}
+    steps:
+      - name: Wait for CI to conclude on this PR head
+        id: wait
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          REPO: {% raw %}${{ github.repository }}{% endraw %}
+          HEAD_SHA: {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+        run: |
+          set -euo pipefail
+          # Gate the review on the CI workflow: only review code the gate
+          # accepted. Poll the CI run for THIS PR head SHA (not github.sha,
+          # which is the merge commit) until it completes; tolerate the
+          # not-yet-created race by looping. Gate on the run *conclusion*
+          # so CI's continue-on-error 3.14 matrix job never blocks.
+          deadline=$(( SECONDS + 25 * 60 ))
+          conclusion=""
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            runs=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=1" 2>/dev/null || echo '{}')
+            status=$(echo "$runs" | jq -r '.workflow_runs[0].status // empty')
+            conclusion=$(echo "$runs" | jq -r '.workflow_runs[0].conclusion // empty')
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            echo "CI status: ${status:-not-found-yet}; waiting 20s..."
+            sleep 20
+          done
+          if [ "$conclusion" = "success" ]; then
+            echo "ci_passed=true" >> "$GITHUB_OUTPUT"
+            echo "CI passed — review will run."
+          else
+            echo "ci_passed=false" >> "$GITHUB_OUTPUT"
+            echo "CI did not pass (conclusion=${conclusion:-timeout}) — skipping review."
+          fi
 
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+  claude-review:
+    needs: wait-for-ci
+    if: {% raw %}${{ needs.wait-for-ci.outputs.ci_passed == 'true' }}{% endraw %}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write  # Required so the review action can post inline comments
+      contents: read          # Reviewer reads code; it must never commit
+      pull-requests: write     # Post inline review comments
       issues: read
       id-token: write
-
+      actions: read            # Read CI results instead of re-running them
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        # Gives the reviewer a working venv so its targeted `uv run` checks
+        # (freedom to investigate one finding) actually execute. REVIEW.md
+        # tells it not to re-run the full gate.
+        run: uv sync --all-extras --all-groups
 
       - name: Run Claude Code Review
         id: claude-review
@@ -49,10 +97,12 @@ jobs:
           # `--comment` tells the plugin to actually post (without it, the plugin
           # runs the full review and stops silently — burning ~$3/PR for no output).
           prompt: '/code-review:code-review --comment {% raw %}${{ github.repository }}{% endraw %}/pull/{% raw %}${{ github.event.pull_request.number }}{% endraw %}'
-          # Surface progress so a silent failure is visible: a sticky tracking
-          # comment updates during the run, and the Claude Code Report appears
-          # in the job's GitHub Step Summary.
+          # Surface progress so a silent failure is visible.
           track_progress: true
           display_report: true
+          # Grant the inline-comment tool (NOT in the default allow-set — this is
+          # what lets the reviewer post inline), gh read tools to read CI results,
+          # and scoped `uv run` for targeted investigation (REVIEW.md sets norms).
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml.jinja
+++ b/.github/workflows/claude-code-review.yml.jinja
@@ -2,6 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
+    # Match ci.yml's trigger. The review is gated on CI (wait-for-ci job), and
+    # the generated ci.yml only runs on PRs targeting main — firing the reviewer
+    # on other-target PRs would just idle the poll to its timeout, then skip.
+    # Broaden both together if a downstream gates CI on more branches.
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write        # Commit fixes when @claude is asked to fix something
+      pull-requests: write   # Post inline review comments
+      issues: write          # Update issue/PR comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/.github/workflows/claude.yml.jinja
+++ b/.github/workflows/claude.yml.jinja
@@ -25,9 +25,9 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write        # Commit fixes when @claude is asked to fix something
+      pull-requests: write   # Post inline review comments
+      issues: write          # Update issue/PR comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -25,6 +25,9 @@
 - Type hints everywhere
 - Tests: `pytest` with fixtures in `tests/fixtures/`
 
+The automated Claude review runs **only after CI passes** — if CI is red, no
+review is posted. Fix CI and push; the review runs on the next green run.
+
 ## Hard PR Acceptance Gates
 
 Every PR must pass **all** of the following before merge. Do not open or push a PR until these are green locally:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,32 @@
+# Review instructions
+
+<!-- DOMAIN-REVIEW-START -->
+<!-- Add project-specific review rules here. Kept across copier update. -->
+<!-- DOMAIN-REVIEW-END -->
+
+<!-- ===== TEMPLATE-OWNED BELOW — DO NOT EDIT; OVERWRITTEN ON COPIER UPDATE ===== -->
+
+## Don't reproduce CI
+
+CI already enforces the full gate: ruff (lint + format), mypy, the pytest
+matrix, dependency audit, secret scan, Vale prose, and — when enabled — the
+structural gate. Do **not** report findings those checks already gate, and do
+**not** re-run the gate. When you need a check's result, read it from CI
+(`gh run view`) instead of running it yourself.
+
+## Investigate narrowly
+
+You may run a single targeted command to confirm one specific hypothesis (for
+example, one test or `mypy` on one file). This is for verifying a finding — not
+for re-executing the suite.
+
+## Focus
+
+Report correctness bugs, security issues, and regressions introduced by this
+diff. Behavior claims need a `file:line` citation in the source, not an
+inference from naming.
+
+## Converge
+
+After the first review of a PR, suppress repeat nits and post Important
+findings only. A one-line fix should not reach round seven on style.

--- a/REVIEW.md.jinja
+++ b/REVIEW.md.jinja
@@ -1,0 +1,32 @@
+# Review instructions
+
+<!-- DOMAIN-REVIEW-START -->
+<!-- Add project-specific review rules here. Kept across copier update. -->
+<!-- DOMAIN-REVIEW-END -->
+
+<!-- ===== TEMPLATE-OWNED BELOW — DO NOT EDIT; OVERWRITTEN ON COPIER UPDATE ===== -->
+
+## Don't reproduce CI
+
+CI already enforces the full gate: ruff (lint + format), mypy, the pytest
+matrix, dependency audit, secret scan, Vale prose, and — when enabled — the
+structural gate. Do **not** report findings those checks already gate, and do
+**not** re-run the gate. When you need a check's result, read it from CI
+(`gh run view`) instead of running it yourself.
+
+## Investigate narrowly
+
+You may run a single targeted command to confirm one specific hypothesis (for
+example, one test or `mypy` on one file). This is for verifying a finding — not
+for re-executing the suite.
+
+## Focus
+
+Report correctness bugs, security issues, and regressions introduced by this
+diff. Behavior claims need a `file:line` citation in the source, not an
+inference from naming.
+
+## Converge
+
+After the first review of a PR, suppress repeat nits and post Important
+findings only. A one-line fix should not reach round seven on style.

--- a/docs/superpowers/plans/2026-07-08-claude-review-workflow-hardening.md
+++ b/docs/superpowers/plans/2026-07-08-claude-review-workflow-hardening.md
@@ -1,0 +1,440 @@
+# Claude review-workflow hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the four `claude-review` bot complaints (inline comments, gate-running, "custom command", commit-on-mention) and make the review depend on CI passing — in both the `.jinja` (downstream) and the template's own non-`.jinja` workflows.
+
+**Architecture:** Realign the `@claude` responder to canonical write permissions; add the canonical `claude_args` inline-comment/investigation allow-list plus a `uv` env and a `wait-for-ci` gating job to the reviewer; add a `REVIEW.md` scoping the reviewer away from reproducing CI; document the CI dependency in the generated `CLAUDE.md`.
+
+**Tech Stack:** GitHub Actions YAML, Jinja2 (copier templates), `anthropics/claude-code-action@v1`, `gh` CLI, `uv`.
+
+## Global Constraints
+
+- Design spec: `docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md`. Closes issue **#242**.
+- Every `.jinja` change has a **non-`.jinja` twin** in this repo's own `.github/workflows/` — change both in the same task (fix the class, not the instance).
+- Wait-for-CI target: workflow **`ci.yml`** downstream (`.jinja`), workflow **`template-ci.yml`** in this repo (non-`.jinja`).
+- Pin action versions to match existing template usage: `actions/checkout@v7`, `astral-sh/setup-uv@v8.2.0`, `actions/cache@v6`. Python `3.12` for the reviewer env (mirrors `ci.yml.jinja` lint job).
+- `{% raw %}…{% endraw %}` wraps every `${{ … }}` GitHub expression inside `.jinja` files (copier renders `{{ }}`); non-`.jinja` files use bare `${{ … }}`.
+- Reviewer keeps `contents: read` (it must never commit); only the `@claude` responder gets `contents: write`.
+- Commit messages: Conventional Commits; end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- Verification is render + YAML-parse + `template-ci`, then a live PR (workflows cannot be unit-tested locally). Do not claim the bot behaviors are fixed until the live-PR step (Task 6) is observed.
+
+---
+
+### Task 1: `@claude` responder — canonical write permissions
+
+**Files:**
+- Modify: `.github/workflows/claude.yml.jinja` (permissions block, ~lines 27-32)
+- Modify: `.github/workflows/claude.yml` (permissions block, same block)
+
+**Interfaces:**
+- Produces: an `@claude` responder that can post inline PR comments (`pull-requests: write`) and commit fixes (`contents: write`). No later task depends on its internals.
+
+- [ ] **Step 1: Edit both files' permissions blocks**
+
+In **both** `.github/workflows/claude.yml.jinja` and `.github/workflows/claude.yml`, change the `permissions:` block from:
+
+```yaml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+```
+
+to:
+
+```yaml
+    permissions:
+      contents: write        # Commit fixes when @claude is asked to fix something
+      pull-requests: write   # Post inline review comments
+      issues: write          # Update issue/PR comments
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+```
+
+Leave the `if:` fork-guard, `additional_permissions`, and all other content unchanged.
+
+- [ ] **Step 2: Verify the non-`.jinja` file is valid YAML**
+
+Run: `uv run --no-project --with pyyaml python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/claude.yml')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Verify both files now grant write**
+
+Run: `grep -c "contents: write" .github/workflows/claude.yml .github/workflows/claude.yml.jinja`
+Expected: each file reports `1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/claude.yml .github/workflows/claude.yml.jinja
+git commit -m "fix(claude): grant @claude responder write perms for inline comments + commits
+
+Refs #242
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `REVIEW.md` — scope the reviewer away from reproducing CI
+
+**Files:**
+- Create: `REVIEW.md.jinja` (renders to `REVIEW.md` downstream)
+- Create: `REVIEW.md` (this repo's own reviewer)
+
+**Interfaces:**
+- Produces: a repo-root `REVIEW.md` read by the reviewer as highest-priority instructions. Task 3's `REVIEW.md`-based scoping (complaint #2) depends on this file existing.
+
+- [ ] **Step 1: Create `REVIEW.md.jinja`**
+
+Create `REVIEW.md.jinja` with exactly this content:
+
+```markdown
+# Review instructions
+
+<!-- DOMAIN-REVIEW-START -->
+<!-- Add project-specific review rules here. Kept across copier update. -->
+<!-- DOMAIN-REVIEW-END -->
+
+<!-- ===== TEMPLATE-OWNED BELOW — DO NOT EDIT; OVERWRITTEN ON COPIER UPDATE ===== -->
+
+## Don't reproduce CI
+
+CI already enforces the full gate: ruff (lint + format), mypy, the pytest
+matrix, dependency audit, secret scan, Vale prose, and — when enabled — the
+structural gate. Do **not** report findings those checks already gate, and do
+**not** re-run the gate. When you need a check's result, read it from CI
+(`gh run view`) instead of running it yourself.
+
+## Investigate narrowly
+
+You may run a single targeted command to confirm one specific hypothesis (for
+example, one test or `mypy` on one file). This is for verifying a finding — not
+for re-executing the suite.
+
+## Focus
+
+Report correctness bugs, security issues, and regressions introduced by this
+diff. Behavior claims need a `file:line` citation in the source, not an
+inference from naming.
+
+## Converge
+
+After the first review of a PR, suppress repeat nits and post Important
+findings only. A one-line fix should not reach round seven on style.
+```
+
+- [ ] **Step 2: Create the template's own `REVIEW.md`**
+
+Create `REVIEW.md` with the **same** content as Step 1 (identical bytes — the template dogfoods its own reviewer).
+
+- [ ] **Step 3: Verify both exist and match**
+
+Run: `diff REVIEW.md REVIEW.md.jinja && echo IDENTICAL`
+Expected: `IDENTICAL` (no jinja expressions in this file, so the two are byte-identical)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add REVIEW.md REVIEW.md.jinja
+git commit -m "feat(review): add REVIEW.md scoping the reviewer away from re-running CI
+
+Refs #242
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Reviewer — inline-comment allow-list, uv env, wait-for-CI gate
+
+**Files:**
+- Modify: `.github/workflows/claude-code-review.yml.jinja` (rewrite the job structure)
+- Modify: `.github/workflows/claude-code-review.yml` (same, wait target `template-ci.yml`)
+
+**Interfaces:**
+- Consumes: `REVIEW.md` from Task 2 (read automatically by the reviewer at repo root).
+- Produces: a reviewer that (a) posts inline comments via the granted `mcp__github_inline_comment__create_inline_comment` tool, (b) can run targeted `uv run` checks, (c) reads CI results, and (d) only runs when the CI workflow concluded `success` for the PR head SHA.
+
+- [ ] **Step 1: Rewrite `.github/workflows/claude-code-review.yml.jinja`**
+
+Replace the file's `jobs:` section so there are two jobs — `wait-for-ci` (gate) and `claude-review` (`needs` it). Keep the existing `name:`, `on:` block, and the fork-guard comment. The full file becomes:
+
+```yaml
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  wait-for-ci:
+    # Skip PRs from forks: GitHub does not expose repository secrets
+    # (including CLAUDE_CODE_OAUTH_TOKEN) to workflows running in fork-PR
+    # context, regardless of maintainer approval. Running anyway produces
+    # a hard-failing check on every external contribution.
+    if: {% raw %}${{ github.event.pull_request.head.repo.full_name == github.repository }}{% endraw %}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+    outputs:
+      ci_passed: {% raw %}${{ steps.wait.outputs.ci_passed }}{% endraw %}
+    steps:
+      - name: Wait for CI to conclude on this PR head
+        id: wait
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          REPO: {% raw %}${{ github.repository }}{% endraw %}
+          HEAD_SHA: {% raw %}${{ github.event.pull_request.head.sha }}{% endraw %}
+        run: |
+          set -euo pipefail
+          # Gate the review on the CI workflow: only review code the gate
+          # accepted. Poll the CI run for THIS PR head SHA (not github.sha,
+          # which is the merge commit) until it completes; tolerate the
+          # not-yet-created race by looping. Gate on the run *conclusion*
+          # so CI's continue-on-error 3.14 matrix job never blocks.
+          deadline=$(( SECONDS + 25 * 60 ))
+          conclusion=""
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            runs=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=1" 2>/dev/null || echo '{}')
+            status=$(echo "$runs" | jq -r '.workflow_runs[0].status // empty')
+            conclusion=$(echo "$runs" | jq -r '.workflow_runs[0].conclusion // empty')
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            echo "CI status: ${status:-not-found-yet}; waiting 20s..."
+            sleep 20
+          done
+          if [ "$conclusion" = "success" ]; then
+            echo "ci_passed=true" >> "$GITHUB_OUTPUT"
+            echo "CI passed — review will run."
+          else
+            echo "ci_passed=false" >> "$GITHUB_OUTPUT"
+            echo "CI did not pass (conclusion=${conclusion:-timeout}) — skipping review."
+          fi
+
+  claude-review:
+    needs: wait-for-ci
+    if: {% raw %}${{ needs.wait-for-ci.outputs.ci_passed == 'true' }}{% endraw %}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # Reviewer reads code; it must never commit
+      pull-requests: write     # Post inline review comments
+      issues: read
+      id-token: write
+      actions: read            # Read CI results instead of re-running them
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Cache Python interpreter
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/uv/python
+          key: uv-python-3.12-{% raw %}${{ runner.os }}{% endraw %}
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        # Gives the reviewer a working venv so its targeted `uv run` checks
+        # (freedom to investigate one finding) actually execute. REVIEW.md
+        # tells it not to re-run the full gate.
+        run: uv sync --all-extras --all-groups
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: {% raw %}${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}{% endraw %}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          # `--comment` tells the plugin to actually post (without it, the plugin
+          # runs the full review and stops silently — burning ~$3/PR for no output).
+          prompt: '/code-review:code-review --comment {% raw %}${{ github.repository }}{% endraw %}/pull/{% raw %}${{ github.event.pull_request.number }}{% endraw %}'
+          # Surface progress so a silent failure is visible.
+          track_progress: true
+          display_report: true
+          # Grant the inline-comment tool (NOT in the default allow-set — this is
+          # what lets the reviewer post inline), gh read tools to read CI results,
+          # and scoped `uv run` for targeted investigation (REVIEW.md sets norms).
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+```
+
+- [ ] **Step 2: Rewrite `.github/workflows/claude-code-review.yml` (non-`.jinja`)**
+
+Create the same two-job structure in the non-`.jinja` file, with these differences: no `{% raw %}` wrappers (bare `${{ … }}`), the wait targets **`template-ci.yml`**, and the token line stays `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`. The `gh api` line becomes:
+
+```bash
+            runs=$(gh api "repos/${REPO}/actions/workflows/template-ci.yml/runs?head_sha=${HEAD_SHA}&per_page=1" 2>/dev/null || echo '{}')
+```
+
+Everything else (permissions blocks, uv setup, plugin inputs, `claude_args`) is identical to Step 1 with `${{ … }}` unwrapped.
+
+- [ ] **Step 3: Verify the non-`.jinja` file is valid YAML**
+
+Run: `uv run --no-project --with pyyaml python -c "import yaml; d=yaml.safe_load(open('.github/workflows/claude-code-review.yml')); assert set(d['jobs'])=={'wait-for-ci','claude-review'}; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Verify the inline-comment tool grant is present in both files**
+
+Run: `grep -c "mcp__github_inline_comment__create_inline_comment" .github/workflows/claude-code-review.yml .github/workflows/claude-code-review.yml.jinja`
+Expected: each file reports `1`
+
+- [ ] **Step 5: Verify each file waits on the correct CI workflow**
+
+Run: `grep -o "workflows/[a-z-]*\.yml/runs" .github/workflows/claude-code-review.yml .github/workflows/claude-code-review.yml.jinja`
+Expected: the non-`.jinja` line shows `workflows/template-ci.yml/runs`; the `.jinja` line shows `workflows/ci.yml/runs`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/claude-code-review.yml .github/workflows/claude-code-review.yml.jinja
+git commit -m "fix(claude-review): grant inline-comment tool, add uv env + CI-pass gate
+
+Adds the canonical mcp__github_inline_comment__create_inline_comment grant
+(the missing piece behind 'unable to create inline comments'), a uv venv +
+scoped uv/gh allow-list for targeted investigation, and a wait-for-ci job so
+the review only runs once CI concludes success.
+
+Refs #242
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Document the CI dependency in the generated `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md.jinja` (a template-owned section, not a `DOMAIN` block)
+
+**Interfaces:**
+- Produces: a one-line contributor expectation. No task depends on it.
+
+- [ ] **Step 1: Find the template-owned Conventions/CI area**
+
+Run: `grep -n "Conventional commits\|TEMPLATE-OWNED\|## Conventions" CLAUDE.md.jinja`
+Expected: locates the template-owned `## Conventions` section (below the `TEMPLATE-OWNED SECTIONS BELOW` banner).
+
+- [ ] **Step 2: Add the expectation line**
+
+Immediately after the `## Conventions` bullet list in `CLAUDE.md.jinja`, add this paragraph:
+
+```markdown
+The automated Claude review runs **only after CI passes** — if CI is red, no
+review is posted. Fix CI and push; the review runs on the next green run.
+```
+
+- [ ] **Step 3: Verify the line is present and inside the template-owned region**
+
+Run: `grep -n "only after CI passes" CLAUDE.md.jinja`
+Expected: one match, at a line number greater than the `TEMPLATE-OWNED SECTIONS BELOW` banner line (confirm by also running `grep -n "TEMPLATE-OWNED SECTIONS BELOW" CLAUDE.md.jinja`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md.jinja
+git commit -m "docs(claude): note review runs only after CI passes
+
+Refs #242
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Render gate — prove the template still renders and its gate passes
+
+**Files:** none modified (integration verification of Tasks 1-4)
+
+**Interfaces:**
+- Consumes: all prior tasks' files.
+- Produces: confidence that rendered output is valid and the generated project's gate is green.
+
+- [ ] **Step 1: Render the template from HEAD**
+
+Run:
+```bash
+rm -rf /tmp/smoke
+uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/smoke
+```
+Expected: render completes with no error; note copier reads the git index, so all prior commits (Tasks 1-4) must be committed first.
+
+- [ ] **Step 2: Confirm the rendered files exist and are valid YAML/Markdown**
+
+Run:
+```bash
+test -f /tmp/smoke/REVIEW.md && echo "REVIEW.md OK"
+uv run --no-project --with pyyaml python -c "import yaml; [yaml.safe_load(open('/tmp/smoke/.github/workflows/'+f)) for f in ('claude.yml','claude-code-review.yml')]; print('workflows OK')"
+grep -q "only after CI passes" /tmp/smoke/CLAUDE.md && echo "CLAUDE.md note OK"
+grep -q "workflows/ci.yml/runs" /tmp/smoke/.github/workflows/claude-code-review.yml && echo "wait target OK"
+grep -q "mcp__github_inline_comment__create_inline_comment" /tmp/smoke/.github/workflows/claude-code-review.yml && echo "inline grant OK"
+```
+Expected: `REVIEW.md OK`, `workflows OK`, `CLAUDE.md note OK`, `wait target OK`, `inline grant OK`
+
+- [ ] **Step 3: Run the generated project's gate**
+
+Run:
+```bash
+cd /tmp/smoke
+uv sync --all-extras --all-groups
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/ tests/ && uv run pytest -x -q
+```
+Expected: all pass (this change touches no Python; the gate confirms the render is intact).
+
+- [ ] **Step 4: No commit** (verification only). Return to the repo dir: `cd -`.
+
+---
+
+### Task 6: Live-PR verification (the real gate)
+
+**Files:** none — behavioral verification that cannot be done locally.
+
+**Interfaces:**
+- Consumes: the merged/pushed workflow changes.
+- Produces: observed evidence the four complaints are resolved. **Do not claim the fix works before this step.**
+
+- [ ] **Step 1: Push the branch and open the PR** (see Execution Handoff — the PR closes #242).
+
+- [ ] **Step 2: Observe the reviewer on the PR**, confirming in order:
+  - the `wait-for-ci` job waits, and `claude-review` is **skipped** while CI is red / runs only once CI is green;
+  - the reviewer **posts inline comments** (proves the `mcp__github_inline_comment__create_inline_comment` grant is the path the plugin uses — if inline comments still fail, capture the run log; the plugin may post via a different tool that then needs allow-listing);
+  - the reviewer **does not** emit the "couldn't run pytest/ruff/mypy" lament (proves REVIEW.md scoping).
+
+- [ ] **Step 3: Observe the responder** — comment `@claude` asking for a trivial fix on the PR; confirm it can post an inline comment and push a commit (proves Task 1 write perms).
+
+- [ ] **Step 4: Record the observations** in the PR thread. If any check fails, treat it as a design-gap signal (return to the spec), not a one-off patch.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 responder write perms → Task 1 ✓
+- §2 reviewer allow-list + actions:read + uv env → Task 3 ✓
+- §2d wait-for-ci gate + failure modes (SHA, race, self-deadlock, matrix, timeout, fail, never-ran) → Task 3 Step 1 poll ✓
+- §3 REVIEW.md.jinja (DOMAIN sentinel, template-owned) → Task 2 ✓
+- §4 CLAUDE.md CI-dependency line → Task 4 ✓
+- copier.yml → no change required (spec §copier wiring) ✓
+- fix-the-class (non-`.jinja` twins + template REVIEW.md) → Tasks 1-3 both files ✓
+- Testing/verification plan → Tasks 5 (render gate) + 6 (live PR) ✓
+
+**Placeholder scan:** every workflow/markdown block is complete copy-paste content; no TBD/TODO; the only conditional (non-`.jinja` differences) is resolved explicitly in Task 3 Step 2.
+
+**Type/name consistency:** job names `wait-for-ci` / `claude-review`, output `ci_passed`, and the `needs.wait-for-ci.outputs.ci_passed == 'true'` gate are used identically across Task 3 and the verification greps. Wait target `ci.yml` (jinja) vs `template-ci.yml` (non-jinja) is stated consistently in Global Constraints, Task 3, and the greps.

--- a/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
@@ -1,0 +1,218 @@
+# Claude review-workflow hardening
+
+**Date:** 2026-07-08
+**Status:** Design — awaiting review
+**Scope:** The template's two Claude GitHub workflows (`claude-code-review.yml.jinja`,
+`claude.yml.jinja`) plus a new `REVIEW.md.jinja`. Rolls out to the four
+downstream repos via `copier update`.
+
+## Problem
+
+The `claude-review` bot in downstream projects consistently complains about
+four things (not all in every PR):
+
+1. **"Running a custom command."** The reviewer runs the `code-review` plugin's
+   `/code-review:code-review` slash command; the bot narrates this as a "custom
+   command," which reads as a warning.
+2. **Can't run the gate.** The bot reports it could not execute `pytest`/`ruff`/
+   `mypy` ("Bash tool required approval for anything beyond basic git read
+   commands") and falls back to static reading of the diff.
+3. **Can't create inline comments.**
+4. **Can't create commits to fix things itself.**
+
+## Root-cause analysis (verified against upstream)
+
+The complaints split cleanly across the two workflows, and three of the four are
+concrete misconfigurations confirmed against the canonical
+`anthropics/claude-code-action@v1` examples and the Claude Code docs
+(`/en/github-actions`, `/en/code-review`).
+
+| # | Workflow | Root cause | Canonical evidence |
+|---|----------|-----------|--------------------|
+| 3 (inline) | `claude-code-review.yml` | The reviewer sets **no `claude_args`**, so the inline-comment tool `mcp__github_inline_comment__create_inline_comment` — which is **not** in the default allow-set — is never granted. It cannot post inline. | `examples/pr-review-comprehensive.yml` allow-lists exactly that tool. |
+| 2 (gate) | `claude-code-review.yml` | The reviewer is a **diff-correctness reviewer, not a gate-runner**. Upstream's review example allow-lists only `gh pr` tools — never `pytest`/`ruff`/`mypy`. The lament is the reviewer straying outside its lane, not a missing permission. | `/en/code-review` recommends telling the reviewer (via `REVIEW.md`) to skip "anything your CI already enforces like linting." |
+| 1 (custom cmd) | `claude-code-review.yml` | `/code-review:code-review` is a **legitimate first-party plugin** (there is no built-in `/code-review` in the action runtime — it must be installed as a plugin). The "custom command" line is benign narration. | `/en/github-actions` "Using skills" shows the identical `plugins:` + `/code-review:code-review` invocation as the blessed pattern. |
+| 3/4 (mention) | `claude.yml` (`@claude` responder) | Permissions diverged to `contents: read` / `pull-requests: read` / `issues: read`. Inline comments need `pull-requests: write`; commits need `contents: write`. | `examples/claude.yml` uses `contents: write`, `pull-requests: write`, `issues: write`. |
+
+## Decisions
+
+Locked with the user:
+
+- **Keep the plugin** for the reviewer (tuned multi-agent review + verification +
+  severity tags). Complaint #1 stays cosmetic-only.
+- **Both** scope *and* investigate for #2: a `REVIEW.md` tells the reviewer not to
+  reproduce CI, but it keeps a scoped Bash allow-list so it can run a *targeted*
+  check to verify a single finding (freedom to investigate, not re-run the gate).
+- **@claude responder gets full write** (`contents`/`pull-requests`/`issues:
+  write`) — fixes #3 and #4 on mention.
+- **Review depends on CI**, via **`pull_request` trigger + a wait-for-CI step**
+  (keeps the canonical PR-context path the plugin/inline-posting is documented to
+  support — avoids the off-canonical `workflow_run`-for-review risk). The review
+  **only runs if CI passed**.
+
+## Design
+
+### 1 — `claude.yml.jinja` (the `@claude` responder)
+
+Realign the `permissions:` block to the canonical `examples/claude.yml`:
+
+```yaml
+permissions:
+  contents: write        # was read — enables commit fixes (#4)
+  pull-requests: write   # was read — enables inline comments (#3)
+  issues: write          # was read
+  id-token: write
+  actions: read
+```
+
+**Keep** the template's stricter fork-guard `if:` (the head-repo check on
+`pull_request_review*` events) — that is deliberate hardening upstream lacks, not
+drift. No other changes.
+
+**Security note.** `claude-code-action` gates who can trigger it: it only acts for
+users with write access to the repo (an @claude mention from a random external
+commenter does not get a write token). The fork-context events are additionally
+guarded by the `if:`. Granting write is the documented posture for the responder.
+
+### 2 — `claude-code-review.yml.jinja` (the reviewer)
+
+Keep the plugin invocation (`/code-review:code-review --comment <url>`,
+`track_progress: true`, `display_report: true`). Add:
+
+**a. The canonical allow-list** (fixes #3, enables targeted investigation):
+
+```yaml
+claude_args: |
+  --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(uv run pytest:*),Bash(uv run mypy:*),Bash(uv run ruff:*)"
+```
+
+- `mcp__github_inline_comment__create_inline_comment` — the missing inline-comment
+  tool (**#3**).
+- `gh run view`/`gh run list` — **read** CI results instead of re-running them.
+- `uv run pytest`/`mypy`/`ruff` — **freedom to investigate** one finding (scoped;
+  `REVIEW.md` sets the norm that this is not for reproducing the gate).
+
+**b. `actions: read`** added to the `permissions:` block so the reviewer can read
+CI results. **Keep `contents: read`** — the reviewer must never commit.
+
+**c. Environment setup** so the targeted `uv run` checks actually work — mirror
+`ci.yml.jinja`'s lint job: `astral-sh/setup-uv@v8.2.0`, cache the interpreter,
+`uv python install 3.12`, `uv sync --all-extras --all-groups`. (Cost: this adds
+setup time to each review; accepted as the price of live investigation.)
+
+**d. Trigger + CI gate** — replace the bare `pull_request` job with a
+two-job structure so the review only runs after CI passes:
+
+- Job `wait-for-ci`: on the same `pull_request` event, poll the **CI** workflow
+  run for the PR **head SHA** until it completes, and emit
+  `outputs.ci_passed = (conclusion == 'success')`.
+- Job `review`: `needs: wait-for-ci`, `if: needs.wait-for-ci.outputs.ci_passed
+  == 'true'`. If CI failed, the review is skipped **neutrally** (no scary red
+  review check on the PR).
+
+Prefer a **`gh`-based poll** (dependency-free, matches the template's ethos)
+over a third-party wait-action, because polling the **workflow-run conclusion**
+(not individual check names) is the only correct way to tolerate CI's
+`continue-on-error` experimental 3.14 matrix job.
+
+#### wait-for-ci failure modes (must be handled)
+
+Per the project's failure-mode-enumeration discipline, the poll must address:
+
+1. **Check-not-yet-created race** — the review job and CI start on the same
+   event; the CI run for the head SHA may not exist yet when the poll begins.
+   Poll with retry; "no run found yet" ≠ "passed."
+2. **Wrong SHA** — check runs attach to `github.event.pull_request.head.sha`, not
+   `github.sha` (the merge commit). Use the head SHA.
+3. **Self-deadlock** — poll only the workflow **named `CI`**, never this review
+   workflow, so it can't wait on itself.
+4. **Experimental matrix job** — CI's Python 3.14 job is `continue-on-error:
+   true`. Gating on the **run conclusion** (not per-check) correctly treats its
+   failure as non-blocking.
+5. **Timeout** — set a job `timeout-minutes` and a poll deadline; on timeout,
+   emit `ci_passed=false` (skip the review) rather than idling forever.
+6. **CI failed** — `ci_passed=false` → review skipped (the gating decision).
+7. **CI never ran** (paths filter / skipped) — resolves via the timeout in (5) to
+   a skip.
+
+### 3 — new `REVIEW.md.jinja` → `REVIEW.md`
+
+A repo-root `REVIEW.md` — read by the reviewer as highest-priority instructions —
+following the same **template-owned + `DOMAIN` sentinel** pattern as
+`CLAUDE.md.jinja` (NOT `_skip_if_exists`; a `<!-- DOMAIN-REVIEW-START/END -->`
+block carries per-project rules that survive `copier update`, the rest is
+template-owned and overwritten).
+
+Fleet-wide (template-owned) content:
+
+- **Don't reproduce CI.** CI already enforces ruff (lint + format), mypy, the
+  pytest matrix, dependency audit, secret scan, Vale prose, and (if enabled) the
+  structural gate. Do not report findings those checks already gate, and do not
+  re-run the full gate. Read CI results (`gh run view`) when you need them.
+- **Investigate narrowly.** You may run a single targeted command to confirm one
+  specific hypothesis — not to re-execute the suite.
+- **Focus.** Correctness, security, and regressions introduced by the diff.
+- **Verification bar.** Behavior claims need a `file:line` citation, not an
+  inference from naming.
+- **Convergence.** After the first review, suppress repeat nits; post Important
+  findings only.
+
+Keep it short (the doc warns a long `REVIEW.md` dilutes the rules that matter).
+
+### 4 — `CLAUDE.md.jinja` (generated project): document the CI dependency
+
+Add a short line to a template-owned section of the generated project's
+`CLAUDE.md` so contributors aren't surprised when no review appears on a red PR:
+
+> The automated Claude review runs **only after CI passes** — if CI is red, no
+> review is posted; fix CI and push, and the review runs on the next green run.
+
+This keeps expectations aligned with the `wait-for-ci` gate (design §2d). One
+sentence, in the template-owned CI/workflow area (not a `DOMAIN` block).
+
+### copier.yml wiring
+
+- Register `REVIEW.md.jinja` following the `CLAUDE.md` precedent (the block of
+  comments around line 83/107 that documents why root `.md` files are
+  template-owned and appear in `_exclude` for the self-test). Add `REVIEW.md` to
+  the same named-file `_exclude` note so the template's own copy isn't rendered
+  into itself.
+- No new copier variable is required; `REVIEW.md` content is static plus the
+  `DOMAIN-REVIEW` sentinel.
+
+## Testing & verification plan
+
+Because running a plugin review + inline posting has moving parts, verify
+empirically before rollout (do not trust static reasoning alone):
+
+1. **Render gate** (per the template's `CLAUDE.md`): commit, render with
+   `--vcs-ref=HEAD` and `smoke-answers.yml`, run the generated project's full
+   local gate. Confirm `REVIEW.md`, both workflows, and `copier.yml` render
+   cleanly and `template-ci` passes on 3.11–3.14.
+2. **Live PR on the template's own generated smoke, or a canary downstream
+   repo:** open a test PR and confirm, in order:
+   - the review job **waits** for CI and is **skipped** when CI is red;
+   - on green CI, the reviewer **posts inline comments** (proves the
+     `mcp__github_inline_comment__create_inline_comment` grant is what the plugin
+     uses — if the plugin posts by another path, adjust the allow-list);
+   - the reviewer **reads CI results** rather than re-running the gate, and no
+     longer emits the "couldn't run pytest" lament;
+   - an `@claude` mention asking for a fix can **commit** and **comment inline**
+     (proves the responder write perms).
+3. Only after (2) passes, roll out downstream via `copier update`.
+
+## Rollout
+
+Template PR closes the tracking issue, then `copier update` to the four
+downstream consumers (each a separate PR per the fleet-convergence process).
+`REVIEW.md` lands as a new template-owned file; downstream per-repo review rules
+go in the `DOMAIN-REVIEW` block.
+
+## Out of scope
+
+- The **managed Code Review service** (Claude GitHub App) is unavailable — it
+  requires a Team/Enterprise plan, which this account does not have. The
+  self-hosted GitHub Actions path in this spec is therefore the only option, not
+  merely the chosen one.
+- Switching the reviewer to a plain natural-language prompt (would erase the
+  "custom command" narration but lose the tuned plugin pipeline) — rejected.

--- a/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
@@ -172,13 +172,25 @@ sentence, in the template-owned CI/workflow area (not a `DOMAIN` block).
 
 ### copier.yml wiring
 
-- Register `REVIEW.md.jinja` following the `CLAUDE.md` precedent (the block of
-  comments around line 83/107 that documents why root `.md` files are
-  template-owned and appear in `_exclude` for the self-test). Add `REVIEW.md` to
-  the same named-file `_exclude` note so the template's own copy isn't rendered
-  into itself.
+- **No `copier.yml` change is required.** Per the existing comment (~line 107),
+  named root `.md` files render via `.jinja` precedence automatically:
+  `REVIEW.md.jinja` renders to `REVIEW.md` in generated projects, while a plain
+  `REVIEW.md` in the template repo stays template-only. Like `CLAUDE.md`,
+  `REVIEW.md` is template-owned (NOT `_skip_if_exists`) with a `DOMAIN-REVIEW`
+  sentinel block, so no `_skip_if_exists` / `_exclude` entry is needed.
 - No new copier variable is required; `REVIEW.md` content is static plus the
   `DOMAIN-REVIEW` sentinel.
+
+### Fix the class, not the instance
+
+The template's **own** non-`.jinja` `.github/workflows/claude.yml` and
+`claude-code-review.yml` carry the identical defects (the reviewer has no
+`claude_args`, so the same inline-comment tool is missing). They are fixed in the
+same PR — the `.jinja` (downstream) and non-`.jinja` (this repo's own) copies
+move together. The only divergence: the wait-for-CI target is the `CI` workflow
+downstream and the `template-ci` workflow here. A plain `REVIEW.md` is added at
+the template root alongside `REVIEW.md.jinja` so this repo's own reviewer is
+scoped too.
 
 ## Testing & verification plan
 

--- a/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md
@@ -187,10 +187,14 @@ The template's **own** non-`.jinja` `.github/workflows/claude.yml` and
 `claude-code-review.yml` carry the identical defects (the reviewer has no
 `claude_args`, so the same inline-comment tool is missing). They are fixed in the
 same PR — the `.jinja` (downstream) and non-`.jinja` (this repo's own) copies
-move together. The only divergence: the wait-for-CI target is the `CI` workflow
-downstream and the `template-ci` workflow here. A plain `REVIEW.md` is added at
-the template root alongside `REVIEW.md.jinja` so this repo's own reviewer is
-scoped too.
+move together. Two justified divergences between the twins: (1) the wait-for-CI
+target is the `CI` workflow downstream and the `template-ci` workflow here; (2)
+the reviewer's `pull_request` trigger matches each repo's CI trigger — the
+downstream `.jinja` reviewer adds `branches: [main]` (downstream `ci.yml` is
+main-only, so firing elsewhere would only idle the poll to timeout), while this
+repo's reviewer keeps all-PR triggering (its `template-ci` runs on every PR).
+A plain `REVIEW.md` is added at the template root alongside `REVIEW.md.jinja` so
+this repo's own reviewer is scoped too.
 
 ## Testing & verification plan
 


### PR DESCRIPTION
Closes #242.

Fixes the four recurring `claude-review` bot complaints and makes the review depend on CI passing. Full design: `docs/superpowers/specs/2026-07-08-claude-review-workflow-hardening-design.md`.

## Root causes → fixes

| Complaint | Root cause (verified against upstream) | Fix |
|-----------|----------------------------------------|-----|
| Can't post **inline comments** | Reviewer set no `claude_args`, so `mcp__github_inline_comment__create_inline_comment` (not default-granted) was missing | Add the canonical allow-list to `claude-code-review.yml{,.jinja}` |
| Can't run **pytest/ruff/mypy** | The reviewer is a diff-correctness reviewer, not a gate-runner | New `REVIEW.md{,.jinja}` scopes it off CI's turf; a scoped `uv run` allow-list + `uv` env preserves targeted investigation |
| "Running a **custom command**" | `/code-review:code-review` is the canonical first-party plugin (no built-in exists) | Benign — documented, no change |
| `@claude` can't **commit / inline-comment** | Responder perms drifted to read-only | `claude.yml{,.jinja}` → `contents`/`pull-requests`/`issues: write` (matches upstream `examples/claude.yml`) |

## CI dependency (new)

The reviewer now runs only after CI passes: a `wait-for-ci` job polls the CI workflow run for the PR **head SHA** and gates the review on `conclusion == success`. Poll handles the not-yet-created race, the `continue-on-error` 3.14 matrix job (gates on run conclusion, not per-check), timeouts, and fork PRs (double-protected). The reviewer keeps `contents: read` — it must never commit.

## Fix-the-class

Both the `.jinja` (downstream) and the template's own non-`.jinja` workflow twins are fixed together. Justified twin divergences: wait target (`ci.yml` vs `template-ci.yml`) and reviewer trigger (downstream adds `branches: [main]` to match its main-only CI; the template keeps all-PR triggering to match `template-ci`).

## Verification

- Template renders cleanly; generated project's gate green (ruff, mypy, **pytest 55 passed / 16 pre-existing skips**).
- Multi-agent review verified fork-guard, poll correctness, permission split, and jinja hygiene independently.
- **This PR is the live check** for the one thing local tests can't prove — that `--allowedTools` augments (not replaces) the default tools so inline posting actually works. The template's own (fixed) reviewer will review this PR; confirm inline comments appear, the CI-gate waits, and no "couldn't run pytest" lament before rolling out downstream via `copier update`.

## Downstream rollout (after merge)

`copier update` to the four consumers, each a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._