### PR TITLE
fix: transport docstring accuracy + seven template-owned tidies

### DIFF
--- a/scripts/{% if include_mcp_apps_scaffold %}vendor_spa.py{% endif %}
+++ b/scripts/{% if include_mcp_apps_scaffold %}vendor_spa.py{% endif %}
@@ -57,20 +57,33 @@ VENDORED_VERSIONS: dict[str, dict[str, str]] = {
 _SOURCE_HASH_MARKER = "<!-- vendor-spa-source-sha256:{hash} -->"
 _SOURCE_HASH_RE = re.compile(r"<!-- vendor-spa-source-sha256:([0-9a-f]{64}) -->")
 
+# The ES-module host tag, matched case-insensitively to stay consistent with
+# _inline_script's <script src> pattern (HTML tag/attribute names are
+# case-insensitive, so a `<SCRIPT TYPE="module">` in app.src.html must not be
+# treated as absent).  ONE pattern drives both the presence guard and the
+# import-map insertion point, so the two can never disagree about what counts
+# as the module tag.
+_MODULE_TAG_RE = re.compile(r"<script\s+type=\"module\"\s*>", re.IGNORECASE)
+
 
 def _discover_static_dir() -> Path:
     """Locate the single ``src/<module>/static`` dir containing app.src.html.
 
     Called lazily from main() (never at import) so the module stays importable
     for unit tests without a project tree present.
+
+    Raises ``ValueError`` rather than ``SystemExit`` so failure reporting stays
+    main()'s job — it catches this alongside the inlining failures and uses the
+    same ``print(..., file=sys.stderr); return 1`` idiom as every other error
+    path here.  The message carries no ``ERROR:`` prefix; main() adds it.
     """
     src_root = Path(__file__).resolve().parent.parent / "src"
     candidates = sorted(src_root.glob("*/static/app.src.html"))
     if not candidates:
-        raise SystemExit(f"ERROR: no src/*/static/app.src.html found under {src_root}")
+        raise ValueError(f"no src/*/static/app.src.html found under {src_root}")
     if len(candidates) > 1:
         found = ", ".join(str(c) for c in candidates)
-        raise SystemExit(f"ERROR: multiple app.src.html found: {found}")
+        raise ValueError(f"multiple app.src.html found: {found}")
     return candidates[0].parent
 
 
@@ -120,7 +133,8 @@ def _inline_module(html: str, _name: str, cfg: dict[str, str], js: str) -> str:
         raise ValueError(
             f"Module-type dependency '{_name}' requires an 'import_specifier' key"
         )
-    if '<script type="module">' not in html:
+    module_tag = _MODULE_TAG_RE.search(html)
+    if module_tag is None:
         raise ValueError(
             'No <script type="module"> tag found — cannot insert import map'
         )
@@ -130,10 +144,9 @@ def _inline_module(html: str, _name: str, cfg: dict[str, str], js: str) -> str:
     import_map_obj = {"imports": {specifier: data_uri}}
     import_map = f'<script type="importmap">\n{json.dumps(import_map_obj)}\n</script>\n'
 
-    # Insert the import map immediately before <script type="module">
-    html = html.replace(
-        '<script type="module">', import_map + '<script type="module">', 1
-    )
+    # Insert the import map immediately before the module tag.  Slicing at the
+    # match offset preserves the tag's original casing/spacing verbatim.
+    html = html[: module_tag.start()] + import_map + html[module_tag.start() :]
 
     # Rewrite the import URL → bare specifier (derive pattern from cfg["url"])
     cdn_url = re.escape(cfg["url"])
@@ -163,7 +176,11 @@ def main() -> int:
     """Entry point.  Returns 0 on success, 1 on failure."""
     check_mode = "--check" in sys.argv
 
-    static_dir = _discover_static_dir()
+    try:
+        static_dir = _discover_static_dir()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     src_html_path = static_dir / "app.src.html"
     out_html_path = static_dir / "app.html"
 

--- a/src/{{python_module}}/server.py.jinja
+++ b/src/{{python_module}}/server.py.jinja
@@ -46,8 +46,10 @@ def make_server(
     """Construct the {{ human_name }} FastMCP server.
 
     Args:
-        transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Used here for
-            logging only.
+        transport: ``"stdio"`` / ``"http"`` / ``"sse"``.  Gates any
+            transport-specific wiring added in the DOMAIN-WIRING block
+            (e.g. HTTP-only custom routes, which cannot be served under
+            stdio) and appears as ``transport=%s`` in the startup log.
         config: Optional pre-loaded config; default loads from env.
 
     Returns:

--- a/tests/test_config_wizard_drift.py.jinja
+++ b/tests/test_config_wizard_drift.py.jinja
@@ -96,16 +96,19 @@ def _read_in_src(suffix: str, src_text: str) -> bool:
 
     Matches the two scaffold read idioms: ``env(_ENV_PREFIX, "SUFFIX")`` (the
     quoted literal ``"SUFFIX"``) and ``os.environ.get(f"{_ENV_PREFIX}_SUFFIX")``
-    (the ``_SUFFIX`` fragment). The fragment arm anchors a trailing
-    word-boundary so a short suffix does not match inside a longer fragment
-    (``_HOST`` must not clear via ``_HOSTNAME``). Requiring one of these — rather
-    than a bare ``suffix in src_text`` substring — avoids clearing a real orphan
-    just because its suffix happens to appear in an unrelated comment or
-    identifier.
+    (the ``_SUFFIX`` fragment). The fragment arm anchors a word boundary on
+    BOTH sides so a short suffix does not match inside a longer fragment:
+    trailing so ``_HOST`` does not clear via ``_HOSTNAME``, leading so it does
+    not clear via ``_ANYHOST`` either (the leading guard excludes ``_`` as well,
+    so ``_HOST`` does not match inside ``_ANY_HOST`` — a different var, not a
+    longer spelling of this one). Requiring one of these — rather than a bare
+    ``suffix in src_text`` substring — avoids clearing a real orphan just
+    because its suffix happens to appear in an unrelated comment or identifier.
     """
     return (
         f'"{suffix}"' in src_text
-        or re.search(rf"_{re.escape(suffix)}(?![A-Z0-9_])", src_text) is not None
+        or re.search(rf"(?<![A-Z0-9_])_{re.escape(suffix)}(?![A-Z0-9_])", src_text)
+        is not None
     )
 
 
@@ -183,6 +186,26 @@ def test_read_in_src_matches_non_prefixed_external_var() -> None:
     src = 'host = os.environ.get("OLLAMA_HOST") or "http://localhost:11434"'
     assert _read_in_src("OLLAMA_HOST", src) is True
     assert _read_in_src("UNRELATED_EXTERNAL_VAR", src) is False
+
+
+def test_read_in_src_fragment_arm_is_bounded_on_both_sides() -> None:
+    """The ``_SUFFIX`` fragment arm must not clear a shorter, distinct suffix.
+
+    ``{PREFIX}_VAULT_PATH`` is a different setting from ``{PREFIX}_PATH``, so a
+    read site for the former must NOT clear the latter — otherwise a genuinely
+    orphaned ``PATH`` var silently passes the orphan guard. The trailing
+    boundary alone (``_PATH(?![A-Z0-9_])``) matched inside ``_VAULT_PATH``; the
+    leading one closes it. Both ``_`` and alphanumerics are excluded before the
+    fragment, so neither ``_ANY_HOST`` nor ``_ANYHOST`` clears ``HOST``.
+    """
+    read_site = 'os.environ.get(f"{_ENV_PREFIX}_VAULT_PATH")'
+    assert _read_in_src("VAULT_PATH", read_site) is True
+    assert _read_in_src("PATH", read_site) is False
+    assert _read_in_src("HOST", '"{_ENV_PREFIX}_ANY_HOST"') is False
+    assert _read_in_src("HOST", '"{_ENV_PREFIX}_ANYHOST"') is False
+    # The idiom the arm exists to match still clears: the char before the
+    # fragment is `}`, which is outside the leading exclusion class.
+    assert _read_in_src("HOST", 'os.environ.get(f"{_ENV_PREFIX}_HOST")') is True
 
 
 def _missing_suffixes(surface: set[str], emitted_suffixes: set[str]) -> list[str]:

--- a/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
+++ b/tests/{% if enable_structural_gate %}test_structural_gate.py{% endif %}.jinja
@@ -126,6 +126,9 @@ def _diff_quality(repo: Path, extend: bool) -> subprocess.CompletedProcess[str]:
         "-m",
         "diff_cover.diff_quality_tool",
         "--violations=ruff.check",
+        # `main`, NOT `origin/main` as the rendered pre-push hook and CI use:
+        # the tmp_path repo this drives is `git init`-ed with no remote, so
+        # `origin/main` does not resolve. Do not "fix" this to match the hook.
         "--compare-branch=main",
         "--fail-under=100",
     ]
@@ -168,20 +171,43 @@ def test_options_reach_ruff_and_gate_is_diff_scoped(tmp_path: Path) -> None:
     )
 
 
