### PR TITLE
fix(docs): clear every Vale error from the rendered docs

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -139,7 +139,7 @@ CI workflows reference three repository secrets. Configure them via **Settings â
 | Secret | Used by | How to generate |
 |---|---|---|
 | `RELEASE_TOKEN` | `release.yml`, `copier-update.yml`, `renovate.yml`, `bootstrap.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write`, `pull_requests: write`, and `administration: write` (bootstrap sets branch protection + auto-merge). Scoped to this repo. |
-| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io>: sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io>: sign in with GitHub and add the repo. The upload token is on its settings page. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
 
 ```bash

--- a/docs/guides/config-migration.md.jinja
+++ b/docs/guides/config-migration.md.jinja
@@ -74,7 +74,7 @@ The generator discovers domain vars by AST-scanning `ProjectConfig.from_env`
 for `env(prefix, "SUFFIX")` reads whose suffix matches a dataclass field.
 See `scripts/gen_config_surface.py`'s `_discover_domain_vars`. That covers
 every var your project reads through a declared field. Add an entry to
-`config-presentation.domain.yml` only for a var the scan genuinely cannot
+`config-presentation.domain.yml` only for a var the scan cannot
 see:
 
 - A deprecated alias for a var that no longer has its own field.

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -19,11 +19,12 @@ that matches how callers authenticate (see the
   to that claim's name, such as `groups`.
 
 To turn either on: set the relevant `{{ env_prefix }}_*` variables
-and build the matching `check` in `src/{{ python_module }}/server.py`,
+and build the matching check in `src/{{ python_module }}/server.py`,
 which ships commented out (plus the config field it reads in
-`config.py`). Install exactly one `AuthMiddleware`: to run both at once,
-such as an OIDC deployment that keeps a bearer break-glass account,
-combine the two checks with `any_check` rather than adding a second one.
+`config.py`). Install only one authorization check: to run bearer and
+OIDC together, such as an OIDC deployment that keeps a bearer
+break-glass account, the stub shows how to combine them into a single
+check rather than adding a second.
 
 ## Gating by an OIDC claim
 
@@ -81,7 +82,8 @@ single-token mode every caller shares one subject (the default
   ACL file or the grants map.
 - **Fails fast on a structural error.** An unreadable or malformed file,
   the wrong shape, or a `*` subject key aborts startup rather than
-  running half-configured. A scope-*name* typo is not structural:
+  running half-configured. Structural checks do not cover a
+  **scope-name typo**:
   `"rite"` for `"write"` is valid and loads cleanly, then silently never
   matches, so those calls are denied. Double-check scope spelling
   against the table below.

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -83,7 +83,7 @@ single-token mode every caller shares one subject (the default
 - **Fails fast on a structural error.** An unreadable or malformed file,
   the wrong shape, or a `*` subject key aborts startup rather than
   running half-configured. Structural checks do not cover a
-  **scope-name typo**:
+  scope-name typo:
   `"rite"` for `"write"` is valid and loads cleanly, then silently never
   matches, so those calls are denied. Double-check scope spelling
   against the table below.

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -20,11 +20,10 @@ that matches how callers authenticate (see the
 
 To turn either on: set the relevant `{{ env_prefix }}_*` variables
 and build the matching check in `src/{{ python_module }}/server.py`,
-which ships commented out (plus the config field it reads in
-`config.py`). Install only one authorization check: to run bearer and
-OIDC together, such as an OIDC deployment that keeps a bearer
-break-glass account, the stub shows how to combine them into a single
-check rather than adding a second.
+where it ships commented out (plus the config field it reads in
+`config.py`). Install only one authorization check. For bearer and OIDC
+together, the stub combines them into a single check rather than a
+second one.
 
 ## Gating by an OIDC claim
 

--- a/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+++ b/docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
@@ -1,12 +1,12 @@
 # Authorization
 
-This server supports opt-in **authorization** — gating individual tools,
+This server supports opt-in **authorization**, gating individual tools,
 resources, and prompts by *scope*. It is **off by default**: every
 authenticated caller can use everything. A component is gated only once
 it declares a required scope; one without is unrestricted regardless of
 caller.
 
-There are two ways to decide which scopes a caller holds — pick the one
+Two mechanisms decide which scopes a caller holds. Pick the one
 that matches how callers authenticate (see the
 [Authentication guide](authentication.md)):
 
@@ -16,23 +16,25 @@ that matches how callers authenticate (see the
 - **OIDC → an identity claim.** The server reads a claim the identity
   provider issues about the user (group or role membership) and treats
   its values as the caller's scopes. Set `{{ env_prefix }}_AUTHZ_CLAIM`
-  to that claim's name (e.g. `groups`).
+  to that claim's name, such as `groups`.
 
-To turn either on: set the relevant `{{ env_prefix }}_*` variable(s)
-and uncomment the matching block in `src/{{ python_module }}/server.py`
-(plus the config field it reads in `config.py`). Both may run together —
-e.g. an OIDC deployment that keeps a bearer break-glass account.
+To turn either on: set the relevant `{{ env_prefix }}_*` variables
+and build the matching `check` in `src/{{ python_module }}/server.py`,
+which ships commented out (plus the config field it reads in
+`config.py`). Install exactly one `AuthMiddleware`: to run both at once,
+such as an OIDC deployment that keeps a bearer break-glass account,
+combine the two checks with `any_check` rather than adding a second one.
 
 ## Gating by an OIDC claim
 
-Authorization reads OIDC **claims** — what the identity provider asserts
-about the *user* (their groups/roles) — not the OAuth scopes the client
-negotiated. Set `{{ env_prefix }}_AUTHZ_CLAIM` to the claim that carries
-the user's group/role list.
+Authorization reads OIDC **claims**, meaning what the identity provider
+asserts about the *user* (their groups/roles), not the OAuth scopes the
+client negotiated. Set `{{ env_prefix }}_AUTHZ_CLAIM` to the claim that
+carries the user's group/role list.
 
-**No mapping is needed when the names already match.** If your IdP's
+**No mapping is needed when the names already match.** If your identity provider's
 group names are the same strings as your tool scopes, a caller is
-granted exactly the values in their claim — there is nothing else to
+granted exactly the values in their claim, and there is nothing else to
 configure. Only when the two vocabularies differ do you supply a
 translation map in `{{ env_prefix }}_AUTHZ_GRANTS`, as inline JSON
 mapping each claim value to the scopes it grants:
@@ -56,21 +58,21 @@ Point `{{ env_prefix }}_ACL_PATH` at a TOML file shaped like:
 
 - **Subject strings are opaque.** The `<kind>:<id>` convention is
   documentation only; each subject is matched as a literal string.
-- **`*` is the only special scope** — it grants every required scope.
+- **`*` is the only special scope.** It grants every required scope.
   Subject-side wildcards (`*` as a subject key) are rejected at startup.
 - **Scope vocabulary is yours.** Per-project or per-folder gating is
-  encoded into the scope string itself (e.g. `read:project-foo`,
-  `write:vault/personal`).
+  encoded into the scope string itself, such as `read:project-foo` or
+  `write:vault/personal`.
 
 ### Aligning subjects with bearer tokens
 
-Subjects come from the authentication layer — see the
+Subjects come from the authentication layer. See the
 [Authentication guide](authentication.md) for how bearer tokens and OIDC
 map callers to subject strings. The subject keyed in this ACL is the
 same string used as a *value* in the bearer-tokens TOML
-(`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In
+(`{{ env_prefix }}_BEARER_TOKENS_FILE`). Keep the two consistent. In
 single-token mode every caller shares one subject (the default
-`"bearer-anon"`, overridable via
+`"bearer-anon"`, which you can change with
 `{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).
 
 ## Operating notes
@@ -79,7 +81,7 @@ single-token mode every caller shares one subject (the default
   ACL file or the grants map.
 - **Fails fast on a structural error.** An unreadable or malformed file,
   the wrong shape, or a `*` subject key aborts startup rather than
-  running half-configured. A scope-*name* typo is **not** structural —
+  running half-configured. A scope-*name* typo is not structural:
   `"rite"` for `"write"` is valid and loads cleanly, then silently never
   matches, so those calls are denied. Double-check scope spelling
   against the table below.
@@ -103,7 +105,7 @@ single-token mode every caller shares one subject (the default
 
 ## See also
 
-- [Authentication guide](authentication.md) — how callers obtain the
+- [Authentication guide](authentication.md): how callers obtain the
   subject and claims this guide gates on.
 
 <!-- DOMAIN-AUTHZ-EXTRA-START -->

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -1,0 +1,380 @@
+# PR A: clear the rendered docs' Vale errors
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a rendered project's `docs/` and `README.md` report zero Vale errors, so PR B can add a CI gate that asserts zero without a baseline file.
+
+**Architecture:** Two authored `.jinja` docs files carry 20 Vale errors between them. Every fix is a prose edit in the template source. No code, no generator, no CI change — those are PR B onwards. The design spec written during brainstorming rides along in this PR rather than getting its own.
+
+**Tech Stack:** Markdown + Jinja2 template sources; `vale` 3.14.2; `copier` for rendering.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md` (PR A in §3).
+
+## Global Constraints
+
+- **Fixes must reach existing downstreams.** `.vale.ini` and `.vale/styles/config/vocabularies/Base/accept.txt` are both in `copier.yml`'s `_skip_if_exists`, so a term added to either reaches **new renders only**. Every spelling error in this plan is therefore fixed by **rewording the prose**, never by adding a vocabulary term.
+- **Replacement wording must itself be Vale-clean.** Measured against the live binary: `For example,` and `For instance,` both trip `ai-tells.FormalTransitions`; `such as` is clean. Never replace `e.g.` with "for example".
+- **`ai-tells.EmDashUsage` flags an em dash at any spacing, and an en dash too.** `A—B` unspaced is an error.
+- **Marker tokens are load-bearing.** `DOMAIN-AUTHZ-SCOPES-START`, `DOMAIN-AUTHZ-SCOPES-END`, `DOMAIN-AUTHZ-EXTRA-START`, `DOMAIN-AUTHZ-EXTRA-END` must survive verbatim. Only the human-readable text *after* a marker token may change.
+- **The exit criterion is `vale` reporting zero, not "the 20 listed errors are fixed".** Vale's reported set shifts as edits land: only 6 of the file's 11 spaced em dashes are currently reported, for reasons not derivable from `.vale.ini`. Fix the whole class, then re-run until zero.
+- **`.vscode/` is untracked on this branch** (its ignore rule is PR G). Move it aside before any render, or `copier` mints a temp commit per render and `_commit` differs between two otherwise identical renders.
+- Verification renders use `--vcs-ref=HEAD`, so **commit before rendering**.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja` | the authorization guide; 19 errors | Modify |
+| `docs/guides/config-migration.md.jinja` | the config migration guide; 1 error | Modify |
+| `docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md` | design spec | Already committed as `f4b5552`; rides along |
+
+The authorization guide's filename contains a Jinja conditional, so it renders only when `enable_authorization` is true. Quote the path in every shell command.
+
+---
+
+## Task 0: File the issue and prepare the branch
+
+**Files:** none (git + GitHub only)
+
+- [ ] **Step 1: Confirm the issue text with the human before filing**
+
+Filing is outward-facing. Show this draft and wait for approval:
+
+> **Title:** `docs/guides/authorization.md` fails Vale with 19 errors in every authz-enabled downstream
+>
+> **Body:**
+> `docs/guides/authorization.md` renders with 19 Vale errors, and `docs/guides/config-migration.md` with 1. Both files are template-owned prose that ships to downstream projects.
+>
+> Every downstream rendered with `enable_authorization: true` runs Vale over `docs/` in `ci.yml` with `MinAlertLevel = error` and `fail_on_error: true`, so those projects have a red `vale` job today.
+>
+> Errors span 7 rules: `Google.EmDash` (6), `ai-tells.EmDashUsage` (4), `Vale.Spelling` (3), `Google.Latin` (3), `write-good.ThereIs` (1), `Google.OptionalPlurals` (1), `ai-tells.EmphaticCopula` (1), plus `ai-tells.OverusedVocabulary` (1) in the migration guide.
+>
+> Fixes must be prose rewordings. `.vale.ini` and the Vocab accept list are both `_skip_if_exists`, so adding an accepted term would reach new renders only and leave existing downstreams red.
+>
+> **Verification:** render the template and run `vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md`; it must report 0 errors.
+
+- [ ] **Step 2: File it**
+
+```bash
+gh issue create --repo pvliesdonk/fastmcp-server-template \
+  --title "docs/guides/authorization.md fails Vale with 19 errors in every authz-enabled downstream" \
+  --body-file /tmp/pr-a-issue.md
+```
+
+Write the approved body to `/tmp/pr-a-issue.md` first. Append the agent-attribution signature line required by the operator's global instructions.
+
+- [ ] **Step 3: Rename the branch so it reflects the PR**
+
+```bash
+git branch -m docs/config-surface-1b-redesign fix/docs-vale-errors
+git branch --show-current
+```
+
+Expected: `fix/docs-vale-errors`
+
+---
+
+## Task 1: Clear the authorization guide
+
+**Files:**
+- Modify: `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. Prose only.
+
+- [ ] **Step 1: Confirm the starting state**
+
+```bash
+SP=/tmp/pr-a && rm -rf $SP && mv .vscode /tmp/vscode-parked 2>/dev/null
+uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD \
+  --data-file tests/fixtures/smoke-answers.yml . $SP 2>&1 | tail -1
+mv /tmp/vscode-parked .vscode 2>/dev/null
+cd $SP && vale sync >/dev/null 2>&1
+vale docs/guides/authorization.md 2>&1 | tail -2
+```
+
+Expected: `✖ 19 errors, 0 warnings and 0 suggestions in 1 file.`
+
+- [ ] **Step 2: Sweep every spaced em dash in prose**
+
+Ten replacements. Line 53 is inside a ```toml fence — Vale skips code blocks, so **leave line 53 alone**.
+
+| Line | Replace | With |
+|---|---|---|
+| 3 | `**authorization** — gating individual tools,` | `**authorization**, gating individual tools,` |
+| 9 | `There are two ways to decide which scopes a caller holds — pick the one` | `Two mechanisms decide which scopes a caller holds. Pick the one` |
+| 35 | `granted exactly the values in their claim — there is nothing else to` | `granted exactly the values in their claim, and there is nothing else to` |
+| 59 | ``- **`*` is the only special scope** — it grants every required scope.`` | ``- **`*` is the only special scope.** It grants every required scope.`` |
+| 67 | `Subjects come from the authentication layer — see the` | `Subjects come from the authentication layer. See the` |
+| 71 | ``(`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In`` | ``(`{{ env_prefix }}_BEARER_TOKENS_FILE`). Keep the two consistent. In`` |
+| 95 | `<!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->` | `<!-- DOMAIN-AUTHZ-SCOPES-START: list THIS server's gated tools; kept across copier update -->` |
+| 106 | `- [Authentication guide](authentication.md) — how callers obtain the` | `- [Authentication guide](authentication.md): how callers obtain the` |
+
+Line 9's replacement also clears the `write-good.ThereIs` error at 9:1.
+
+Lines 28-31 are one sentence with a pair of em dashes. Replace the whole block:
+
+```markdown
+Authorization reads OIDC **claims**, meaning what the identity provider
+asserts about the *user* (their groups/roles), not the OAuth scopes the
+client negotiated. Set `{{ env_prefix }}_AUTHZ_CLAIM` to the claim that
+carries the user's group/role list.
+```
+
+- [ ] **Step 3: Fix the Latin abbreviations**
+
+`such as`, never "for example" — the latter trips `ai-tells.FormalTransitions`.
+
+Line 19:
+
+```markdown
+  to that claim's name, such as `groups`.
+```
+
+Lines 61-63, replace the whole bullet:
+
+```markdown
+- **Scope vocabulary is yours.** Per-project or per-folder gating is
+  encoded into the scope string itself, such as `read:project-foo` or
+  `write:vault/personal`.
+```
+
+- [ ] **Step 4: Fix the spelling, plurals, and emphasis errors**
+
+`uncomment`, `IdP's` and `overridable` are all absent from the Vocab list, and adding them would not reach existing downstreams. Reword instead.
+
+Lines 21-24, replace the whole paragraph. This clears `Google.OptionalPlurals` (21), `Vale.Spelling` on "uncomment" (22), the em dash (23), and `Google.Latin` (24) together:
+
+```markdown
+To turn either on: set the relevant `{{ env_prefix }}_*` variables
+and enable the matching block in `src/{{ python_module }}/server.py`,
+which ships commented out (plus the config field it reads in
+`config.py`). Both may run together, such as an OIDC deployment that
+keeps a bearer break-glass account.
+```
+
+Line 33:
+
+```markdown
+**No mapping is needed when the names already match.** If your identity provider's
+```
+
+Lines 73-74:
+
+```markdown
+`"bearer-anon"`, which you can change with
+`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).
+```
+
+Line 82, which clears both `ai-tells.EmphaticCopula` and its trailing em dash:
+
+```markdown
+  running half-configured. A scope-*name* typo is not structural:
+```
+
+- [ ] **Step 5: Verify the marker tokens survived**
+
+```bash
+grep -c "DOMAIN-AUTHZ-SCOPES-START\|DOMAIN-AUTHZ-SCOPES-END\|DOMAIN-AUTHZ-EXTRA-START\|DOMAIN-AUTHZ-EXTRA-END" \
+  'docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja'
+```
+
+Expected: `4`
+
+- [ ] **Step 6: Re-render and re-run Vale until it reports zero**
+
+```bash
+git add -A && git commit -q -m "wip" && mv .vscode /tmp/vscode-parked 2>/dev/null
+rm -rf /tmp/pr-a && uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/pr-a 2>&1 | tail -1
+mv /tmp/vscode-parked .vscode 2>/dev/null
+cd /tmp/pr-a && vale docs/guides/authorization.md 2>&1 | tail -2
+```
+
+Expected: `0 errors`. If any error remains, fix it and repeat this step — the reported set shifts as edits land.
+
+- [ ] **Step 7: Squash the wip commit and commit properly**
+
+```bash
+git reset --soft HEAD~1
+git add 'docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja'
+git commit -m "$(cat <<'EOF'
+fix(docs): clear the authorization guide's Vale errors
+
+The guide rendered with 19 Vale errors, and every downstream created with
+enable_authorization: true runs Vale over docs/ at MinAlertLevel = error
+with fail_on_error: true. Those projects have a red vale job today.
+
+Every fix is a reword rather than a new accepted term. The Vocab list and
+.vale.ini are both _skip_if_exists, so a term added to either would reach
+new renders only and leave the affected projects red.
+
+The em-dash sweep covers all ten prose occurrences, not the six Vale
+currently reports; the reported subset shifts as edits land, and the one
+inside the TOML fence is left alone because Vale skips code blocks.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P
+EOF
+)"
+```
+
+---
+
+## Task 2: Clear the migration guide
+
+**Files:**
+- Modify: `docs/guides/config-migration.md.jinja:77`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. Prose only.
+
+- [ ] **Step 1: Confirm the error**
+
+```bash
+cd /tmp/pr-a && vale docs/guides/config-migration.md 2>&1 | tail -2
+```
+
+Expected: `1 error`, `ai-tells.OverusedVocabulary` on `genuinely` at 77:58.
+
+- [ ] **Step 2: Reword line 77**
+
+Current:
+
+```markdown
+`config-presentation.domain.yml` only for a var the scan genuinely cannot
+```
+
+Replace with:
+
+```markdown
+`config-presentation.domain.yml` only for a var the scan cannot
+```
+
+The adverb carries no meaning the sentence needs; deleting it is the whole fix.
+
+- [ ] **Step 3: Re-render and verify the full CI scope reports zero**
+
+This is the gate PR B will automate, run by hand here.
+
+```bash
+git add -A && git commit -q -m "wip" && mv .vscode /tmp/vscode-parked 2>/dev/null
+rm -rf /tmp/pr-a && uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/pr-a 2>&1 | tail -1
+mv /tmp/vscode-parked .vscode 2>/dev/null
+cd /tmp/pr-a && vale sync >/dev/null 2>&1
+vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md 2>&1 | tail -2
+```
+
+Expected: `✖ 0 errors, 0 warnings and 0 suggestions in 13 files.`
+
+- [ ] **Step 4: Verify the gate-off render is clean too**
+
+`authorization.md` does not exist when `enable_authorization` is false, but the migration guide does. `template-ci` renders both variants.
+
+```bash
+mv .vscode /tmp/vscode-parked 2>/dev/null
+rm -rf /tmp/pr-a-off && uv run --no-project --with copier copier copy --trust --defaults \
+  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml \
+  --data enable_authorization=false . /tmp/pr-a-off 2>&1 | tail -1
+mv /tmp/vscode-parked .vscode 2>/dev/null
+cd /tmp/pr-a-off && vale sync >/dev/null 2>&1
+vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md 2>&1 | tail -2
+```
+
+Expected: `0 errors`.
+
+- [ ] **Step 5: Squash and commit**
+
+```bash
+git reset --soft HEAD~1
+git add docs/guides/config-migration.md.jinja
+git commit -m "$(cat <<'EOF'
+fix(docs): drop an overused adverb from the migration guide
+
+ai-tells.OverusedVocabulary flags "genuinely", and the adverb carries no
+meaning the sentence needs. With this the whole rendered docs set reports
+zero Vale errors, which is what lets the next PR gate on zero without a
+baseline file.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P
+EOF
+)"
+```
+
+---
+
+## Task 3: Confirm the render is otherwise unaffected
+
+**Files:** none (verification only)
+
+Prose edits should not change anything structural. This task proves it.
+
+- [ ] **Step 1: Render twice and diff**
+
+```bash
+mv .vscode /tmp/vscode-parked 2>/dev/null
+rm -rf /tmp/pr-a-1 /tmp/pr-a-2
+for d in /tmp/pr-a-1 /tmp/pr-a-2; do
+  uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD \
+    --data-file tests/fixtures/smoke-answers.yml . $d 2>&1 | tail -1
+done
+mv /tmp/vscode-parked .vscode 2>/dev/null
+diff -r /tmp/pr-a-1 /tmp/pr-a-2 && echo "RENDERS IDENTICAL"
+```
+
+Expected: `RENDERS IDENTICAL`. If `_commit` differs, `.vscode/` was not parked.
+
+- [ ] **Step 2: Check render hygiene on both variants**
+
+```bash
+python3 scripts/check_render_hygiene.py /tmp/pr-a-1 /tmp/pr-a-off
+```
+
+Expected: `render hygiene OK` for both.
+
+- [ ] **Step 3: Confirm the docs site still builds**
+
+An edit that breaks a heading anchor breaks `mkdocs --strict`. Line 82's change removes bold from `**not**` and line 59's moves a bold span; neither is a heading, but prove it.
+
+```bash
+cd /tmp/pr-a-1 && uv sync --all-extras --all-groups -q 2>&1 | tail -1
+uv run mkdocs build --strict 2>&1 | tail -2
+```
+
+Expected: `Documentation built in …` with no warnings.
+
+- [ ] **Step 4: Confirm only the two intended files changed**
+
+```bash
+git diff --name-only 352c0c9..HEAD
+```
+
+Expected exactly three paths — the two guides plus the design spec from `f4b5552`:
+
+```
+docs/guides/config-migration.md.jinja
+docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+```
+
+---
+
+## Wrap-up
+
+- [ ] **Run the pre-push review** over `origin/main..HEAD` before opening the PR, per the operator's global instructions.
+- [ ] **Open the PR** with `Closes #<issue from Task 0>` in the **commit message**, not only the body — GitHub acts on the squashed commit message, and a stale `Closes` line in Stage 1a's squash auto-closed three issues that still had work outstanding.
+- [ ] **Do not merge and do not release.** Both are human-only.
+- [ ] Note in the PR body that the design spec rides along, and link it.
+
+## What this PR deliberately does not do
+
+- No CI change. Gating on zero is PR B, together with the missing `check_anchor` for the fifth detach-scrub rule.
+- No generator, no `config-presentation.yml`, no markers. Those are PRs D-F.
+- No new accepted Vale terms, for the propagation reason in Global Constraints.
+- `docs/guides/authorization.md`'s prose is corrected, not restructured. Content changes belong to the PR that owns that content.

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -37,6 +37,14 @@ re-derived.
 - **Vale reports a subset.** Only 6 of this file's 11 spaced em dashes were
   reported, and the set shifted as edits landed. The exit criterion has to be
   "re-run until zero", not "fix the reported list".
