### PR TITLE
ci: make detach-smoke fail loudly when CLAUDE.md drifts from the scrub

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -367,6 +367,46 @@ jobs:
                 .github/workflows/claude-code-review.yml
           rm -f scripts/copier_update_aggregator.py
           rm -rf scripts/copier_update_prompts
+          # --- Step 3 PREFLIGHT: every scrub anchor must exist, at the exact
+          #     count the scrub expects (issue #199).
+          #
+          #     Without this the whole step passes VACUOUSLY whenever
+          #     CLAUDE.md.jinja is reworded and the scrub is not: the `sed`
+          #     matches nothing, and the post-scrub "wording is gone"
+          #     assertions still pass — because the wording is gone from the
+          #     SOURCE, not because the scrub removed it. Source and scrub
+          #     drift out of coupling in lockstep and CI stays green, so a real
+          #     detach regression ships to forks undetected.
+          #
+          #     Asserting counts (not mere presence) also catches the reverse
+          #     drift: a new section that adds a fourth ` Kept across copier
+          #     update.` the scrub was never told about.
+          #
+          #     Counts must be bumped deliberately when CLAUDE.md.jinja gains or
+          #     loses one of these strings — that edit is exactly the moment to
+          #     check FORKING.md's scrub still covers it.
+          preflight_fail=0
+          check_anchor() {
+            # `|| true` keeps bash -e from aborting the command substitution
+            # when grep finds zero matches (exit 1) — zero is the failure this
+            # function exists to REPORT, not a reason to die without context.
+            actual=$(grep -cF "$2" CLAUDE.md || true)
+            if [ "$actual" != "$1" ]; then
+              echo "::error::scrub-anchor drift: expected $1 occurrence(s) of '$2' in the rendered CLAUDE.md, found $actual. CLAUDE.md.jinja was reworded without updating the detach scrub (FORKING.md + this workflow) — fix the scrub, or bump the expected count here if the change is intentional."
+              preflight_fail=1
+            fi
+          }
+          check_anchor 2 '<!-- TEMPLATE-TRACKING-START -->'
+          check_anchor 2 '<!-- TEMPLATE-TRACKING-END -->'
+          check_anchor 1 '<!-- ===== TEMPLATE-OWNED SECTIONS BELOW'
+          check_anchor 1 '<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->'
+          check_anchor 3 ' Kept across copier update.'
+          check_anchor 1 ' on top of the shipped defaults survive `copier update`.'
+          check_anchor 1 ' are preserved across `copier update`.'
+          check_anchor 2 'The block is preserved across `copier update`.'
+          [ "$preflight_fail" = "0" ] \
+            || { echo "::error::detach scrub is no longer coupled to CLAUDE.md.jinja — see the scrub-anchor drift errors above"; exit 1; }
+
           # --- Step 3: scrub CLAUDE.md template-tracking + copier-update wording ---
           # -i.bak + rm mirrors FORKING.md's portable form (GNU + BSD sed).
           sed -i.bak \
@@ -440,8 +480,32 @@ jobs:
           # '## Key Design Decisions' (asserted in the kept-section loop above):
           # it sits below where the END fence was, so a range delete that ran to
           # EOF past pair 2 would drop it too.
