### PR TITLE
docs: point contributors to REVIEW.md (verifies hardened claude-review runs)

### DIFF
--- a/CLAUDE.md.jinja
+++ b/CLAUDE.md.jinja
@@ -26,7 +26,9 @@
 - Tests: `pytest` with fixtures in `tests/fixtures/`
 
 The automated Claude review runs **only after CI passes** — if CI is red, no
-review is posted. Fix CI and push; the review runs on the next green run.
+review is posted. Fix CI and push; the review runs on the next green run. To
+tune what the reviewer flags for this repo, add rules to the `DOMAIN-REVIEW`
+block in `REVIEW.md`.
 
 ## Hard PR Acceptance Gates
 


### PR DESCRIPTION
Closes #244.

## What this is

A deliberately trivial, **non-workflow** documentation change (one sentence in `CLAUDE.md.jinja` pointing contributors to `REVIEW.md`'s `DOMAIN-REVIEW` block). Its real purpose is to **verify the hardened `claude-review` from #243 actually works** now that it's on `main`.

#243 could not self-verify: `claude-code-action` skips the review on any PR that modifies the review workflow. This PR touches **no** workflow file, so the reviewer should run for real.

## Acceptance signals to watch on this PR

- [ ] `wait-for-ci` waits for `template-ci`, goes green, then releases the reviewer
- [ ] `claude-review` **runs** (is NOT skipped by workflow validation)
- [ ] The reviewer **posts** an inline comment or a coherent review summary — proving `--allowedTools` *augmented* (didn't replace) the plugin's default tools
- [ ] No "could not run pytest/ruff/mypy" lament (proves the `REVIEW.md` scoping)

If inline posting fails, the run log will show which tool the plugin used, and `--allowedTools` gets extended accordingly (tracked in #244).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._