+- **`ai-tells.VerbTricolon` flags exactly three parallel verbs.** A sentence
+  written here tripped it (`run` / `keeps` / `shows`) and was split in two.
+- **An accepted vocabulary term suppresses non-spelling rules inside its
+  match span.** That tricolon reported zero only because the span contained
+  `OIDC`, which is in `accept.txt`; removing that one term surfaced the error.
+  So "Vale reports zero" is a weaker signal than it looks, and PR B's gate
+  inherits the weakness. A strict check drops the domain vocabulary and
+  re-runs; used here to confirm the tricolon was gone rather than masked.
 
 ## Constraints that governed the fix
 

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -1,413 +1,90 @@
-# PR A: clear the rendered docs' Vale errors
+# PR A: clear the rendered docs' Vale errors — execution record
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
-**Goal:** Make a rendered project's `docs/` and `README.md` report zero Vale errors, so PR B can add a CI gate that asserts zero without a baseline file.
-
-**Architecture:** Two authored `.jinja` docs files carry 20 Vale errors between them. Every fix is a prose edit in the template source. No code, no generator, no CI change — those are PR B onwards. The design spec written during brainstorming rides along in this PR rather than getting its own.
-
-**Tech Stack:** Markdown + Jinja2 template sources; `vale` 3.14.2; `copier` for rendering.
+**Status:** done. This records what was changed and what was learned. It is not
+a recipe to re-run: re-executing it against a fresh render would be wrong,
+because the lines it edited have already moved.
 
 **Spec:** `docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md` (PR A in §3).
