### PR TITLE
ci: guard that a pristine render already satisfies the shipped pre-commit hooks

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -83,6 +83,28 @@ jobs:
           ! grep -qF 'Structural quality (diff) passes' CLAUDE.md \
             || { echo "::error::structural acceptance-gate item rendered with gate off"; exit 1; }
 
+      - name: render hygiene (pristine render already satisfies the shipped hooks)
+        # The template ships `trailing-whitespace` and `end-of-file-fixer`
+        # (.pre-commit-config.yaml.jinja). Both REWRITE files, so anything they
+        # would touch in a pristine render is a latent `copier update` conflict:
+        # the downstream commits the fixed-up form, so copier's 3-way merge sees
+        # `ours` != `base` in that region, and the first template version that
+        # also changes that region conflicts for EVERY downstream.
+        #
+        # Issue #251 is the real instance — ci.yml.jinja used to end with the
+        # endif closing the structural-gate block, and Jinja (no trim_blocks)
+        # keeps the newline after a block tag, so the render ended with a blank
+        # line. end-of-file-fixer stripped it downstream; the v2.11.0
+        # `ci-success` job then appended to that exact tail and every
+        # downstream's ci.yml conflicted. Latent for months because nothing had
+        # touched ci.yml's tail before.
+        #
+        # Runs BEFORE `uv sync` so the render is still pristine, and covers the
+        # gate-off render too — a Jinja tag at EOF only appears in one branch of
+        # a conditional, so checking a single variant would miss it.
+        run: |
+          python3 scripts/check_render_hygiene.py /tmp/smoke /tmp/smoke-gate-off
+
       - name: structural gate clean-tree assertion present (default) / dropped (opt-out)
         # structural_gate_assert_clean_tree gates ONLY the whole-tree clean
         # assertion (test_shipped_code_passes_…): default true keeps it; false
@@ -544,9 +566,9 @@ jobs:
             --select E,W,F,I,B,C4,UP,ARG,SIM,TC,PTH,RUF \
             --ignore E501 \
             --line-length 88 \
-            scripts/copier_update_aggregator.py scripts/tests/
+            scripts/copier_update_aggregator.py scripts/check_render_hygiene.py scripts/tests/
 
       - name: Format check aggregator (ruff format matching downstream)
         run: |
           uv run --with ruff ruff format --check --line-length 88 \
-            scripts/copier_update_aggregator.py scripts/tests/
+            scripts/copier_update_aggregator.py scripts/check_render_hygiene.py scripts/tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,28 @@ create new projects.
    latest git tag (the default).  Without it, your edits render only
    after a release.  If you need to iterate, amend the commit or make
    follow-up commits — rendering from the working tree is not supported.