+def _structural_hook_block(text: str) -> str:
+    """The `structural-diff-gate` hook's own YAML block, sliced out of the config.
+
+    Whole-file `in text` checks are too weak here: `types: [python]`,
+    `language: system` and friends also appear in the ruff/mypy hooks, so
+    dropping one from THIS hook would still leave it present elsewhere and the
+    assertion would pass. Slice from this hook's `- id:` to the next one and
+    assert inside that window instead.
+    """
+    start = text.index("- id: structural-diff-gate")
+    # End at whichever comes first: the next hook, or the next repo block (this
+    # hook is currently last in `- repo: local`, so the repo boundary is the
+    # real terminator today).
+    ends = [
+        pos
+        for marker in ("\n      - id:", "\n  - repo:")
+        if (pos := text.find(marker, start)) != -1
+    ]
+    return text[start : min(ends)] if ends else text[start:]
+
+
 def test_precommit_config_wires_pre_push_hook() -> None:
     text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
     assert "default_install_hook_types: [pre-commit, pre-push]" in text
     assert "id: structural-diff-gate" in text
-    assert "stages: [pre-push]" in text
-    assert "language: system" in text
+
+    block = _structural_hook_block(text)
+    assert "stages: [pre-push]" in block
+    assert "language: system" in block
     # Mirrors the CI HAS_PY skip: no Python in the push → hook does not run.