-          ! grep -qE '^<!-- ===== TEMPLATE-OWNED SECTIONS (BELOW|END)' CLAUDE.md \
-            || { echo "::error::TEMPLATE-OWNED banner fence survived the detach scrub"; exit 1; }
+          #
+          # Asserted as TWO independent fixed-string checks, each using the same
+          # literal its own `sed` -e deletes (issue #199). The previous single
+          # alternation '^<!-- ===== TEMPLATE-OWNED SECTIONS (BELOW|END)' shared a
+          # prefix with both fences, so it could not distinguish "the END fence
+          # was deleted" from "the END fence was renamed and now neither the sed
+          # nor this regex matches it" — the delete and its check failed
+          # together instead of independently.
+          ! grep -qF '<!-- ===== TEMPLATE-OWNED SECTIONS BELOW' CLAUDE.md \
+            || { echo "::error::TEMPLATE-OWNED BELOW banner fence survived the detach scrub"; exit 1; }
+          ! grep -qF '<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->' CLAUDE.md \
+            || { echo "::error::TEMPLATE-OWNED END banner fence survived the detach scrub"; exit 1; }
+
+          # --- the substitutions PRODUCED their replacement text ---
+          # Absence of the old wording is not proof the scrub ran — the wording
+          # could simply never have been there (issue #199, vector 2). Assert the
+          # REPLACEMENT text the s/// commands emit, which can only appear if the
+          # substitution actually fired. Counts mirror the preflight anchors.
+          check_replacement() {
+            actual=$(grep -cF "$2" CLAUDE.md || true)
+            [ "$actual" = "$1" ] \
+              || { echo "::error::detach scrub substitution did not fire: expected $1 occurrence(s) of '$2' after the scrub, found $actual"; exit 1; }
+          }
+          check_replacement 1 ' on top of the shipped defaults are yours to maintain.'
+          check_replacement 1 ' are domain-owned.'
+          check_replacement 2 'The block is domain-owned.'
           # stripped files gone:
           for gone in \
               .github/workflows/copier-update.yml \

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -392,11 +392,20 @@ jobs:
           # means what a maintainer thinks it means — a future anchor twice on
           # one line would otherwise silently undercount and the drift guard
           # would pass. wc's leading padding is stripped so the string compare