-
-## Global Constraints
-
-- **Fixes must reach existing downstreams.** `.vale.ini` and `.vale/styles/config/vocabularies/Base/accept.txt` are both in `copier.yml`'s `_skip_if_exists`, so a term added to either reaches **new renders only**. Every spelling error in this plan is therefore fixed by **rewording the prose**, never by adding a vocabulary term.
-- **Replacement wording must itself be Vale-clean.** Measured against the live binary: `For example,` and `For instance,` both trip `ai-tells.FormalTransitions`; `such as` is clean. Never replace `e.g.` with "for example".
-- **`ai-tells.EmDashUsage` flags an em dash at any spacing, and an en dash too.** `A—B` unspaced is an error.
-- **Marker tokens are load-bearing.** `DOMAIN-AUTHZ-SCOPES-START`, `DOMAIN-AUTHZ-SCOPES-END`, `DOMAIN-AUTHZ-EXTRA-START`, `DOMAIN-AUTHZ-EXTRA-END` must survive verbatim. Only the human-readable text *after* a marker token may change.
-- **The exit criterion is `vale` reporting zero, not "the 20 listed errors are fixed".** Vale's reported set shifts as edits land: only 6 of the file's 11 spaced em dashes are currently reported, for reasons not derivable from `.vale.ini`. Fix the whole class, then re-run until zero.
-- **`.vscode/` is untracked on this branch** (its ignore rule is PR G). Two consequences, and both bit during execution:
-  - Add it to `.git/info/exclude` **before starting**. That file is local-only and never committed. Without it, any `git add -A` sweeps `.vscode/` into a commit, which is how it landed in this PR's first attempt and had to be rewritten out.
-  - Move it aside before any render. Otherwise `copier` mints a temp commit per render and `_commit` differs between two otherwise identical renders. Once it is *tracked*, moving it aside dirties the tree and causes the same divergence — so do the exclude first.
-- **Run `check_render_hygiene.py` on a pristine render.** `vale sync` downloads style packages into the render tree, and `uv sync` writes a venv; either makes hygiene fail on files the change never touched. Render for hygiene, then copy the render before linting it.
-- Verification renders use `--vcs-ref=HEAD`, so **commit before rendering**.
-
----
-
-## File Structure
-
-| File | Responsibility | Change |
-|---|---|---|
-| `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja` | the authorization guide; 19 errors | Modify |
-| `docs/guides/config-migration.md.jinja` | the config migration guide; 1 error | Modify |
-| `docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md` | design spec | Already committed as `f4b5552`; rides along |
-| `docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md` | this plan | Rides along; it is in its own reviewed range |
-
-The authorization guide's filename contains a Jinja conditional, so it renders only when `enable_authorization` is true. Quote the path in every shell command.
-
----
-
-## Task 0: File the issue and prepare the branch
-
-**Files:** none (git + GitHub only)
-
-- [ ] **Step 1: Confirm the issue text with the human before filing**
-
-Filing is outward-facing. Show this draft and wait for approval:
-
-> **Title:** `docs/guides/authorization.md` fails Vale with 19 errors in every authz-enabled downstream
->
-> **Body:**
-> `docs/guides/authorization.md` renders with 19 Vale errors, and `docs/guides/config-migration.md` with 1. Both files are template-owned prose that ships to downstream projects.
->
-> Every downstream rendered with `enable_authorization: true` runs Vale over `docs/` in `ci.yml` with `MinAlertLevel = error` and `fail_on_error: true`, so those projects have a red `vale` job today.
->
-> Errors span 7 rules: `Google.EmDash` (6), `ai-tells.EmDashUsage` (4), `Vale.Spelling` (3), `Google.Latin` (3), `write-good.ThereIs` (1), `Google.OptionalPlurals` (1), `ai-tells.EmphaticCopula` (1), plus `ai-tells.OverusedVocabulary` (1) in the migration guide.
->
-> Fixes must be prose rewordings. `.vale.ini` and the Vocab accept list are both `_skip_if_exists`, so adding an accepted term would reach new renders only and leave existing downstreams red.
->
-> **Verification:** render the template and run `vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md`; it must report 0 errors.
->
-> — 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
-
-- [ ] **Step 2: File it**
-
-```bash
-gh issue create --repo pvliesdonk/fastmcp-server-template \
-  --title "docs/guides/authorization.md fails Vale with 19 errors in every authz-enabled downstream" \
-  --body-file /tmp/pr-a-issue.md
-```
-
-Write the approved body to `/tmp/pr-a-issue.md` first, including the signature line shown at the end of the draft above. It is required verbatim on every agent-authored GitHub post, the PR body included.
-
-- [ ] **Step 3: Stop `.vscode/` reaching a commit**
-
-```bash
-printf '.vscode/\n' >> .git/info/exclude
-git status --porcelain | grep -c vscode
-```
-
-Expected: `0`. `.git/info/exclude` is local-only and never committed. Do
-this **before** any `git add -A`, and before parking `.vscode/` for a
-render: once it is tracked, parking it dirties the tree and `_commit`
-diverges between two otherwise identical renders.
-
-- [ ] **Step 4: Rename the branch so it reflects the PR**
-
-```bash
-git branch -m docs/config-surface-1b-redesign fix/docs-vale-errors
-git branch --show-current
-```
-
-Expected: `fix/docs-vale-errors`
-
----
-
-## Task 1: Clear the authorization guide
-
-**Files:**
-- Modify: `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja`
-
-**Interfaces:**
-- Consumes: nothing.
-- Produces: nothing. Prose only.
-
-- [ ] **Step 1: Confirm the starting state**
-
-```bash
-SP=/tmp/pr-a && rm -rf $SP && mv .vscode /tmp/vscode-parked 2>/dev/null
-uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD \
-  --data-file tests/fixtures/smoke-answers.yml . $SP 2>&1 | tail -1
-mv /tmp/vscode-parked .vscode 2>/dev/null
-cd $SP && vale sync >/dev/null 2>&1
-vale docs/guides/authorization.md 2>&1 | tail -2
-```
-
-Expected: `✖ 19 errors, 0 warnings and 0 suggestions in 1 file.`
-
-- [ ] **Step 2: Sweep every spaced em dash in prose**
-
-Ten replacements. Line 53 is inside a ```toml fence — Vale skips code blocks, so **leave line 53 alone**.
-
-| Line | Replace | With |
-|---|---|---|
-| 3 | `**authorization** — gating individual tools,` | `**authorization**, gating individual tools,` |
-| 9 | `There are two ways to decide which scopes a caller holds — pick the one` | `Two mechanisms decide which scopes a caller holds. Pick the one` |
-| 35 | `granted exactly the values in their claim — there is nothing else to` | `granted exactly the values in their claim, and there is nothing else to` |
-| 59 | ``- **`*` is the only special scope** — it grants every required scope.`` | ``- **`*` is the only special scope.** It grants every required scope.`` |
-| 67 | `Subjects come from the authentication layer — see the` | `Subjects come from the authentication layer. See the` |
-| 71 | ``(`{{ env_prefix }}_BEARER_TOKENS_FILE`) — keep the two consistent. In`` | ``(`{{ env_prefix }}_BEARER_TOKENS_FILE`). Keep the two consistent. In`` |
-| 95 | `<!-- DOMAIN-AUTHZ-SCOPES-START — list THIS server's gated tools; kept across copier update -->` | `<!-- DOMAIN-AUTHZ-SCOPES-START: list THIS server's gated tools; kept across copier update -->` |
-| 106 | `- [Authentication guide](authentication.md) — how callers obtain the` | `- [Authentication guide](authentication.md): how callers obtain the` |
-
-Line 9's replacement also clears the `write-good.ThereIs` error at 9:1.
-
-Lines 28-31 are one sentence with a pair of em dashes. Replace the whole block:
-
-```markdown
-Authorization reads OIDC **claims**, meaning what the identity provider
-asserts about the *user* (their groups/roles), not the OAuth scopes the
-client negotiated. Set `{{ env_prefix }}_AUTHZ_CLAIM` to the claim that
-carries the user's group/role list.
-```
-
-- [ ] **Step 3: Fix the Latin abbreviations**
-
-`such as`, never "for example" — the latter trips `ai-tells.FormalTransitions`.
-
-Line 19:
-
-```markdown
-  to that claim's name, such as `groups`.
-```
-
-Lines 61-63, replace the whole bullet:
-
-```markdown
-- **Scope vocabulary is yours.** Per-project or per-folder gating is
-  encoded into the scope string itself, such as `read:project-foo` or
-  `write:vault/personal`.
-```
-
-- [ ] **Step 4: Fix the spelling, plurals, and emphasis errors**
-
-`uncomment`, `IdP's` and `overridable` are all absent from the Vocab list, and adding them would not reach existing downstreams. Reword instead.
-
-Lines 21-24, replace the whole paragraph. This clears `Google.OptionalPlurals` (21), `Vale.Spelling` on "uncomment" (22), the em dash (23), and `Google.Latin` (24) together:
-
-```markdown
-To turn either on: set the relevant `{{ env_prefix }}_*` variables
-and enable the matching block in `src/{{ python_module }}/server.py`,
-which ships commented out (plus the config field it reads in
-`config.py`). Both may run together, such as an OIDC deployment that
-keeps a bearer break-glass account.
-```
-
-Line 33:
-
-```markdown
-**No mapping is needed when the names already match.** If your identity provider's
-```
-
-Lines 73-74:
-
-```markdown
-`"bearer-anon"`, which you can change with
-`{{ env_prefix }}_BEARER_DEFAULT_SUBJECT`).
-```
-
-Line 82, which clears both `ai-tells.EmphaticCopula` and its trailing em dash:
-
-```markdown
-  running half-configured. A scope-*name* typo is not structural:
-```
-
-- [ ] **Step 5: Verify the marker tokens survived**
-
-```bash
-grep -c "DOMAIN-AUTHZ-SCOPES-START\|DOMAIN-AUTHZ-SCOPES-END\|DOMAIN-AUTHZ-EXTRA-START\|DOMAIN-AUTHZ-EXTRA-END" \
-  'docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja'
-```
-
-Expected: `4`
-
-- [ ] **Step 6: Re-render and re-run Vale until it reports zero**
-
-```bash
-git add -A && git commit -q -m "wip" && mv .vscode /tmp/vscode-parked 2>/dev/null
-rm -rf /tmp/pr-a && uv run --no-project --with copier copier copy --trust --defaults \
-  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/pr-a 2>&1 | tail -1
-mv /tmp/vscode-parked .vscode 2>/dev/null
-cd /tmp/pr-a && vale sync >/dev/null 2>&1
-vale docs/guides/authorization.md 2>&1 | tail -2
-```
-
-`vale sync` is required after **every** fresh render: the style packages live
-under the render's own `.vale/styles`, so a new render has none and `vale`
-exits with `E100 [loadStyles] Runtime error`.
-
-Expected: `0 errors`.
-
-If any error remains, apply **only** a substitution from the catalogue in
-Steps 2-4 (`e.g.` to `such as`; a spaced dash to `.`, `,` or `:`; a
-non-vocabulary word reworded away) and re-run. If the remaining error is
-not covered by that catalogue, **stop and report the `vale` output** rather
-than improvising a reword: the replacement has to be lint-clean itself, and
-the obvious substitutions are frequently not. Do not add a Vocab term.
-
-- [ ] **Step 7: Squash the wip commit and commit properly**
-
-```bash
-git reset HEAD~1   # mixed, NOT --soft: --soft leaves the wip index staged,
-                   # so the selective add below would be a no-op
-git add 'docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja'
-git commit -m "$(cat <<'EOF'
-fix(docs): clear the authorization guide's Vale errors
-
-The guide rendered with 19 Vale errors, and every downstream created with
-enable_authorization: true runs Vale over docs/ at MinAlertLevel = error
-with fail_on_error: true. Those projects have a red vale job today.
-
-Every fix is a reword rather than a new accepted term. The Vocab list and
-.vale.ini are both _skip_if_exists, so a term added to either would reach
-new renders only and leave the affected projects red.
-
-The em-dash sweep covers all ten prose occurrences, not the six Vale
-currently reports; the reported subset shifts as edits land, and the one
-inside the TOML fence is left alone because Vale skips code blocks.
-
-Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P
-EOF
-)"
-```
-
----
-
-## Task 2: Clear the migration guide
-
-**Files:**
-- Modify: `docs/guides/config-migration.md.jinja:77`
-
-**Interfaces:**
-- Consumes: nothing.
-- Produces: nothing. Prose only.
-
-- [ ] **Step 1: Confirm the error**
-
-```bash
-cd /tmp/pr-a && vale docs/guides/config-migration.md 2>&1 | tail -2
-```
-
-Expected: `1 error`, `ai-tells.OverusedVocabulary` on `genuinely` at 77:58.
-
-- [ ] **Step 2: Reword line 77**
-
-Current:
-
-```markdown
-`config-presentation.domain.yml` only for a var the scan genuinely cannot
-```
-
-Replace with:
-
-```markdown
-`config-presentation.domain.yml` only for a var the scan cannot
-```
-
-The adverb carries no meaning the sentence needs; deleting it is the whole fix.
-
-- [ ] **Step 3: Re-render and verify the full CI scope reports zero**
-
-This is the gate PR B will automate, run by hand here.
-
-```bash
-git add -A && git commit -q -m "wip" && mv .vscode /tmp/vscode-parked 2>/dev/null
-rm -rf /tmp/pr-a && uv run --no-project --with copier copier copy --trust --defaults \
-  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/pr-a 2>&1 | tail -1
-mv /tmp/vscode-parked .vscode 2>/dev/null
-cd /tmp/pr-a && vale sync >/dev/null 2>&1
-vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md 2>&1 | tail -2
-```
-
-Expected: `✖ 0 errors, 0 warnings and 0 suggestions in 13 files.`
-
-- [ ] **Step 4: Verify the gate-off render is clean too**
-
-`authorization.md` does not exist when `enable_authorization` is false, but the migration guide does. `template-ci` renders both variants.
-
-```bash
-mv .vscode /tmp/vscode-parked 2>/dev/null
-rm -rf /tmp/pr-a-off && uv run --no-project --with copier copier copy --trust --defaults \
-  --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml \
-  --data enable_authorization=false . /tmp/pr-a-off 2>&1 | tail -1
-mv /tmp/vscode-parked .vscode 2>/dev/null
-cd /tmp/pr-a-off && vale sync >/dev/null 2>&1
-vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md 2>&1 | tail -2
-```
-
-Expected: `0 errors`.
-
-- [ ] **Step 5: Squash and commit**
-
-```bash
-git reset HEAD~1   # mixed, not --soft; see Task 1 Step 7
-git add docs/guides/config-migration.md.jinja
-git commit -m "$(cat <<'EOF'
-fix(docs): drop an overused adverb from the migration guide
-
-ai-tells.OverusedVocabulary flags "genuinely", and the adverb carries no
-meaning the sentence needs. With this the whole rendered docs set reports
-zero Vale errors, which is what lets the next PR gate on zero without a
-baseline file.
-
-Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
-Claude-Session: https://claude.ai/code/session_01As25PstUQeTR47J5SP5g7P
-EOF
-)"
-```
-
----
-
-## Task 3: Confirm the render is otherwise unaffected
-
-**Files:** none (verification only)
-
-Prose edits should not change anything structural. This task proves it.
-
-- [ ] **Step 1: Render twice and diff**
-
-```bash
-mv .vscode /tmp/vscode-parked 2>/dev/null
-rm -rf /tmp/pr-a-1 /tmp/pr-a-2
-for d in /tmp/pr-a-1 /tmp/pr-a-2; do
-  uv run --no-project --with copier copier copy --trust --defaults --vcs-ref=HEAD \
-    --data-file tests/fixtures/smoke-answers.yml . $d 2>&1 | tail -1
-done
-mv /tmp/vscode-parked .vscode 2>/dev/null
-diff -r /tmp/pr-a-1 /tmp/pr-a-2 && echo "RENDERS IDENTICAL"
-```
-
-Expected: `RENDERS IDENTICAL`. If `_commit` differs, `.vscode/` was not parked.
-
-- [ ] **Step 2: Check render hygiene on both variants**
-
-```bash
-python3 scripts/check_render_hygiene.py /tmp/pr-a-1 /tmp/pr-a-off
-```
-
-Expected: `render hygiene OK` for both.
-
-- [ ] **Step 3: Confirm the docs site still builds**
-
-An edit that breaks a heading anchor breaks `mkdocs --strict`. Line 82's change removes bold from `**not**` and line 59's moves a bold span; neither is a heading, but prove it.
-
-```bash
-cd /tmp/pr-a-1 && uv sync --all-extras --all-groups -q 2>&1 | tail -1
-uv run mkdocs build --strict 2>&1 | tail -2
-```
-
-Expected: `Documentation built in …` with no warnings.
-
-- [ ] **Step 4: Confirm only the two intended files changed**
-
-```bash
-git diff --name-only 352c0c9..HEAD
-```
-
-Expected exactly four paths — the two guides, plus the design spec and this
-plan, both of which ride along in this PR:
-
-```
-docs/guides/config-migration.md.jinja
-docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
-docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
-docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
-```
-
----
-
-## Wrap-up
-
-- [ ] **Run the pre-push review** over `origin/main..HEAD` before opening the PR, per the operator's global instructions.
-- [ ] **Open the PR** with `Closes #<issue from Task 0>` in the **commit message**, not only the body — GitHub acts on the squashed commit message, and a stale `Closes` line in Stage 1a's squash auto-closed three issues that still had work outstanding.
-- [ ] **Do not merge and do not release.** Both are human-only.
-- [ ] Note in the PR body that the design spec rides along, and link it.
-
-## What this PR deliberately does not do
-
-- No CI change. Gating on zero is PR B, together with the missing `check_anchor` for the fifth detach-scrub rule.
-- No generator, no `config-presentation.yml`, no markers. Those are PRs D-F.
-- No new accepted Vale terms, for the propagation reason in Global Constraints.
-- `docs/guides/authorization.md`'s prose is corrected, not restructured. Content changes belong to the PR that owns that content.
+**Issue:** #266.
+
+## What changed
+
+Two authored `.jinja` files, 24 lines. No code, no CI, no generator.
+
+| File | Change |
+|---|---|
+| `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja` | 19 Vale errors cleared across 7 rules |
+| `docs/guides/config-migration.md.jinja` | 1 `ai-tells.OverusedVocabulary` cleared |
+
+Verified: 0 Vale errors in the default and gate-off renders, renders
+byte-identical, hygiene clean on both variants, `mkdocs build --strict` passes.
+
+## Measured Vale behaviour
+
+Probed against the live binary with this template's own ruleset. Each of these
+contradicts what the rule name suggests, so they are recorded rather than
+re-derived.
+
+- **`ai-tells.EmDashUsage` flags an em dash at any spacing, and an en dash
+  too.** `A—B` unspaced is an error. Keying a normaliser on the spaced form
+  alone leaves failures behind.
+- **`For example,` and `For instance,` both trip
+  `ai-tells.FormalTransitions`.** Neither can replace `e.g.`. `such as` is
+  clean, as is dropping the abbreviation and capitalising the next word.
+- **Vale skips code spans and fenced blocks.** Wrapping a literal in backticks
+  immunises it against `Vale.Spelling`, which is why a generated table's
+  `Default` column should be a code span rather than bare prose.
+- **Vale reports a subset.** Only 6 of this file's 11 spaced em dashes were
+  reported, and the set shifted as edits landed. The exit criterion has to be
+  "re-run until zero", not "fix the reported list".
+
+## Constraints that governed the fix
+
+- **Spelling errors were reworded, never accepted.** `.vale.ini` and
+  `.vale/styles/config/vocabularies/Base/accept.txt` are both in
+  `_skip_if_exists`, so a term added to either reaches new renders only and
+  leaves an existing project red. That ruled out accepting `uncomment`,
+  `IdP's`, `overridable` and `middleware`.
+- **Replacement wording needs linting too.** Swapping `e.g.` for "for example"
+  trades a `Google.Latin` error for a `FormalTransitions` one, and one rewrite
+  introduced a fresh `Vale.Spelling` hit on "middleware". Both were caught by
+  re-running Vale, not by reading.
+- **Vale rewrites must not shed semantic force.** PR #145 established this and
+  the maintainer applied it. Dropping the bold from `is **not** structural`
+  removed the salience from the guide's one silent-failure warning; the
+  negation moved off the copula instead, keeping the emphasis and clearing
+  `ai-tells.EmphaticCopula`.
+- **Downstream docs are operator-only.** `2a0e36d` deliberately purged the
+  pvl-core API surface from this guide. A correction that reintroduced two of
+  those symbols was reverted to a behavioural statement pointing at the stub.
+
+## Deliberately not done
+
+- **The `DOMAIN-AUTHZ-SCOPES-START` marker line keeps its em dash.** Editing
+  it is unnecessary — with the other occurrences fixed, Vale reports zero
+  either way, verified by restoring it — and it would open a `copier update`
+  3-way-merge conflict on a block downstream projects customise.
+- **The em dash inside the TOML fence is untouched.** Vale skips code blocks.
+- **One paragraph was restructured, the rest only reworded.** The "turn either
+  on" paragraph told the reader to enable "the matching block" and that "both
+  may run together". `server.py.jinja` ships one block of three mutually
+  exclusive checks and warns against installing two. That sentence was being
+  rewritten anyway, so the contradiction was fixed rather than preserved.
+
+## What this cost, and why the next plan should be shorter
+
+Two rounds of six-lens review produced roughly twenty findings. One was in the
+24-line prose change. The rest were in the plan document that described it,
+which ran to 420 lines of shell blocks and line-anchored edits for a change
+that amounted to sixteen string replacements.
+
+The specific failures were: line anchors that the plan's own first edit
+invalidated; `git reset --soft` followed by a selective `git add`, which is a
+no-op because the soft reset leaves the index staged; shell blocks that
+inherited a working directory from a previous step's `cd`; a `mv` park/restore
+that nests on a second run; and mitigations written into the constraints
+section but never into the step they governed.
+
+For PRs B-H: keep the plan to the decisions and the verification criteria.
+Exact string replacements belong in the execution, not in a document that goes
+stale the moment the first one lands.

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -49,11 +49,12 @@ re-derived.
   trades a `Google.Latin` error for a `FormalTransitions` one, and one rewrite
   introduced a fresh `Vale.Spelling` hit on "middleware". Both were caught by
   re-running Vale, not by reading.