-    assert "types: [python]" in text
+    assert "types: [python]" in block
     # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
     # pre-commit's arg splitter) own the --options quoting verified by the
     # end-to-end test. Assert it so a refactor to a direct `uv run` entry —
     # which would break that quoting — can't pass silently.
-    assert "entry: bash -c " in text
-    assert f"--extend-select={STRUCTURAL}" in text
+    assert "entry: bash -c " in block
+    assert f"--extend-select={STRUCTURAL}" in block
 
 
 def test_ci_has_structure_job() -> None:
@@ -197,8 +223,10 @@ def test_claudemd_documents_the_gate_command() -> None:
     text = (REPO_ROOT / "CLAUDE.md").read_text()
     assert "diff-quality" in text
     assert f"--extend-select={STRUCTURAL}" in text
-    # Advisory audit + eyes content present.
-    assert "radon" in text and "vulture" in text
+    # Advisory audit + eyes content present. Split, not `and`-joined, so a
+    # failure names which tool went missing instead of a bare AssertionError.
+    assert "radon" in text
+    assert "vulture" in text
     assert "Why it compounds" in text  # decay-issue template marker
 
 

--- a/tests/{% if include_mcp_apps_scaffold %}test_apps_vendoring.py{% endif %}.jinja
+++ b/tests/{% if include_mcp_apps_scaffold %}test_apps_vendoring.py{% endif %}.jinja
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -29,19 +30,54 @@ def test_vendor_check_is_clean() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_vendor_check_detects_drift() -> None:
-    """Mutating app.src.html makes --check fail (anti-drift gate works)."""
+def test_vendor_check_detects_drift(tmp_path: Path) -> None:
+    """Mutating app.src.html makes --check fail (anti-drift gate works).
+
+    Mirrors the script and the static dir into ``tmp_path`` and drifts the COPY
+    rather than editing the committed ``app.src.html`` in place.  An in-place
+    edit with a try/finally restore leaves the working tree dirty if the test
+    is SIGKILLed mid-run, and two ``pytest-xdist`` workers hitting it
+    concurrently would race on the same file.
+
+    ``vendor_spa.py`` finds its tree via ``Path(__file__).parent.parent / "src"``,
+    so copying the script alongside a ``src/`` mirror is what redirects it — the
+    subprocess boundary puts ``monkeypatch`` out of reach.
+    """
     repo = Path(__file__).resolve().parent.parent