-          # below is exact. A zero-match grep exits 1, but the pipe means wc
-          # still prints 0 and the command substitution succeeds, so bash -e
-          # has nothing to abort on.
+          # below is exact.
+          #
+          # The trailing `|| true` is defensive, not currently load-bearing.
+          # A zero-match grep exits 1, but this step has no `shell:` key, so
+          # Actions runs it as `bash -e {0}` — WITHOUT pipefail, which is only
+          # added for an explicit `shell: bash` — and the pipeline takes tr's
+          # status (0). Should anyone add `shell: bash` or a `defaults.run`
+          # shell later, pipefail would abort the step at the FIRST missing
+          # anchor, killing the ::error:: diagnostics and the
+          # accumulate-don't-stop behaviour both helpers rely on — precisely in
+          # the drift case this step exists to report. `|| true` costs nothing
+          # and makes the behaviour independent of that setting.
           count_occurrences() {
-            grep -oF "$1" CLAUDE.md | wc -l | tr -d '[:space:]'
+            grep -oF "$1" CLAUDE.md | wc -l | tr -d '[:space:]' || true
           }
           check_anchor() {
             actual=$(count_occurrences "$2")

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -386,11 +386,20 @@ jobs:
           #     loses one of these strings — that edit is exactly the moment to
           #     check FORKING.md's scrub still covers it.
           preflight_fail=0
+          # `grep -oF | wc -l` counts OCCURRENCES, not matching lines as
+          # `grep -c` would. Every anchor is one-per-line today, but the
+          # "bump the count deliberately" model above only works if the number
+          # means what a maintainer thinks it means — a future anchor twice on
+          # one line would otherwise silently undercount and the drift guard
+          # would pass. wc's leading padding is stripped so the string compare
+          # below is exact. A zero-match grep exits 1, but the pipe means wc
+          # still prints 0 and the command substitution succeeds, so bash -e
+          # has nothing to abort on.
+          count_occurrences() {
+            grep -oF "$1" CLAUDE.md | wc -l | tr -d '[:space:]'
+          }
           check_anchor() {
-            # `|| true` keeps bash -e from aborting the command substitution
-            # when grep finds zero matches (exit 1) — zero is the failure this
-            # function exists to REPORT, not a reason to die without context.
-            actual=$(grep -cF "$2" CLAUDE.md || true)
+            actual=$(count_occurrences "$2")
             if [ "$actual" != "$1" ]; then
               echo "::error::scrub-anchor drift: expected $1 occurrence(s) of '$2' in the rendered CLAUDE.md, found $actual. CLAUDE.md.jinja was reworded without updating the detach scrub (FORKING.md + this workflow) — fix the scrub, or bump the expected count here if the change is intentional."
               preflight_fail=1
@@ -498,14 +507,23 @@ jobs:
           # could simply never have been there (issue #199, vector 2). Assert the
           # REPLACEMENT text the s/// commands emit, which can only appear if the
           # substitution actually fired. Counts mirror the preflight anchors.
+          # Accumulates like check_anchor rather than exiting on the first
+          # mismatch: if several substitutions silently fail to fire, one CI
+          # run should name all of them, not send the maintainer round the
+          # loop once per substitution.
+          replacement_fail=0
           check_replacement() {
-            actual=$(grep -cF "$2" CLAUDE.md || true)
-            [ "$actual" = "$1" ] \
-              || { echo "::error::detach scrub substitution did not fire: expected $1 occurrence(s) of '$2' after the scrub, found $actual"; exit 1; }
+            actual=$(count_occurrences "$2")
+            if [ "$actual" != "$1" ]; then
+              echo "::error::detach scrub substitution did not fire: expected $1 occurrence(s) of '$2' after the scrub, found $actual"
+              replacement_fail=1
+            fi
           }
           check_replacement 1 ' on top of the shipped defaults are yours to maintain.'
           check_replacement 1 ' are domain-owned.'
           check_replacement 2 'The block is domain-owned.'
+          [ "$replacement_fail" = "0" ] \
+            || { echo "::error::detach scrub ran but did not produce its replacement text — see the errors above"; exit 1; }
           # stripped files gone:
           for gone in \
               .github/workflows/copier-update.yml \


### PR DESCRIPTION
Closes #199.

## Problem

detach-smoke renders `CLAUDE.md` from `CLAUDE.md.jinja` and runs the FORKING.md scrub against it. Because source and scrub target the same text, a rewording that skips the scrub leaves both in lockstep: the `sed` matches nothing, and the post-scrub *"wording is gone"* assertions still pass — **because the wording is gone from the source, not because the scrub removed it.** The step goes green while the detach it certifies is broken.

## Changes — one per evaluation point in the issue

**1. Pre-scrub anchor preflight.** Every string the scrub keys on is asserted present at an exact count *before* the `sed` runs. Counts rather than mere presence, so the reverse drift is caught too: a new section adding a fourth `Kept across copier update.` that the scrub was never told about.

**2. Post-scrub replacement assertions.** Absence of the old wording never proved the scrub ran. The three `s///` commands emit replacement text that can only appear if the substitution actually fired — assert that instead.

**3. Decoupled banner-fence checks.** The single alternation `^<!-- ===== TEMPLATE-OWNED SECTIONS (BELOW|END)` shared a prefix with both fences, so it could not distinguish *"the END fence was deleted"* from *"the END fence was renamed, so neither the sed nor this regex matches it"* — delete and check failed together. Now two independent fixed-string checks, each using the literal its own `sed -e` deletes.

## Verification

Ran both the old and the new step logic over a real render, injecting each drift vector:

| Drift vector | Old logic | New logic |
|---|---|---|
| END fence renamed (issue vector 1) | **PASS** ⚠️ | fail — anchor count 1 → 0 |
| `are preserved across` reworded (issue vector 2) | **PASS** ⚠️ | fail — anchor count 1 → 0 |
| extra `Kept across copier update.` added (reverse drift) | **PASS** ⚠️ | fail — anchor count 3 → 4 |

Under the old logic, vector 1 left a stray `<!-- ===== TEMPLATE-OWNED SECTIONS FINISH ===== -->` fence sitting in the "detached" fork **and CI was still green** — precisely the silent failure this closes.

The pristine render passes unchanged (control run: `DETACH OK`).

Also checked: workflow YAML parses, render hygiene clean on the default and gate-off renders, template suite 73 passed / 1 skipped.

## Note

The anchor list here mirrors FORKING.md's `sed`, which this step already duplicated before this change. That duplication is pre-existing and not addressed here — but the preflight now makes a drift between the render and the scrub loud, which is the failure mode that actually bit.

## Stacking

Independent of #255 (#241's `CONFIG-VALIDATE` seam) — separate branch off `main`, no overlapping files. I verified #255's `CLAUDE.md.jinja` edits do not change any of the anchor counts asserted here, so the two merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_017nHp9C9PTDL8sGVgYAMS1H)_