-4. Commit any fixes, push, open a PR.
-5. `template-ci.yml` runs the same gate on Python 3.11–3.14.
+4. Check the render is hygiene-clean (run it before `uv sync` pollutes
+   the tree, or on a second pristine render):
+   ```bash
+   python3 scripts/check_render_hygiene.py /tmp/smoke
+   ```
+5. Commit any fixes, push, open a PR.
+6. `template-ci.yml` runs the same gate on Python 3.11–3.14.
+
+### Render hygiene
+
+The template ships the `trailing-whitespace` and `end-of-file-fixer`
+pre-commit hooks, and both *rewrite* files.  Anything they would touch in
+a pristine render becomes a latent `copier update` conflict: the
+downstream commits the fixed-up form, so copier's 3-way merge sees `ours`
+differ from `base` in that region, and the first template version that
+also changes that region conflicts for **every** downstream.
+
+The classic trap (issue #251) is a Jinja block tag at EOF — Jinja has no
+`trim_blocks` here, so the newline after `{% endif %}` survives and the
+render ends with a blank line.  Use `{%- endif %}` or put real content
+after it.  `scripts/check_render_hygiene.py` is the guard; `template-ci`
+runs it over both the default and gate-off renders.
 
 ## Release
 

--- a/copier.yml
+++ b/copier.yml
@@ -128,6 +128,7 @@ _exclude:
   - "docs/superpowers"
   - "uv.lock"                                 # generated projects create their own
   - "scripts/tests"                            # aggregator unit tests — template-only
+  - "scripts/check_render_hygiene.py"          # template-ci render guard — template-only
   # Scaffold files that projects routinely have their own version of
   # (different docs layout, different test organisation).  Excluding
   # them here means they never render on copy OR update — fresh

--- a/scripts/check_render_hygiene.py
+++ b/scripts/check_render_hygiene.py
@@ -63,6 +63,9 @@ _SKIP_DIRS = frozenset(
 # rendered docs are text and ARE checked; images are not).
 _BINARY_SNIFF_BYTES = 1024
 
+# Longest-first so ``\r\n`` is consumed as ONE terminator, not as ``\r`` + ``\n``.
+_LINE_ENDINGS = (b"\r\n", b"\n", b"\r")
+
 
 class Violation:
     """One hook finding: a file (and optionally line) a hook would rewrite."""
@@ -85,6 +88,14 @@ def _is_binary(data: bytes) -> bool:
     return b"\x00" in data[:_BINARY_SNIFF_BYTES]
 
 
+def _strip_one_line_ending(data: bytes) -> bytes | None:
+    """Drop exactly one trailing line terminator, or None if there isn't one."""
+    for ending in _LINE_ENDINGS:
+        if data.endswith(ending):
+            return data[: -len(ending)]
+    return None
+
+
 def check_file(path: Path) -> list[Violation]:
     """Return the violations `trailing-whitespace` / `end-of-file-fixer` would fix."""
     data = path.read_bytes()
@@ -94,12 +105,18 @@ def check_file(path: Path) -> list[Violation]:
 
     violations: list[Violation] = []
 
-    # end-of-file-fixer: exactly one trailing newline.
-    if not data.endswith(b"\n"):
+    # end-of-file-fixer: exactly one trailing line terminator.  Compare on
+    # terminators rather than a literal b"\n\n" so a CRLF file ending
+    # "\r\n\r\n" is caught too — the hook strips every trailing newline
+    # character regardless of flavour, so a bare b"\n\n" test would miss it.
+    # `body == b""` means the file is nothing but terminators, which the hook
+    # truncates to empty.
+    body = _strip_one_line_ending(data)
+    if body is None:
         violations.append(
             Violation(path, None, "missing final newline (end-of-file-fixer would add)")
         )
-    elif data.endswith(b"\n\n"):
+    elif body == b"" or body.endswith((b"\n", b"\r")):
         violations.append(
             Violation(
                 path,

--- a/scripts/check_render_hygiene.py
+++ b/scripts/check_render_hygiene.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Assert a pristine copier render is already whitespace-clean.
+
+The template ships the ``trailing-whitespace`` and ``end-of-file-fixer``
+pre-commit hooks (see ``.pre-commit-config.yaml.jinja``).  Both *rewrite*
+files.  So any render artifact those hooks would touch is a latent
+``copier update`` conflict: the downstream commits the fixed-up form,
+copier's 3-way merge sees ``base`` (the pristine render) differ from
+``ours`` (the committed file) in that exact region, and the moment a
+template version also changes that region -- ``theirs`` -- the merge
+conflicts for **every** downstream, even ones that never touched the file.
+
+Issue #251 is the real instance: ``ci.yml.jinja`` used to end with the
+``{% endif %}`` closing the ``enable_structural_gate`` block.  Jinja (no
+``trim_blocks``) keeps the newline after a block tag, so the render ended
+``\\n\\n``; ``end-of-file-fixer`` stripped the blank on every downstream's
+first commit.  Latent for months -- until v2.11.0 appended the
+``ci-success`` job to the same tail and every downstream's update
+conflicted on ci.yml alone.
+
+This checker is the regression guard: run it over a freshly rendered
+project and it fails if either hook would have anything to do.  Keeping a
+render byte-identical to its committed form is what makes copier's merge
+see ``ours == base`` and apply template changes cleanly.
+
+Usage::
+
+    python scripts/check_render_hygiene.py /tmp/smoke [/tmp/smoke-gate-off ...]
+
+Exits 0 when every checked file is clean, 1 otherwise (violations are
+printed as ``path:line: message``, plus GitHub Actions ``::error::``
+annotations when ``GITHUB_ACTIONS`` is set).
+
+Template-repo only -- listed in ``copier.yml``'s ``_exclude``, so it never
+renders into generated projects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Directories never present in a pristine render, but cheap to guard against:
+# a caller may point this at a tree that has since been installed or linted.
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+    }
+)
+
+# pre-commit resolves `types: [text]` via identify, which reads a leading
+# chunk and calls the file binary if it contains a NUL byte.  Mirror that
+# so we skip exactly the files the hooks skip (the vendored SPA and the
+# rendered docs are text and ARE checked; images are not).
+_BINARY_SNIFF_BYTES = 1024
+
+
+class Violation:
+    """One hook finding: a file (and optionally line) a hook would rewrite."""
+
+    def __init__(self, path: Path, line: int | None, message: str) -> None:
+        self.path = path
+        self.line = line
+        self.message = message
+
+    def format(self, root: Path) -> str:
+        try:
+            rel = self.path.relative_to(root)
+        except ValueError:  # pragma: no cover - path always under root in practice
+            rel = self.path
+        where = f"{rel}:{self.line}" if self.line is not None else str(rel)
+        return f"{where}: {self.message}"
+
+
+def _is_binary(data: bytes) -> bool:
+    return b"\x00" in data[:_BINARY_SNIFF_BYTES]
+
+
+def check_file(path: Path) -> list[Violation]:
+    """Return the violations `trailing-whitespace` / `end-of-file-fixer` would fix."""
+    data = path.read_bytes()
+    # Both hooks leave an empty file untouched.
+    if not data or _is_binary(data):
+        return []
+
+    violations: list[Violation] = []
+
+    # end-of-file-fixer: exactly one trailing newline.
+    if not data.endswith(b"\n"):
+        violations.append(
+            Violation(path, None, "missing final newline (end-of-file-fixer would add)")
+        )
+    elif data.endswith(b"\n\n"):
+        violations.append(
+            Violation(
+                path,
+                None,
+                "blank line(s) at EOF (end-of-file-fixer would strip) — "
+                "a Jinja block tag at EOF is the usual cause; "
+                "use {%- endif %} or drop the trailing newline",
+            )
+        )
+
+    # trailing-whitespace: no space/tab before the line terminator.  The
+    # template passes no --markdown-linebreak-ext, so .md files are not
+    # exempt: a two-space hard break would be stripped too.
+    for lineno, raw in enumerate(data.split(b"\n"), start=1):
+        line = raw.removesuffix(b"\r")
+        if line != line.rstrip(b" \t"):
+            violations.append(
+                Violation(
+                    path,
+                    lineno,
+                    "trailing whitespace (trailing-whitespace would strip)",
+                )
+            )
+
+    return violations
+
+
+def check_tree(root: Path) -> list[Violation]:
+    """Check every text file under `root`, skipping build/VCS directories."""
+    violations: list[Violation] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if _SKIP_DIRS.intersection(path.relative_to(root).parts):
+            continue
+        violations.extend(check_file(path))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "roots",
+        nargs="+",
+        type=Path,
+        help="rendered project directories to check",
+    )
+    args = parser.parse_args(argv)
+
+    in_actions = bool(os.environ.get("GITHUB_ACTIONS"))
+    failed = False
+
+    for root in args.roots:
+        if not root.is_dir():
+            print(f"not a directory: {root}", file=sys.stderr)
+            failed = True
+            continue
+        violations = check_tree(root)
+        if not violations:
+            print(f"render hygiene OK: {root}")
+            continue
+        failed = True
+        print(f"render hygiene FAILED: {root} ({len(violations)} violation(s))")
+        for violation in violations:
+            line = violation.format(root)
+            print(f"  {line}")
+            if in_actions:
+                print(f"::error::{root}: {line}")
+
+    if failed:
+        print(
+            "\nA pristine render must already satisfy the pre-commit hooks the "
+            "template ships; otherwise every downstream's committed file differs "
+            "from the render at that spot and copier update conflicts there (#251).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_render_hygiene.py
+++ b/scripts/tests/test_check_render_hygiene.py
@@ -1,0 +1,162 @@
+"""Unit tests for the render-hygiene guard (issue #251).
+
+The guard asserts a pristine copier render already satisfies the
+``trailing-whitespace`` and ``end-of-file-fixer`` pre-commit hooks the
+template ships, so a downstream's committed file stays byte-identical to
+the render and ``copier update`` never conflicts on hook-rewritten
+regions.
+
+These tests exercise the checker itself against synthetic trees -- no
+copier render, so they stay fast.  ``template-ci.yml`` runs the checker
+against the real renders.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+# Make the script importable as a module (pytest runs from repo root).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_render_hygiene import (  # pyright: ignore[reportMissingImports]
+    check_file,
+    check_tree,
+    main,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def test_clean_file_has_no_violations(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\n  lint:\n    runs-on: ubuntu-latest\n")
+    assert check_file(path) == []
+
+
+def test_blank_line_at_eof_is_flagged(tmp_path: Path) -> None:
+    """The #251 shape: a terminal Jinja block tag leaves the render ending \\n\\n."""
+    path = _write(tmp_path, "ci.yml", b"      --fail-under=100\n\n")
+    (violation,) = check_file(path)
+    assert violation.line is None
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_multiple_blank_lines_at_eof_are_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\n\n\n\n")
+    (violation,) = check_file(path)
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_missing_final_newline_is_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\n  lint: {}")
+    (violation,) = check_file(path)
+    assert "missing final newline" in violation.message
+
+
+def test_trailing_whitespace_is_flagged_with_line_number(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\n  lint:   \n    x: 1\n")
+    (violation,) = check_file(path)
+    assert violation.line == 2
+    assert "trailing whitespace" in violation.message
+
+
+def test_trailing_tab_is_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "a.md", b"text\t\n")
+    (violation,) = check_file(path)
+    assert violation.line == 1
+
+
+def test_markdown_hard_break_is_not_exempt(tmp_path: Path) -> None:
+    """No --markdown-linebreak-ext is configured, so .md gets no exemption."""
+    path = _write(tmp_path, "README.md", b"line one  \nline two\n")
+    (violation,) = check_file(path)
+    assert violation.line == 1
+
+
+def test_crlf_line_without_trailing_space_is_clean(tmp_path: Path) -> None:
+    """The \\r belongs to the terminator, not the content."""
+    path = _write(tmp_path, "a.txt", b"one\r\ntwo\r\n")
+    assert check_file(path) == []
+
+
+def test_crlf_line_with_trailing_space_is_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "a.txt", b"one \r\ntwo\r\n")
+    (violation,) = check_file(path)
+    assert violation.line == 1
+
+
+def test_empty_file_is_left_alone(tmp_path: Path) -> None:
+    """end-of-file-fixer does not add a newline to an empty file."""
+    path = _write(tmp_path, "py.typed", b"")
+    assert check_file(path) == []
+
+
+def test_binary_file_is_skipped(tmp_path: Path) -> None:
+    """`types: [text]` means the hooks never see a NUL-bearing file."""
+    path = _write(tmp_path, "logo.png", b"\x89PNG\r\n\x1a\n\x00\x00\x00 trailing  ")
+    assert check_file(path) == []
+
+
+def test_check_tree_reports_every_offender(tmp_path: Path) -> None:
+    _write(tmp_path, "good.yml", b"ok\n")
+    _write(tmp_path, ".github/workflows/ci.yml", b"jobs:\n\n")
+    _write(tmp_path, "docs/index.md", b"title  \n")
+    violations = check_tree(tmp_path)
+    assert len(violations) == 2
+    rendered = sorted(v.format(tmp_path) for v in violations)
+    assert rendered[0].startswith(".github/workflows/ci.yml:")
+    assert rendered[1].startswith("docs/index.md:1:")
+
+
+def test_check_tree_skips_build_and_vcs_dirs(tmp_path: Path) -> None:
+    _write(tmp_path, ".venv/lib/x.py", b"junk  \n\n")
+    _write(tmp_path, ".git/COMMIT_EDITMSG", b"msg  \n\n")
+    _write(tmp_path, "src/__pycache__/x.pyc", b"junk  \n\n")
+    assert check_tree(tmp_path) == []
+
+
+def test_main_passes_on_a_clean_tree(tmp_path: Path, capsys) -> None:
+    _write(tmp_path, "ci.yml", b"jobs:\n")
+    assert main([str(tmp_path)]) == 0
+    assert "render hygiene OK" in capsys.readouterr().out
+
+
+def test_main_fails_and_names_the_file(tmp_path: Path, capsys) -> None:
+    _write(tmp_path, ".github/workflows/ci.yml", b"jobs:\n\n")
+    assert main([str(tmp_path)]) == 1
+    out = capsys.readouterr().out
+    assert "render hygiene FAILED" in out
+    assert ".github/workflows/ci.yml" in out
+
+
+def test_main_emits_actions_annotations(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    _write(tmp_path, "ci.yml", b"jobs:\n\n")
+    assert main([str(tmp_path)]) == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_main_fails_on_a_missing_directory(tmp_path: Path) -> None:
+    assert main([str(tmp_path / "nope")]) == 1
+
+
+def test_main_checks_every_root(tmp_path: Path, capsys) -> None:
+    clean = tmp_path / "clean"
+    dirty = tmp_path / "dirty"
+    _write(clean, "ci.yml", b"jobs:\n")
+    _write(dirty, "ci.yml", b"jobs:\n\n")
+    assert main([str(clean), str(dirty)]) == 1
+    out = capsys.readouterr().out
+    assert "render hygiene OK" in out
+    assert "render hygiene FAILED" in out

--- a/scripts/tests/test_check_render_hygiene.py
+++ b/scripts/tests/test_check_render_hygiene.py
@@ -56,6 +56,37 @@ def test_multiple_blank_lines_at_eof_are_flagged(tmp_path: Path) -> None:
     assert "blank line(s) at EOF" in violation.message
 
 
+def test_crlf_blank_line_at_eof_is_flagged(tmp_path: Path) -> None:
+    """A CRLF file ends "\\r\\n\\r\\n", so a literal b"\\n\\n" test would miss it."""
+    path = _write(tmp_path, "ci.yml", b"jobs:\r\n\r\n")
+    (violation,) = check_file(path)
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_lone_cr_blank_line_at_eof_is_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\r\r")
+    (violation,) = check_file(path)
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_mixed_terminators_at_eof_are_flagged(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\n\r\n")
+    (violation,) = check_file(path)
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_file_of_only_terminators_is_flagged(tmp_path: Path) -> None:
+    """end-of-file-fixer truncates an all-newline file to empty."""
+    path = _write(tmp_path, "blank.txt", b"\n")
+    (violation,) = check_file(path)
+    assert "blank line(s) at EOF" in violation.message
+
+
+def test_single_crlf_terminator_is_clean(tmp_path: Path) -> None:
+    path = _write(tmp_path, "ci.yml", b"jobs:\r\n")
+    assert check_file(path) == []
+
+
 def test_missing_final_newline_is_flagged(tmp_path: Path) -> None:
     path = _write(tmp_path, "ci.yml", b"jobs:\n  lint: {}")
     (violation,) = check_file(path)


### PR DESCRIPTION
Closes #251.

## Problem

The template ships `trailing-whitespace` and `end-of-file-fixer` (`.pre-commit-config.yaml.jinja`), and both **rewrite** files. Anything they touch in a pristine render is a latent `copier update` conflict: the downstream commits the fixed-up form, so copier's 3-way merge sees `ours` differ from `base` in that region, and the first template version that also changes that region conflicts for *every* downstream — even ones that never touched the file.

#251 is the real instance. `ci.yml.jinja` used to end with the `endif` closing the `enable_structural_gate` block; Jinja (no `trim_blocks`) keeps the newline after a block tag, so the render ended with a blank line that `end-of-file-fixer` stripped on every downstream's first commit. Latent for months — until v2.11.0 (#250) appended the `ci-success` job to that exact tail, at which point every downstream's update conflicted on ci.yml alone.

## What changed

#250 incidentally removed the trailing blank by putting real content after the `endif`, so the current render is **already clean** — verified across the default, gate-off and apps-off renders. Nothing enforced that, so this PR adds the guard rather than a code fix:

- **`scripts/check_render_hygiene.py`** — walks a rendered tree and fails on any file the two hooks would rewrite (missing final newline, blank line(s) at EOF, trailing whitespace). Mirrors their `types: [text]` NUL-byte binary skip and the absence of `--markdown-linebreak-ext` (so `.md` hard breaks are not exempt). Template-repo only, added to `copier.yml`'s `_exclude`.
- **`template-ci.yml`** — new `render hygiene` step, placed before `uv sync` so the tree is still pristine, run over **both** `/tmp/smoke` and `/tmp/smoke-gate-off`: a Jinja tag at EOF can appear in only one branch of a conditional, so checking a single variant would miss it. The new script is also added to the `aggregator-tests` job's ruff check/format commands.
- **`scripts/tests/test_check_render_hygiene.py`** — 18 unit tests over synthetic trees (no render, so they stay fast) covering the EOF cases, trailing space/tab, CRLF, markdown hard breaks, empty and binary files, directory skipping, and the CLI's exit codes and Actions annotations.
- **`CLAUDE.md`** — new *Render hygiene* section documenting the trap and the `{%- endif %}` fix, plus a hygiene step in the *Making changes* checklist.

## Verification

- Negative control: run against a **v2.10.5** render the guard reports `.github/workflows/ci.yml: blank line(s) at EOF` and exits 1 — it would have caught #251.
- Positive: exits 0 against the default, gate-off and apps-off renders at HEAD.
- Excluded file confirmed absent from a fresh render's `scripts/`.
- Generated-project gate on the HEAD render: `ruff check` / `ruff format --check` / `mypy src/ tests/` clean, `pytest` 55 passed, 16 skipped.
- Template's own suite: `pytest scripts/tests/` 68 passed, 1 skipped; ruff check + format clean under the downstream-matching config.

## Not fixed here

Downstreams that already updated to v2.11.0 keep that one-time ci.yml conflict — the stale `base` render lives in their `.copier-answers.yml` history and no template change can rewrite it. Updates from v2.11.x forward are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017nHp9C9PTDL8sGVgYAMS1H)_