-- **Vale rewrites must not shed semantic force.** PR #145 established this and
-  the maintainer applied it. Dropping the bold from `is **not** structural`
-  removed the salience from the guide's one silent-failure warning; the
-  negation moved off the copula instead, keeping the emphasis and clearing
-  `ai-tells.EmphaticCopula`.
+- **A flagged emphasis gets deleted, not relocated.**
+  `ai-tells.EmphaticCopula` fired on `is **not** structural`. The first two
+  attempts kept the emphasis and moved it, onto the verb and then onto the
+  noun; the rule caught both, correctly. Emphasising a negation is the tic the
+  rule exists to catch, so the emphasis is gone. The sentence reads no worse
+  without it.
 - **Downstream docs are operator-only.** `2a0e36d` deliberately purged the
   pvl-core API surface from this guide. A correction that reintroduced two of
   those symbols was reverted to a behavioural statement pointing at the stub.

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -17,7 +17,10 @@
 - **`ai-tells.EmDashUsage` flags an em dash at any spacing, and an en dash too.** `A—B` unspaced is an error.
 - **Marker tokens are load-bearing.** `DOMAIN-AUTHZ-SCOPES-START`, `DOMAIN-AUTHZ-SCOPES-END`, `DOMAIN-AUTHZ-EXTRA-START`, `DOMAIN-AUTHZ-EXTRA-END` must survive verbatim. Only the human-readable text *after* a marker token may change.
 - **The exit criterion is `vale` reporting zero, not "the 20 listed errors are fixed".** Vale's reported set shifts as edits land: only 6 of the file's 11 spaced em dashes are currently reported, for reasons not derivable from `.vale.ini`. Fix the whole class, then re-run until zero.