-    src = repo / "src" / "{{ python_module }}" / "static" / "app.src.html"
-    original = src.read_text(encoding="utf-8")
-    try:
-        src.write_text(original + "\n<!-- drift -->\n", encoding="utf-8")
-        result = subprocess.run(
-            [sys.executable, str(repo / "scripts" / "vendor_spa.py"), "--check"],
-            capture_output=True,
-            text=True,
-            cwd=repo,
-        )
-        assert result.returncode == 1
-    finally:
-        src.write_text(original, encoding="utf-8")
+    static_src = repo / "src" / "{{ python_module }}" / "static"
+
+    script = tmp_path / "scripts" / "vendor_spa.py"
+    script.parent.mkdir(parents=True)
+    shutil.copy2(repo / "scripts" / "vendor_spa.py", script)
+
+    static_copy = tmp_path / "src" / "{{ python_module }}" / "static"
+    static_copy.mkdir(parents=True)
+    for name in ("app.src.html", "app.html"):
+        shutil.copy2(static_src / name, static_copy / name)
+
+    # Sanity: the untouched mirror is clean, so a failure below is the drift we
+    # introduced and not a broken copy.
+    clean = subprocess.run(
+        [sys.executable, str(script), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert clean.returncode == 0, clean.stderr
+
+    drifted = static_copy / "app.src.html"
+    drifted.write_text(
+        drifted.read_text(encoding="utf-8") + "\n<!-- drift -->\n", encoding="utf-8"
+    )
+    result = subprocess.run(
+        [sys.executable, str(script), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 1
+
+    # The committed source is untouched — the whole point of the tmp mirror.
+    assert "<!-- drift -->" not in (static_src / "app.src.html").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Closes #246, closes #229.

Note #229 is **seven** items, not four — the issue comment adds items 5–7 (structural-gate test) on top of the four in the body.

## #246 — `transport` docstring

`make_server`'s docstring called `transport` *"Used here for logging only"*, but the adjacent `DOMAIN-WIRING` sentinel is the sanctioned place for transport-gated HTTP wiring (custom routes, webhooks) that cannot be served under stdio. `server.py` is template-owned and enforced byte-for-byte by the downstream conformance gate, so a domain that adds such wiring **cannot** correct the docstring locally — it had to be fixed upstream. Reworded to say it gates `DOMAIN-WIRING` additions and appears in the startup log.

## #229 — items 1–7

**1. `_read_in_src` fragment-arm boundary** (`tests/test_config_wizard_drift.py`) — the arm had a trailing word boundary but no leading one.

The issue's example does not reproduce: `_read_in_src("HOST", "_ANYHOST")` is already `False`, because `_HOST` is not a substring of `_ANYHOST`. The **defect is real** though, for underscore-separated names:

| suffix | src text | old | new |
|---|---|---|---|
| `HOST` | `_ANYHOST` | False | False |
| `HOST` | `_ANY_HOST` | **True** ❌ | False ✅ |
| `PATH` | `f"{_ENV_PREFIX}_VAULT_PATH"` | **True** ❌ | False ✅ |
| `HOST` | `os.environ.get(f"{_ENV_PREFIX}_HOST")` | True ✅ | True ✅ |

A read site for `{PREFIX}_VAULT_PATH` cleared a wholly unrelated `PATH` var, so a genuine orphan passed the guard. Added `(?<[A-Z0-9_])` plus a test covering the fixed cases and the idiom the arm exists to match.

**2. In-place mutation in `test_vendor_check_detects_drift`** — the issue suggests `monkeypatch` on `_discover_static_dir`, but the test shells out to `vendor_spa.py`, so monkeypatch cannot reach the subprocess. Instead the script and static dir are mirrored into `tmp_path` and the **copy** is drifted. The test also asserts the untouched mirror is clean first (so a failure is the injected drift, not a broken copy) and that the committed source is untouched at the end.

**3. `_discover_static_dir` raised `SystemExit(str)`** while `main()` uses `print(..., file=sys.stderr); return 1` everywhere else. Now raises `ValueError` — the file's existing convention for reportable failures, already caught in `main()` for inlining errors. Verified both error paths still emit exactly one `ERROR:` line and exit 1, with no traceback and no doubled prefix.

**4. Case-sensitive module-tag guard** — `_inline_module`'s `'<script type="module">' not in html` was case-sensitive while `_inline_script` uses `re.IGNORECASE`. A single `_MODULE_TAG_RE` now drives both the presence guard and the import-map insertion point, so the two cannot disagree about what counts as the module tag. Slicing at the match offset preserves the tag's original casing. Verified against `<SCRIPT TYPE="module">`.

**5. Whole-file assertions in `test_precommit_config_wires_pre_push_hook`** — `types: [python]`, `language: system` and `stages: [pre-push]` also appear in the `ruff-check`/`ruff-format`/`mypy` hooks, so dropping one from the `structural-diff-gate` block would still pass. Assertions are now scoped to that hook's own YAML block. Verified the slice is 12 lines and contains neither `ruff-check` nor `trailing-whitespace`, while still containing all four asserted strings.

**6. Compound assertion** — split `assert "radon" in text and "vulture" in text` so a failure names which tool went missing instead of a bare `AssertionError`.

**7. `_diff_quality`'s `--compare-branch=main`** — commented to explain why it is *not* `origin/main` (the `tmp_path` repo is `git init`-ed with no remote), so a future editor doesn't "fix" it into a broken state.

## Verification

- Rendered project gate: `ruff check` + `ruff format --check` clean, `mypy src/ tests/` clean, `pytest` **56 passed, 16 skipped** (up one — the new boundary test).
- The three touched test files run green: `test_apps_vendoring.py`, `test_structural_gate.py`, `test_config_wizard_drift.py` — 25 passed.
- Template's own suite: **73 passed, 1 skipped**.
- Render hygiene clean across the default, gate-off and apps-off renders (the guard shipped in v2.11.1).
- Each behavioural change checked empirically rather than by inspection — the regex table above, the uppercase module tag, both `_discover_static_dir` error paths, and the block-slice contents.

---
_Generated by [Claude Code](https://claude.ai/code/session_017nHp9C9PTDL8sGVgYAMS1H)_