-- **`.vscode/` is untracked on this branch** (its ignore rule is PR G). Move it aside before any render, or `copier` mints a temp commit per render and `_commit` differs between two otherwise identical renders.
+- **`.vscode/` is untracked on this branch** (its ignore rule is PR G). Two consequences, and both bit during execution:
+  - Add it to `.git/info/exclude` **before starting**. That file is local-only and never committed. Without it, any `git add -A` sweeps `.vscode/` into a commit, which is how it landed in this PR's first attempt and had to be rewritten out.
+  - Move it aside before any render. Otherwise `copier` mints a temp commit per render and `_commit` differs between two otherwise identical renders. Once it is *tracked*, moving it aside dirties the tree and causes the same divergence — so do the exclude first.
+- **Run `check_render_hygiene.py` on a pristine render.** `vale sync` downloads style packages into the render tree, and `uv sync` writes a venv; either makes hygiene fail on files the change never touched. Render for hygiene, then copy the render before linting it.
 - Verification renders use `--vcs-ref=HEAD`, so **commit before rendering**.
 
 ---
@@ -29,6 +32,7 @@
 | `docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja` | the authorization guide; 19 errors | Modify |
 | `docs/guides/config-migration.md.jinja` | the config migration guide; 1 error | Modify |
 | `docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md` | design spec | Already committed as `f4b5552`; rides along |
+| `docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md` | this plan | Rides along; it is in its own reviewed range |
 
 The authorization guide's filename contains a Jinja conditional, so it renders only when `enable_authorization` is true. Quote the path in every shell command.
 
@@ -54,6 +58,8 @@ Filing is outward-facing. Show this draft and wait for approval:
 > Fixes must be prose rewordings. `.vale.ini` and the Vocab accept list are both `_skip_if_exists`, so adding an accepted term would reach new renders only and leave existing downstreams red.
 >
 > **Verification:** render the template and run `vale --glob='!docs/{superpowers,design,decisions}/**' docs README.md`; it must report 0 errors.
+>
+> — 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
 
 - [ ] **Step 2: File it**
 
@@ -63,9 +69,21 @@ gh issue create --repo pvliesdonk/fastmcp-server-template \
   --body-file /tmp/pr-a-issue.md
 ```
 
-Write the approved body to `/tmp/pr-a-issue.md` first. Append the agent-attribution signature line required by the operator's global instructions.
+Write the approved body to `/tmp/pr-a-issue.md` first, including the signature line shown at the end of the draft above. It is required verbatim on every agent-authored GitHub post, the PR body included.
 
-- [ ] **Step 3: Rename the branch so it reflects the PR**
+- [ ] **Step 3: Stop `.vscode/` reaching a commit**
+
+```bash
+printf '.vscode/\n' >> .git/info/exclude
+git status --porcelain | grep -c vscode
+```
+
+Expected: `0`. `.git/info/exclude` is local-only and never committed. Do
+this **before** any `git add -A`, and before parking `.vscode/` for a
+render: once it is tracked, parking it dirties the tree and `_commit`
+diverges between two otherwise identical renders.
+
+- [ ] **Step 4: Rename the branch so it reflects the PR**
 
 ```bash
 git branch -m docs/config-surface-1b-redesign fix/docs-vale-errors
@@ -191,15 +209,28 @@ git add -A && git commit -q -m "wip" && mv .vscode /tmp/vscode-parked 2>/dev/nul
 rm -rf /tmp/pr-a && uv run --no-project --with copier copier copy --trust --defaults \
   --vcs-ref=HEAD --data-file tests/fixtures/smoke-answers.yml . /tmp/pr-a 2>&1 | tail -1
 mv /tmp/vscode-parked .vscode 2>/dev/null
-cd /tmp/pr-a && vale docs/guides/authorization.md 2>&1 | tail -2
+cd /tmp/pr-a && vale sync >/dev/null 2>&1
+vale docs/guides/authorization.md 2>&1 | tail -2
 ```
 
-Expected: `0 errors`. If any error remains, fix it and repeat this step — the reported set shifts as edits land.
+`vale sync` is required after **every** fresh render: the style packages live
+under the render's own `.vale/styles`, so a new render has none and `vale`
+exits with `E100 [loadStyles] Runtime error`.
+
+Expected: `0 errors`.
+
+If any error remains, apply **only** a substitution from the catalogue in
+Steps 2-4 (`e.g.` to `such as`; a spaced dash to `.`, `,` or `:`; a
+non-vocabulary word reworded away) and re-run. If the remaining error is
+not covered by that catalogue, **stop and report the `vale` output** rather
+than improvising a reword: the replacement has to be lint-clean itself, and
+the obvious substitutions are frequently not. Do not add a Vocab term.
 
 - [ ] **Step 7: Squash the wip commit and commit properly**
 
 ```bash
-git reset --soft HEAD~1
+git reset HEAD~1   # mixed, NOT --soft: --soft leaves the wip index staged,
+                   # so the selective add below would be a no-op
 git add 'docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja'
 git commit -m "$(cat <<'EOF'
 fix(docs): clear the authorization guide's Vale errors
@@ -291,7 +322,7 @@ Expected: `0 errors`.
 - [ ] **Step 5: Squash and commit**
 
 ```bash
-git reset --soft HEAD~1
+git reset HEAD~1   # mixed, not --soft; see Task 1 Step 7
 git add docs/guides/config-migration.md.jinja
 git commit -m "$(cat <<'EOF'
 fix(docs): drop an overused adverb from the migration guide
@@ -355,11 +386,13 @@ Expected: `Documentation built in …` with no warnings.
 git diff --name-only 352c0c9..HEAD
 ```
 
-Expected exactly three paths — the two guides plus the design spec from `f4b5552`:
+Expected exactly four paths — the two guides, plus the design spec and this
+plan, both of which ride along in this PR:
 
 ```
 docs/guides/config-migration.md.jinja
 docs/guides/{% if enable_authorization %}authorization.md{% endif %}.jinja
+docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
 docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
 ```
 

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -46,6 +46,11 @@ re-derived.
   inherits the weakness. A strict check drops the domain vocabulary and
   re-runs; used here to confirm the tricolon was gone rather than masked.
 
+  That strict run also surfaces one pre-existing case outside this PR's diff:
+  `README.md.jinja:142` carries a verb tricolon that only passes because
+  `GitHub` is an accepted term. It came from #209 and is left alone here;
+  PR B owns the gate and should decide whether the gate runs strict.
+
 ## Constraints that governed the fix
 
 - **Spelling errors were reworded, never accepted.** `.vale.ini` and

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -19,37 +19,25 @@ Two authored `.jinja` files, 24 lines. No code, no CI, no generator.
 Verified: 0 Vale errors in the default and gate-off renders, renders
 byte-identical, hygiene clean on both variants, `mkdocs build --strict` passes.
 
-## Measured Vale behaviour
+## Rules this prose follows
 
-Probed against the live binary with this template's own ruleset. Each of these
-contradicts what the rule name suggests, so they are recorded rather than
-re-derived.
+Established by running the linter, not by reading rule names. Follow them when
+writing; do not treat them as a description of the tool.
 
-- **`ai-tells.EmDashUsage` flags an em dash at any spacing, and an en dash
-  too.** `A—B` unspaced is an error. Keying a normaliser on the spaced form
-  alone leaves failures behind.
-- **`For example,` and `For instance,` both trip
-  `ai-tells.FormalTransitions`.** Neither can replace `e.g.`. `such as` is
-  clean, as is dropping the abbreviation and capitalising the next word.
-- **Vale skips code spans and fenced blocks.** Wrapping a literal in backticks
-  immunises it against `Vale.Spelling`, which is why a generated table's
-  `Default` column should be a code span rather than bare prose.
-- **Vale reports a subset.** Only 6 of this file's 11 spaced em dashes were
-  reported, and the set shifted as edits landed. The exit criterion has to be
-  "re-run until zero", not "fix the reported list".
-- **`ai-tells.VerbTricolon` flags exactly three parallel verbs.** A sentence
-  written here tripped it (`run` / `keeps` / `shows`) and was split in two.
-- **An accepted vocabulary term suppresses non-spelling rules inside its
-  match span.** That tricolon reported zero only because the span contained
-  `OIDC`, which is in `accept.txt`; removing that one term surfaced the error.
-  So "Vale reports zero" is a weaker signal than it looks, and PR B's gate
-  inherits the weakness. A strict check drops the domain vocabulary and
-  re-runs; used here to confirm the tricolon was gone rather than masked.
-
-  That strict run also surfaces one pre-existing case outside this PR's diff:
-  `README.md.jinja:142` carries a verb tricolon that only passes because
-  `GitHub` is an accepted term. It came from #209 and is left alone here;
-  PR B owns the gate and should decide whether the gate runs strict.
+- No em dash or en dash, at any spacing. `A—B` is as wrong as `A — B`.
+- No Latin abbreviations. Use `such as`, or drop the abbreviation and
+  capitalise the next word. Never `For example,` or `For instance,`.
+- No emphasised negation. Delete the emphasis; do not move it to a
+  neighbouring word.
+- At most two parallel verbs in a clause.
+- Fix a flagged word by rewriting the sentence, never by adding a vocabulary
+  term: `.vale.ini` and the accept list are both `_skip_if_exists`, so a new
+  term reaches new renders only and leaves existing projects failing.
+- Re-run the linter until it reports zero. The reported set changes as edits
+  land, so the first report is not the whole list.
+- Run it a second time with the domain vocabulary dropped. An accepted term
+  suppresses non-spelling rules inside its match span, so a plain zero can
+  hide a flagged pattern. This PR clears both runs.
 
 ## Constraints that governed the fix
 

--- a/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
+++ b/docs/superpowers/plans/2026-07-27-pr-a-clear-vale-errors.md
@@ -62,16 +62,19 @@ writing; do not treat them as a description of the tool.
 
 ## Deliberately not done
 
-- **The `DOMAIN-AUTHZ-SCOPES-START` marker line keeps its em dash.** Editing
-  it is unnecessary — with the other occurrences fixed, Vale reports zero
-  either way, verified by restoring it — and it would open a `copier update`
+- **The `DOMAIN-AUTHZ-SCOPES-START` marker line keeps its em dash.** Vale skips
+  HTML comments, the same way it skips fenced blocks and code spans, so the
+  dash there is structurally out of scope rather than merely unreported.
+  `README.md.jinja:39` has carried a spaced em dash in a comment through a
+  clean gate since #145. Editing the line would also open a `copier update`
   3-way-merge conflict on a block downstream projects customise.
 - **The em dash inside the TOML fence is untouched.** Vale skips code blocks.
 - **One paragraph was restructured, the rest only reworded.** The "turn either
-  on" paragraph told the reader to enable "the matching block" and that "both
-  may run together". `server.py.jinja` ships one block of three mutually
-  exclusive checks and warns against installing two. That sentence was being
-  rewritten anyway, so the contradiction was fixed rather than preserved.
+  on" paragraph said to enable "the matching block", which reads as plural and
+  invites installing two middlewares; `server.py.jinja` warns against exactly
+  that. Running both mechanisms was never the problem, and is still described:
+  the stub's third option is bearer break-glass plus OIDC combined into one
+  check. The rewrite keeps that case and drops the plural-blocks reading.
 
 ## What this cost, and why the next plan should be shorter
 

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -344,6 +344,16 @@ These must reach the release note and the rollout issue.
 | G | to file — `.vscode/` is untracked noise and `.mcp.json/` never matched the file |
 | H | to file — dead `READ_ONLY` in the `.mcpb` manifest (the remainder of #240) |
 
+Two pre-existing defects were found by PR A's review and filed rather than
+folded in, since neither belongs to a prose-linting change:
+
+- **#267** — the authorization guide's `See also` has no pvl-core reference.
+  Raised twice on #181 and unanswered. Belongs with C, which owns that
+  guide's prose.
+- **#268** — `config-migration.md` misdescribes the AST scan and steers a
+  reader into the duplicate-name `SystemExit`. The same wording appears in
+  five files, so it is a sweep. Belongs with E, which owns domain discovery.
+
 At merge time the **squashed commit message's** closing keywords are what
 GitHub acts on, not the PR body. A stale `Closes` line in Stage 1a's squashed
 commit auto-closed three issues that still had work outstanding.

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -137,9 +137,23 @@ rendered with `enable_authorization: true`, and those projects run Vale at
 fixes them; a baseline would have recorded a shipped bug as accepted, and
 would then have to be maintained and eventually retired.
 
-The 19 errors span 7 rules, all in one authored file: 6 `Google.EmDash`, 4
-`ai-tells.EmDashUsage`, 3 `Vale.Spelling`, 3 `Google.Latin`, and one each of
-`write-good.ThereIs`, `Google.OptionalPlurals`, `ai-tells.EmphaticCopula`.
+The errors span 8 rules across two authored files. `docs/guides/authorization.md`
+carries 19: 6 `Google.EmDash`, 4 `ai-tells.EmDashUsage`, 3 `Vale.Spelling`, 3
+`Google.Latin`, and one each of `write-good.ThereIs`,
+`Google.OptionalPlurals`, `ai-tells.EmphaticCopula`.
+`docs/guides/config-migration.md` carries 1, `ai-tells.OverusedVocabulary`.
+
+**The net covers the whole render, not only the generated regions, because
+the authored prose is agent-written too.** `ai-tells` is a rule pack built
+from the writing tics of Claude models, and every finding here is one:
+`git blame` attributes the authorization guide's flagged lines to a commit
+co-authored by Claude Opus 4.8. During the abandoned attempt, three further
+`ai-tells` errors were introduced by the agent doing the fixing — a spaced em
+dash and an italicised `*not*` in a README edit, and a normaliser that emitted
+"For example," while its own docstring said that phrase trips
+`FormalTransitions`. A gate scoped to generated output would have caught none
+of them. The author of this prose cannot self-review for these patterns; only
+the tool surfaces them.
 
 ### 4.2 Prose normalisation: minimal, verified against core
 

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -1,7 +1,7 @@
 # Config-surface Stage 1b, restructured into reviewable PRs
 
 **Date:** 2026-07-27
-**Status:** design approved, implementation not started
+**Status:** design approved. PR A shipped; B-H not started.
 **Supersedes:** `docs/superpowers/plans/2026-07-26-config-surface-generation-1b.md` (abandoned; exists only on the unpushed `feat/config-surface-splicing` spike at `283811e`, not on `main`)
 **Upstream spec:** `docs/superpowers/specs/2026-07-25-config-generation-and-ownership-model-design.md`, Stage 1
 **Closes (design-level):** #257, #260, plus four issues still to be filed (§8)
@@ -87,7 +87,7 @@ revertible.
 
 | PR | Scope | Primary verification |
 |---|---|---|
-| **A** | Fix `docs/guides/authorization.md`'s 19 Vale errors | `vale` over a render reports 0 |
+| **A** | Clear the 20 Vale errors in `authorization.md` and `config-migration.md` | `vale` over a render reports 0 |
 | **B** | `template-ci` runs Vale over the render; add the missing `check_anchor` | A deliberately injected error fails the build |
 | **C** | OIDC prose corrections (key derivation, re-registration, restart) | Every claim cited to a `fastmcp` file and symbol |
 | **D** | Markdown splice engine + the two OIDC doc tables + `required_vars` | The rendered tables read correctly to an operator |
@@ -139,9 +139,14 @@ would be red.
 No current consumer is exposed: all seven sibling repos render with
 `enable_authorization` false or absent, so the blast radius today is zero.
 That makes this the cheapest possible moment to fix it rather than a reason to
-defer — the same reasoning applies to PR A's marker-adjacent edits, which
-would conflict on `copier update` for an authz-enabled downstream that had
-already populated its gated-tools table.
+defer.
+
+That argument covers prose near a marker, not the marker line itself. PR A
+left the `DOMAIN-AUTHZ-SCOPES-START` line alone: editing it bought no
+error-count improvement, and a marker line is where a `copier update` 3-way
+merge is most likely to conflict for a downstream that customised the block
+beneath it. Where an edit is unnecessary, low blast radius is not a reason to
+make it.
 
 PR A fixes the errors; a baseline would have recorded them as accepted, and
 would then have to be maintained and eventually retired.
@@ -330,7 +335,7 @@ These must reach the release note and the rollout issue.
 
 | PR | Issue |
 |---|---|
-| A | to file — `docs/guides/authorization.md` fails Vale with 19 errors in every authz-enabled downstream |
+| A | #266 — the rendered docs fail Vale (19 in `authorization.md`, 1 in `config-migration.md`) |
 | B | to file — `template-ci` never runs Vale over the render, and one scrub rule is unguarded |
 | C, D, E | #260 (authored-prose remainder) |
 | F | #257 (`server.json` remainder) |

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -1,0 +1,319 @@
+# Config-surface Stage 1b, restructured into reviewable PRs
+
+**Date:** 2026-07-27
+**Status:** design approved, implementation not started
+**Supersedes:** `docs/superpowers/plans/2026-07-26-config-surface-generation-1b.md` (abandoned)
+**Upstream spec:** `docs/superpowers/specs/2026-07-25-config-generation-and-ownership-model-design.md`, Stage 1
+**Closes (design-level):** #257, #260, plus four issues still to be filed (§8)
+
+## 1. Why this design exists
+
+A first attempt at Stage 1b was implemented, reviewed three times by a
+seven-lens adversarial review, and abandoned. It is preserved unpushed on
+`feat/config-surface-splicing` at `283811e` as a spike.
+
+The scope was not wrong. The unit of review was. The branch reached **3,515
+added lines across 17 files** in a single range, and the reviews found **12
+confirmed findings in the third round alone** — two of which would have failed
+CI or shipped broken output to every downstream.
+
+The decisive evidence was not the count. Round 2's fixes introduced three new
+defects that were each instances of the class round 1 had just closed; round
+3 then found a fourth, in the same function, twelve lines from a sibling fixed
+in the same edit. Iteration was not converging.
+
+### 1.1 What actually failed, and what did not
+
+This split drives the whole decomposition.
+
+**Mechanism survived.** Across three rounds with independent execution, no
+lens found a confirmed defect in: the splice engine and its marker guards, the
+`json-splice` structural replacement, `--check` read-only semantics,
+determinism under varying `PYTHONHASHSEED`, or byte-parity with
+`bump_manifests.py`. Lens 6 validated the generated `server.json` against the
+real published registry schema with zero errors, and proved the version-bump
+round trip leaves the file byte-identical.
+
+**Content failed, repeatedly.** Every round found defects in *which vars go
+where*, *what "required" means*, *what a default is*, and *what the prose
+claims*. A representative sample:
+
+- `KV_STORE_URL` was moved into the stdio package on the strength of core's
+  help prose, reversing a decision PR #153's review thread had already settled
+  on the code — `build_event_store` is called only inside `if transport ==
+  "http":`.
+- `isRequired` was emitted for four OIDC vars, asserting something false: a
+  container with none of them set starts and serves unauthenticated.
+- `x: str | None = None`, the ordinary spelling of an optional setting,
+  published as **Required: Yes** in every downstream README.
+- A rewording of `CLAUDE.md.jinja` silently broke the `detach-smoke` scrub,
+  and the guard built to catch exactly that passed, because it had no anchor
+  for the rule that broke.
+
+The difference is reviewability. A mechanism defect is visible by reading
+code. A content defect is visible only by reading rendered output against an
+external source of truth — the template's own code, the review record, the
+published schema, or a lint tool's actual behaviour.
+
+### 1.2 Root cause
+
+Three rounds of review located one root cause with two faces.
+
+**No verification feedback loop for prose.** `template-ci` renders the
+template but never runs Vale over the result; it only grep-checks `.vale.ini`
+structurally. Every prose defect was therefore found by hand, late, or would
+have been found by a downstream's red build. The normalisation layer was
+written to *guess* which shapes would trip rules nobody had measured.
+
+**The wrong source of truth for content decisions.** Core's help text
+describes what the *library* can do. The template's own `cli.py.jinja` decides
+what the *scaffold* does. Decisions were made from the former.
+
+## 2. Design principles
+
+1. **Every PR ships a rendered artifact a reviewer can read.** No PR asks a
+   reviewer to simulate a generator in their head.
+2. **Verification before generation.** The prose safety net lands before
+   anything generates prose.
+3. **Minimal over speculative.** Rules exist for shapes that are observed,
+   not imagined. The safety net covers the unobserved.
+4. **Salvage what execution verified; redecide what judgement produced.**
+
+## 3. PR sequence
+
+Strictly sequential off `main` — one PR at a time, per the repo's
+no-stacked-PRs rule. Each row is independently shippable and independently
+revertible.
+
+| PR | Scope | Primary verification |
+|---|---|---|
+| **A** | Fix `docs/guides/authorization.md`'s 19 Vale errors | `vale` over a render reports 0 |
+| **B** | `template-ci` runs Vale over the render; add the missing `check_anchor` | A deliberately injected error fails the build |
+| **C** | OIDC prose corrections (key derivation, re-registration, restart) | Every claim cited to a `fastmcp` file and symbol |
+| **D** | Markdown splice engine + the two OIDC doc tables + `required_vars` | The rendered tables read correctly to an operator |
+| **E** | README core + domain tables + `documented_defaults` + the `MISSING` fix | A real `ProjectConfig` field renders Required correctly both ways |
+| **F** | `json-splice` + `server.json` arrays + `packaging` / `choices` / key validation | Schema-valid; `bump_manifests` round trip byte-identical; every guard bites |
+| **G** | `.vscode/` ignore + the `.mcp.json/` trailing-slash fix | Both patterns verified in a fresh `git init` inside a render |
+| **H** | Remove dead `READ_ONLY` from `packaging/mcpb/manifest.json.in.jinja` | No `_READ_ONLY` env var anywhere in a render |
+
+G and H are independent of the rest and may land at any point.
+
+### 3.1 Why C is separate from D
+
+Both touch `docs/guides/authentication.md` and `docs/deployment/oidc.md`, so
+folding C into D would look economical. It is not. Verifying claims about a
+third-party library against its source is a different review activity from
+reviewing a table generator, and mixing them is how the first attempt
+*relocated* a false claim rather than fixing it: a correction was written,
+reviewed alongside unrelated generator changes, and turned out to assert
+something new that was also untrue.
+
+C touches prose sections. D replaces tables. They occupy disjoint regions of
+the same files.
+
+### 3.2 Why B carries the `check_anchor` fix
+
+`template-ci` scrubs `copier update` wording out of `CLAUDE.md` for the
+detach-fork smoke test, and guards that scrub with `check_anchor` calls that
+assert each anchored phrase still exists. There are five substitution rules
+and only four anchors. The unguarded rule is precisely the one a reword broke,
+so the guard passed while the scrub silently failed.
+
+Both B and the anchor fix are "make `template-ci` actually verify what it
+claims to verify". They belong together.
+
+## 4. Design decisions
+
+### 4.1 Vale safety net, no baseline
+
+`template-ci` renders the template and runs Vale over `docs/` and `README.md`
+with the same scope, version and flags the downstream `ci.yml` uses, and
+asserts **zero** errors.
+
+No baseline file. The 19 pre-existing errors are not acceptable noise — they
+are a live failure. `docs/guides/authorization.md` ships to every downstream
+rendered with `enable_authorization: true`, and those projects run Vale at
+`MinAlertLevel = error` with `fail_on_error: true`. They are red today. PR A
+fixes them; a baseline would have recorded a shipped bug as accepted, and
+would then have to be maintained and eventually retired.
+
+The 19 errors span 7 rules, all in one authored file: 6 `Google.EmDash`, 4
+`ai-tells.EmDashUsage`, 3 `Vale.Spelling`, 3 `Google.Latin`, and one each of
+`write-good.ThereIs`, `Google.OptionalPlurals`, `ai-tells.EmphaticCopula`.
+
+### 4.2 Prose normalisation: minimal, verified against core
+
+The generator normalises core's help text for the Vale-linted markdown
+destination only. The rule set covers **exactly the shapes core currently
+emits**, and no more:
+
+- a spaced em dash,
+- `e.g.` in the comma-clause shape,
+- the vocabulary term `JWTs`.
+
+No residual sweeps. No sentence-initial branch. No catch-alls for shapes core
+has never produced. Every one of those speculative constructs produced a
+defect in the abandoned attempt, and none of them was reachable by any real
+input.
+
+The sufficiency check is what makes this safe, and it has two halves that must
+not be confused:
+
+- **A unit test** iterates `server_config_surface()`, pushes every real help
+  string through the normaliser, and asserts no *known-bad pattern* survives —
+  a spaced or unspaced dash of either kind, a Latin abbreviation, a
+  formal-transition phrase. It is a pattern assertion, not a lint run, so it
+  needs no `vale` binary and runs everywhere.
+- **`template-ci` (§4.1)** runs the real Vale binary over the rendered output.
+  That is the authority. The unit test exists to fail fast and to localise the
+  offending var; it is never the reason to believe the output is clean.
+
+Together they prove the rule set is sufficient *for the pinned core*. When a
+future core introduces a new shape, `template-ci` goes red and a rule is added
+then — which is the entire purpose of §4.1.
+
+Facts measured against the live Vale binary, recorded so they are not
+re-derived:
+
+- `ai-tells.EmDashUsage` flags an em dash at **any** spacing, and an en dash
+  too. `A—B` unspaced is an error.
+- `For example,` **and** `For instance,` both trip
+  `ai-tells.FormalTransitions`. Neither can replace `e.g.`.
+- `such as` is clean, as is dropping the abbreviation entirely.
+- A code span is skipped by Vale, which is why a rendered `Default` cell is
+  wrapped in backticks: it immunises the whole column against every
+  non-English default value at once, rather than one vocabulary entry per
+  value.
+
+### 4.3 Required-ness for domain vars
+
+`_discover_domain_vars` stops collapsing "no default declared" into `None`.
+`dataclasses` already distinguishes them — `field.default is MISSING` — and
+discarding that distinction made the documented rule unimplementable and
+published the common case wrongly.
+
+The resulting rule is honest and needs no new vocabulary:
+
+| Field | Signal | Required |
+|---|---|---|
+| `vault_path: str = field(default="/data")` | has a default | No |
+| `api_key: str \| None = None` | has a default | No |
+| `api_key: str = field(metadata={...})` | no default; cannot construct without it | Yes |
+
+Template-enumerable vars continue to use the explicit `required_vars:` list,
+because their required-ness is a semantic property of the feature, not of the
+dataclass.
+
+### 4.4 Destination-specific formatters
+
+A var's default has four destinations with four correct answers. Each pair is
+pinned apart by a test; the abandoned attempt merged the fourth and wrote a
+test asserting they agreed.
+
+| Destination | Default renders as | Rationale |
+|---|---|---|
+| env file (`_format_value`) | real default, else `example` | the reader wants something fillable |
+| markdown cell (`_md_default_cell`) | real default, else declared documented default, else `(none)`; always a code span | the column states what happens if you set nothing |
+| `server.json` (`_json_default`) | real default as a string, else `placeholder` | the schema's own split: `default` is behaviour, `placeholder` is guidance |
+| wizard spec | untouched core prose | not linted, not a value field |
+
+`isRequired` is **never** emitted into `server.json`. `required_vars:` means
+"required for the feature this var belongs to"; the docs tables get away with
+it because they sit under an `## OIDC` heading that supplies the condition. A
+package manifest has no such context and the schema offers no conditional
+scoping, so the flag would assert something false.
+
+### 4.5 Salvage boundary
+
+Carried forward from the spike, with their tests, because three rounds
+verified them by execution:
+
+- `splice_region` and its four marker guards
+- the `json-splice` structural replacement and the `registryType` cross-check
+- `--check` read-only semantics
+- determinism (no set iteration feeding ordered output)
+- `bump_manifests.py` byte-parity and its round-trip test
+
+Redecided from scratch, because judgement produced them and judgement was
+wrong:
+
+- which vars appear in which destination
+- `required_vars`, `documented_defaults`, `packaging`, `choices` contents
+- every normaliser rule
+- every prose claim about `fastmcp` behaviour
+
+## 5. Verification contract
+
+Every PR that changes generated output verifies along three axes the
+abandoned attempt never checked. All three blockers found in round 1 lived
+outside the intersection of "fresh render" and "core's current help text".
+
+1. **An existing downstream.** Re-run the check with `_skip_if_exists` files
+   reset to their pre-change state. `.vale.ini`,
+   `.vale/styles/config/vocabularies/Base/accept.txt`, `.gitignore` and
+   `packaging/mcpb/manifest.json.in` reach new renders only. A fix that
+   depends on one of them does not propagate and is not a fix.
+2. **Downstream-authored help text.** The README domain region renders text a
+   downstream author wrote, which no test in this repo can enumerate. Exercise
+   it with multi-line help, help containing a pipe, and help containing
+   markup.
+3. **A core whose prose differs from today's.** The normaliser's sufficiency
+   test pins the current core; the safety net covers the next one.
+
+Additional invariants:
+
+- Any PR touching `CLAUDE.md.jinja` greps `FORKING.md.jinja` and
+  `template-ci.yml` for a scrub rule matching the edited sentence. That
+  coupling is invisible from the file itself.
+- Any content decision that contradicts an apparent prior choice is checked
+  against the review record (`gh api .../pulls/<N>/comments`, `/reviews`,
+  `/issues/<N>/comments`) before it is made.
+- Every mechanical edit asserts that it applied. Two silent `str.replace()`
+  no-ops occurred in the abandoned attempt, one of which was reported as a
+  completed fix.
+- Every `SystemExit` a downstream can hit during `copier update` has its
+  recovery documented in `docs/guides/config-migration.md`.
+
+## 6. Rollout hazards
+
+These must reach the release note and the rollout issue.
+
+- **README's domain table conflicts for every downstream.** All four carry a
+  hand-written table inside the `DOMAIN` fence that PR E replaces with
+  `GENERATED-ENV-TABLE-DOMAIN` markers. A downstream that resolves the
+  conflict by keeping its own table *without* the markers gets a hard CI
+  failure, not a silent skip: `splice_region` raises and `ci.yml` runs
+  `--check`. The migration guide must name the marker pair, state that only
+  the rows between them may be deleted, and give the recovery for a
+  missing-marker error mid-update.
+- **`_skip_if_exists` fixes do not propagate.** PR G's `.gitignore`
+  corrections and PR H's manifest cleanup reach new renders only. The four
+  downstreams need a one-time manual edit.
+- **Stage 1b must merge before the template is released**, or downstreams
+  receive generated documentation without the corresponding fixes.
+
+## 7. Out of scope
+
+- `.pre-commit-config.yaml` reclassification (Stage 1c, #254).
+- Pushing prose fixes upstream into `fastmcp-pvl-core`. Filed as core#237;
+  the template-side rules are still required for downstreams pinned to older
+  cores.
+- `docs/deployment/docker.md`'s deployment-subset table and
+  `packaging/mcpb/manifest.json.in`'s `env` block remain hand-owned. They are
+  env-var surfaces the generator deliberately does not own, and any statement
+  about generator ownership must say so.
+
+## 8. Issues
+
+| PR | Issue |
+|---|---|
+| A | to file — `docs/guides/authorization.md` fails Vale with 19 errors in every authz-enabled downstream |
+| B | to file — `template-ci` never runs Vale over the render, and one scrub rule is unguarded |
+| C, D, E | #260 (authored-prose remainder) |
+| F | #257 (`server.json` remainder) |
+| G | to file — `.vscode/` is untracked noise and `.mcp.json/` never matched the file |
+| H | to file — dead `READ_ONLY` in the `.mcpb` manifest (the remainder of #240) |
+
+At merge time the **squashed commit message's** closing keywords are what
+GitHub acts on, not the PR body. A stale `Closes` line in Stage 1a's squashed
+commit auto-closed three issues that still had work outstanding.

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -127,9 +127,16 @@ claims to verify". They belong together.
 
 ### 4.1 Vale safety net, no baseline
 
-`template-ci` renders the template and runs Vale over `docs/` and `README.md`
-with the same scope, version and flags the downstream `ci.yml` uses, and
-asserts **zero** errors.
+`template-ci` renders the template and runs Vale over `docs/` and `README.md`,
+and asserts **zero** errors.
+
+Scope, version and exclusion glob must be **extracted from the rendered
+`ci.yml`**, not restated. #143/#159 established that Vale's scope is derived
+and compared rather than duplicated, because two surfaces drifting apart make
+a finding visible to one and silent to the other; the existing lockstep steps
+compare `ci.yml` against `.pre-commit-config.yaml` using an `awk` anchor on
+the `vale:` job. This gate is a third surface, so it either reuses that anchor
+or the lockstep grows to assert over all three.
 
 No baseline file. The pre-existing errors are not acceptable noise.
 `docs/guides/authorization.md` ships to any downstream rendered with

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -136,8 +136,11 @@ No baseline file. The pre-existing errors are not acceptable noise.
 `MinAlertLevel = error` with `fail_on_error: true`, so such a project's build
 would be red.
 
-No current consumer is exposed: all seven sibling repos render with
-`enable_authorization` false or absent, so the blast radius today is zero.
+No current consumer is exposed: all seven sibling checkouts in this
+workspace render with `enable_authorization` false or absent, so the blast
+radius today is zero. (Checked against each checkout's
+`.copier-answers.yml`; that is the local working set, which may not be the
+full consumer list.)
 That makes this the cheapest possible moment to fix it rather than a reason to
 defer.
 
@@ -306,8 +309,8 @@ Additional invariants:
 
 These must reach the release note and the rollout issue.
 
-- **README's domain table conflicts for every downstream.** All four carry a
-  hand-written table inside the `DOMAIN` fence that PR E replaces with
+- **README's domain table conflicts for every downstream.** Six of the seven local
+  checkouts carry a hand-written table inside the `DOMAIN` fence that PR E replaces with
   `GENERATED-ENV-TABLE-DOMAIN` markers. A downstream that resolves the
   conflict by keeping its own table *without* the markers gets a hard CI
   failure, not a silent skip: `splice_region` raises and `ci.yml` runs
@@ -315,8 +318,8 @@ These must reach the release note and the rollout issue.
   the rows between them may be deleted, and give the recovery for a
   missing-marker error mid-update.
 - **`_skip_if_exists` fixes do not propagate.** PR G's `.gitignore`
-  corrections and PR H's manifest cleanup reach new renders only. The four
-  downstreams need a one-time manual edit.
+  corrections and PR H's manifest cleanup reach new renders only. Each affected
+  downstream needs a one-time manual edit.
 - **Stage 1b must merge before the template is released**, or downstreams
   receive generated documentation without the corresponding fixes.
 

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -4,7 +4,7 @@
 **Status:** design approved. PR A shipped; B-H not started.
 **Supersedes:** `docs/superpowers/plans/2026-07-26-config-surface-generation-1b.md` (abandoned; exists only on the unpushed `feat/config-surface-splicing` spike at `283811e`, not on `main`)
 **Upstream spec:** `docs/superpowers/specs/2026-07-25-config-generation-and-ownership-model-design.md`, Stage 1
-**Closes (design-level):** #257, #260, plus four issues still to be filed (§8)
+**Closes (design-level):** #257, #260, #266, plus three issues still to be filed (§8)
 
 ## 1. Why this design exists
 

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -89,6 +89,7 @@ revertible.
 |---|---|---|
 | **A** | Clear the 20 Vale errors in `authorization.md` and `config-migration.md` | `vale` over a render reports 0 |
 | **B** | `template-ci` runs Vale over the render; add the missing `check_anchor` | A deliberately injected error fails the build |
+| | *B must also decide whether the gate runs with the domain vocabulary dropped: an accepted term suppresses non-spelling rules inside its match span, so a plain zero-error run can pass prose that still carries a flagged pattern. One such case already exists at `README.md.jinja:142`.* | |
 | **C** | OIDC prose corrections (key derivation, re-registration, restart) | Every claim cited to a `fastmcp` file and symbol |
 | **D** | Markdown splice engine + the two OIDC doc tables + `required_vars` | The rendered tables read correctly to an operator |
 | **E** | README core + domain tables + `documented_defaults` + the `MISSING` fix | A real `ProjectConfig` field renders Required correctly both ways |

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -89,7 +89,7 @@ revertible.
 |---|---|---|
 | **A** | Clear the 20 Vale errors in `authorization.md` and `config-migration.md` | `vale` over a render reports 0 |
 | **B** | `template-ci` runs Vale over the render; add the missing `check_anchor` | A deliberately injected error fails the build |
-| | *B must also decide whether the gate runs with the domain vocabulary dropped: an accepted term suppresses non-spelling rules inside its match span, so a plain zero-error run can pass prose that still carries a flagged pattern. One such case already exists at `README.md.jinja:142`.* | |
+| | *B decides whether the gate also runs with the domain vocabulary dropped. An accepted term suppresses non-spelling rules inside its match span, so a plain zero can pass prose carrying a flagged pattern. PR A leaves both runs clean, so B starts from zero either way.* | |
 | **C** | OIDC prose corrections (key derivation, re-registration, restart) | Every claim cited to a `fastmcp` file and symbol |
 | **D** | Markdown splice engine + the two OIDC doc tables + `required_vars` | The rendered tables read correctly to an operator |
 | **E** | README core + domain tables + `documented_defaults` + the `MISSING` fix | A real `ProjectConfig` field renders Required correctly both ways |
@@ -204,18 +204,9 @@ Together they prove the rule set is sufficient *for the pinned core*. When a
 future core introduces a new shape, `template-ci` goes red and a rule is added
 then — which is the entire purpose of §4.1.
 
-Facts measured against the live Vale binary, recorded so they are not
-re-derived:
+The rules this generated prose must follow are recorded once, in PR A's
+execution record. They are writing rules, not properties of the tool.
 
-- `ai-tells.EmDashUsage` flags an em dash at **any** spacing, and an en dash
-  too. `A—B` unspaced is an error.
-- `For example,` **and** `For instance,` both trip
-  `ai-tells.FormalTransitions`. Neither can replace `e.g.`.
-- `such as` is clean, as is dropping the abbreviation entirely.
-- A code span is skipped by Vale, which is why a rendered `Default` cell is
-  wrapped in backticks: it immunises the whole column against every
-  non-English default value at once, rather than one vocabulary entry per
-  value.
 
 ### 4.3 Required-ness for domain vars
 

--- a/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
+++ b/docs/superpowers/specs/2026-07-27-config-surface-1b-restructured-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-27
 **Status:** design approved, implementation not started
-**Supersedes:** `docs/superpowers/plans/2026-07-26-config-surface-generation-1b.md` (abandoned)
+**Supersedes:** `docs/superpowers/plans/2026-07-26-config-surface-generation-1b.md` (abandoned; exists only on the unpushed `feat/config-surface-splicing` spike at `283811e`, not on `main`)
 **Upstream spec:** `docs/superpowers/specs/2026-07-25-config-generation-and-ownership-model-design.md`, Stage 1
 **Closes (design-level):** #257, #260, plus four issues still to be filed (§8)
 
@@ -130,11 +130,20 @@ claims to verify". They belong together.
 with the same scope, version and flags the downstream `ci.yml` uses, and
 asserts **zero** errors.
 
-No baseline file. The 19 pre-existing errors are not acceptable noise — they
-are a live failure. `docs/guides/authorization.md` ships to every downstream
-rendered with `enable_authorization: true`, and those projects run Vale at
-`MinAlertLevel = error` with `fail_on_error: true`. They are red today. PR A
-fixes them; a baseline would have recorded a shipped bug as accepted, and
+No baseline file. The pre-existing errors are not acceptable noise.
+`docs/guides/authorization.md` ships to any downstream rendered with
+`enable_authorization: true`, and those projects run Vale at
+`MinAlertLevel = error` with `fail_on_error: true`, so such a project's build
+would be red.
+
+No current consumer is exposed: all seven sibling repos render with
+`enable_authorization` false or absent, so the blast radius today is zero.
+That makes this the cheapest possible moment to fix it rather than a reason to
+defer — the same reasoning applies to PR A's marker-adjacent edits, which
+would conflict on `copier update` for an authz-enabled downstream that had
+already populated its gated-tools table.
+
+PR A fixes the errors; a baseline would have recorded them as accepted, and
 would then have to be maintained and eventually retired.
 
 The errors span 8 rules across two authored files. `docs/guides/authorization.md`


### PR DESCRIPTION
Clears every Vale error from the rendered docs, so PR B can add a CI gate that
asserts zero without a baseline file.

`Closes #266` is in the commit message as well as here, because GitHub acts on
the squashed message.

## What changed

Three template-owned prose files, 24 lines of edits.

| File | Change |
|---|---|
| `docs/guides/authorization.md.jinja` | 19 errors across 7 rules |
| `docs/guides/config-migration.md.jinja` | 1 `ai-tells.OverusedVocabulary` |
| `README.md.jinja` | 1 `ai-tells.VerbTricolon` |

Every spelling error is reworded rather than accepted. `.vale.ini` and the
Vocab accept list are both `_skip_if_exists`, so a term added to either
reaches new renders only and leaves existing projects failing.

## One change beyond style

The authorization guide's "turn either on" paragraph said to enable "the
matching block", which reads as plural and invites installing two
middlewares. `src/{{python_module}}/server.py.jinja` warns against exactly
that, and a reviewer raised it on #181. The paragraph was being rewritten to
clear four Vale errors anyway, so the contradiction is fixed rather than
preserved. Running both mechanisms is still described; the stub combines them
into a single check.

## Verification

- 0 Vale errors, default and `enable_authorization=false` renders
- 0 non-spelling errors with the domain vocabulary dropped, so nothing passes
  only because an accepted term sits inside a match span
- Renders byte-identical, hygiene clean on both variants
- `mkdocs build --strict` with no warnings

## Rides along

The Stage 1b design spec and PR A's execution record, both under
`docs/superpowers/` and therefore excluded from the render. The spec
sequences the eight PRs this one opens; the record holds the writing rules
the linter established, so PRs B to H do not rederive them.

## Follow-ups filed, not folded in

- **#267** — the authorization guide's `See also` has no pvl-core reference,
  raised twice on #181 and unanswered.
- **#268** — `config-migration.md` misdescribes the AST scan and steers a
  reader into the duplicate-name `SystemExit`. Five files carry the wording.

Both are pre-existing and outside a prose-linting change.

## Note for review

`docs/guides/authorization.md.jinja:98` keeps a spaced em dash on the
`DOMAIN-AUTHZ-SCOPES-START` marker line. Vale skips HTML comments, so it is
structurally out of scope rather than merely unreported, and editing a marker
line is where a `copier update` 3-way merge is most likely to conflict for a
downstream that customised the block beneath it.

— 🤖 _Automated post by Claude Code (agent) via the account owner's GitHub token; agent analysis/proposal, not a personal directive from the account owner._
